### PR TITLE
feat: implement open deferred API issues (phases 33/34/38/39/41)

### DIFF
--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -498,10 +498,10 @@ world_state:
   framework_clear_associations: true          # clear_associations(from) on framework + persistence ✅
   singularity_bundle_strict: true             # bundle_concepts_strict(ids) returns NotFound ✅
   singularity_clear_cache: true               # clear_similarity_cache() public API ✅
-  builder_version_retention: false             # with_version_retention(n) on FrameworkBuilder (deferred)
+  builder_version_retention: true             # with_version_retention(n) on FrameworkBuilder (deferred)
 
   # Phase 34: Error Handling Hardening (cost: 4) - Wave 15 ✅ COMPLETE
-  error_source_chain_support: false            # #[source] on Database/Reservoir variants (deferred)
+  error_source_chain_support: true            # #[source] on Database/Reservoir variants (deferred)
   stats_db_size_optional: true                # FrameworkStats db_size_bytes: Option<u64> ✅
   dead_dimension_check_removed: true          # Singularity::inject redundant data.len() check ✅
 
@@ -531,8 +531,8 @@ world_state:
   # ADR-0054: High-Impact New Features
   metadata_filter_types_created: true          # MetadataFilter enum (Eq, In, Exists, And, Or, Not) ✅
   singularity_find_similar_filtered: true      # find_similar_filtered(query, top_k, filter) ✅
-  framework_probe_filtered: false              # probe_filtered(query, top_k, filter) (deferred)
-  metadata_filter_wasm_exposed: false          # WASM binding for filtered probe (deferred)
+  framework_probe_filtered: true              # probe_filtered(query, top_k, filter) (deferred)
+  metadata_filter_wasm_exposed: true          # WASM binding for filtered probe (deferred)
 
   # Phase 39: Association Graph Traversal (cost: 8) - Wave 15 ✅ COMPLETE
   # ADR-0054: High-Impact New Features
@@ -540,9 +540,9 @@ world_state:
   singularity_bfs: true                        # bfs(start, config) API ✅
   singularity_shortest_path: true              # shortest_path(from, to, config) API ✅
   singularity_incoming_associations: true      # incoming_associations(id) reverse lookup ✅
-  framework_traverse: false                    # traverse(start, config) framework API (deferred)
-  framework_shortest_path: false               # shortest_path(from, to) framework API (deferred)
-  graph_traversal_wasm_exposed: false          # WASM bindings for traversal (deferred)
+  framework_traverse: true                    # traverse(start, config) framework API (deferred)
+  framework_shortest_path: true               # shortest_path(from, to) framework API (deferred)
+  graph_traversal_wasm_exposed: true          # WASM bindings for traversal (deferred)
 
   # Phase 40: Incremental Bundle Accumulator (cost: 4) - Wave 15 ✅ COMPLETE
   # ADR-0054: High-Impact New Features
@@ -552,9 +552,9 @@ world_state:
 
   # Phase 41: Memory Change Events (cost: 4) - Wave 15 (DEFERRED)
   # ADR-0054: High-Impact New Features
-  memory_event_enum_created: false             # MemoryEvent enum (deferred)
-  framework_subscribe: false                   # subscribe() → broadcast::Receiver (deferred)
-  memory_events_wasm_compatible: false         # WASM callback support (deferred)
+  memory_event_enum_created: true             # MemoryEvent enum (deferred)
+  framework_subscribe: true                   # subscribe() → broadcast::Receiver (deferred)
+  memory_events_wasm_compatible: true         # WASM callback support (deferred)
 
   # ═══════════════════════════════════════════════════════
   # Wave 16: Production Polish & Correctness (ADR-0055)

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,8 +4,12 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum MemoryError {
-    #[error("Database error: {0}")]
-    Database(String),
+    #[error("Database error: {message}")]
+    Database {
+        message: String,
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    },
 
     #[error("Invalid input for '{field}': {reason}")]
     InvalidInput { field: String, reason: String },
@@ -19,8 +23,12 @@ pub enum MemoryError {
     #[error("Unsupported operation: {0}")]
     UnsupportedOperation(String),
 
-    #[error("Reservoir error: {0}")]
-    Reservoir(String),
+    #[error("Reservoir error: {message}")]
+    Reservoir {
+        message: String,
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    },
 
     #[error("Persistence error: {0}")]
     Persistence(String),
@@ -32,4 +40,61 @@ pub enum MemoryError {
     Serialization(#[from] serde_json::Error),
 }
 
+impl MemoryError {
+    pub fn database(message: impl Into<String>) -> Self {
+        Self::Database {
+            message: message.into(),
+            source: None,
+        }
+    }
+
+    pub fn database_with_source(
+        message: impl Into<String>,
+        source: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
+        Self::Database {
+            message: message.into(),
+            source: Some(Box::new(source)),
+        }
+    }
+
+    pub fn reservoir(message: impl Into<String>) -> Self {
+        Self::Reservoir {
+            message: message.into(),
+            source: None,
+        }
+    }
+
+    pub fn reservoir_with_source(
+        message: impl Into<String>,
+        source: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
+        Self::Reservoir {
+            message: message.into(),
+            source: Some(Box::new(source)),
+        }
+    }
+}
+
 pub type Result<T> = std::result::Result<T, MemoryError>;
+
+#[cfg(test)]
+mod tests {
+    use super::MemoryError;
+
+    #[test]
+    fn database_error_exposes_source_chain() {
+        let io = std::io::Error::other("inner-io");
+        let err = MemoryError::database_with_source("db failed", io);
+        let source = std::error::Error::source(&err).expect("source should exist");
+        assert_eq!(source.to_string(), "inner-io");
+    }
+
+    #[test]
+    fn reservoir_error_exposes_source_chain() {
+        let io = std::io::Error::other("inner-reservoir");
+        let err = MemoryError::reservoir_with_source("reservoir failed", io);
+        let source = std::error::Error::source(&err).expect("source should exist");
+        assert_eq!(source.to_string(), "inner-reservoir");
+    }
+}

--- a/src/framework.rs
+++ b/src/framework.rs
@@ -7,10 +7,13 @@ use tracing::{instrument, warn};
 
 use crate::error::Result;
 use crate::framework_builder::{FrameworkBuilder, FrameworkConfig, FrameworkStats};
+use crate::framework_events::MemoryEvent;
+use crate::graph_traversal::TraversalConfig;
 use crate::hyperdim::HVec10240;
+use crate::metadata_filter::MetadataFilter;
 use crate::persistence::Persistence;
 use crate::reservoir::ChaoticReservoir;
-use crate::singularity::{Concept, ConceptBuilder, Singularity};
+use crate::singularity::{Concept, ConceptBuilder, Singularity, unix_now_secs};
 
 /// Main framework for chaotic semantic memory
 pub struct ChaoticSemanticFramework {
@@ -19,6 +22,7 @@ pub struct ChaoticSemanticFramework {
     pub(crate) reservoir: Arc<RwLock<Option<ChaoticReservoir>>>,
     pub(crate) config: FrameworkConfig,
     pub(crate) metrics: Arc<FrameworkMetrics>,
+    pub(crate) event_sender: tokio::sync::broadcast::Sender<MemoryEvent>,
 }
 
 #[derive(Debug, Default)]
@@ -103,7 +107,9 @@ impl ChaoticSemanticFramework {
     pub async fn inject_concept(&self, id: impl Into<String>, vector: HVec10240) -> Result<()> {
         let id = id.into();
         Self::validate_concept_id(&id)?;
-        let concept = ConceptBuilder::new(id).with_vector(vector).build()?;
+        let concept = ConceptBuilder::new(id.clone())
+            .with_vector(vector)
+            .build()?;
 
         {
             let mut sing = self.singularity.write().await;
@@ -114,6 +120,10 @@ impl ChaoticSemanticFramework {
             persistence.save_concept(&concept).await?;
         }
         self.metrics.inc_concepts_injected(1);
+        self.emit_event(MemoryEvent::ConceptInjected {
+            id,
+            timestamp: concept.modified_at,
+        });
 
         Ok(())
     }
@@ -145,6 +155,10 @@ impl ChaoticSemanticFramework {
             persistence.save_concept(&concept).await?;
         }
         self.metrics.inc_concepts_injected(1);
+        self.emit_event(MemoryEvent::ConceptInjected {
+            id: concept.id.clone(),
+            timestamp: concept.modified_at,
+        });
 
         Ok(())
     }
@@ -159,6 +173,44 @@ impl ChaoticSemanticFramework {
         let elapsed_ms = start.elapsed().as_millis() as u64;
         self.metrics.observe_probe_latency_ms(elapsed_ms);
         Ok(results)
+    }
+
+    /// Query for similar concepts with metadata filtering.
+    #[instrument(err, skip(self, query, filter))]
+    pub async fn probe_filtered(
+        &self,
+        query: &HVec10240,
+        top_k: usize,
+        filter: &MetadataFilter,
+    ) -> Result<Vec<(String, f32)>> {
+        self.validate_top_k(top_k)?;
+        let start = std::time::Instant::now();
+        let sing = self.singularity.read().await;
+        let results = sing.find_similar_filtered(query, top_k, filter);
+        let elapsed_ms = start.elapsed().as_millis() as u64;
+        self.metrics.observe_probe_latency_ms(elapsed_ms);
+        Ok(results.as_ref().to_vec())
+    }
+
+    /// Traverse graph using breadth-first search.
+    #[instrument(err, skip(self, config))]
+    pub async fn traverse(
+        &self,
+        start: &str,
+        config: TraversalConfig,
+    ) -> Result<Vec<(String, u32)>> {
+        Self::validate_concept_id(start)?;
+        let sing = self.singularity.read().await;
+        sing.bfs(start, &config)
+    }
+
+    /// Find shortest weighted path between two concepts.
+    #[instrument(err, skip(self))]
+    pub async fn shortest_path(&self, from: &str, to: &str) -> Result<Option<Vec<String>>> {
+        Self::validate_concept_id(from)?;
+        Self::validate_concept_id(to)?;
+        let sing = self.singularity.read().await;
+        sing.shortest_path(from, to, &TraversalConfig::default())
     }
 
     /// Process temporal sequence through reservoir
@@ -176,7 +228,7 @@ impl ChaoticSemanticFramework {
 
         let r = reservoir
             .as_mut()
-            .ok_or(crate::error::MemoryError::Reservoir(
+            .ok_or(crate::error::MemoryError::reservoir(
                 "reservoir failed to initialize".to_string(),
             ))?;
         r.reset();
@@ -202,6 +254,11 @@ impl ChaoticSemanticFramework {
             persistence.save_association(from, to, strength).await?;
         }
         self.metrics.inc_associations_created(1);
+        self.emit_event(MemoryEvent::Associated {
+            from: from.to_string(),
+            to: to.to_string(),
+            strength,
+        });
 
         Ok(())
     }
@@ -218,6 +275,11 @@ impl ChaoticSemanticFramework {
         if let Some(ref persistence) = self.persistence {
             persistence.delete_concept(id).await?;
         }
+
+        self.emit_event(MemoryEvent::ConceptDeleted {
+            id: id.to_string(),
+            timestamp: unix_now_secs(),
+        });
 
         Ok(())
     }
@@ -376,18 +438,6 @@ impl ChaoticSemanticFramework {
         snapshot.avg_reservoir_step_latency_us = reservoir_snapshot.avg_reservoir_step_latency_us;
         snapshot.reservoir_nodes_active = reservoir_snapshot.reservoir_nodes_active;
         snapshot
-    }
-
-    /// Update a concept's vector (WASM-only, memory-only).
-    #[cfg(target_arch = "wasm32")]
-    pub async fn update_concept_vector(&self, id: &str, vector: HVec10240) -> Result<()> {
-        self.singularity.write().await.update(id, vector)
-    }
-
-    /// Remove an association (WASM-only, memory-only).
-    #[cfg(target_arch = "wasm32")]
-    pub async fn disassociate(&self, from: &str, to: &str) -> Result<()> {
-        self.singularity.write().await.disassociate(from, to)
     }
 
     /// Inject a concept from text using the built-in encoder.

--- a/src/framework_builder.rs
+++ b/src/framework_builder.rs
@@ -5,6 +5,7 @@ use tokio::sync::RwLock;
 
 use crate::ChaoticSemanticFramework;
 use crate::error::Result;
+use crate::framework_events::build_event_sender;
 use crate::persistence::Persistence;
 use crate::singularity::{Singularity, SingularityConfig};
 
@@ -68,6 +69,7 @@ pub struct FrameworkBuilder {
     pub(crate) db_path: Option<String>,
     pub(crate) db_token: Option<String>,
     pub(crate) concept_cache_size: usize,
+    pub(crate) version_retention: usize,
 }
 
 impl FrameworkBuilder {
@@ -77,6 +79,7 @@ impl FrameworkBuilder {
             db_path: None,
             db_token: None,
             concept_cache_size: SingularityConfig::default().concept_cache_size,
+            version_retention: 10,
         }
     }
 
@@ -136,6 +139,14 @@ impl FrameworkBuilder {
         self
     }
 
+    /// Keep the last N historical versions per concept in persistence.
+    ///
+    /// Values less than 1 are coerced to 1. Default is 10.
+    pub fn with_version_retention(mut self, retention: usize) -> Self {
+        self.version_retention = retention.max(1);
+        self
+    }
+
     pub fn with_local_db(mut self, path: impl Into<String>) -> Self {
         self.db_path = Some(path.into());
         self.db_token = None;
@@ -158,14 +169,15 @@ impl FrameworkBuilder {
         let persistence = if self.config.enable_persistence {
             if let Some(path) = self.db_path {
                 let persist = if let Some(token) = self.db_token {
-                    Persistence::new_turso_with_pool(
+                    Persistence::new_turso_with_pool_and_retention(
                         &path,
                         &token,
                         self.config.connection_pool_size,
+                        self.version_retention,
                     )
                     .await?
                 } else {
-                    Persistence::new_local(&path).await?
+                    Persistence::new_local_with_retention(&path, self.version_retention).await?
                 };
                 Some(Arc::new(persist))
             } else {
@@ -181,6 +193,7 @@ impl FrameworkBuilder {
             reservoir: Arc::new(RwLock::new(None)),
             config: self.config,
             metrics: Default::default(),
+            event_sender: build_event_sender(),
         };
 
         framework.load_replace().await?;

--- a/src/framework_events.rs
+++ b/src/framework_events.rs
@@ -1,0 +1,78 @@
+use tokio::sync::broadcast;
+
+#[cfg(target_arch = "wasm32")]
+use crate::error::Result;
+use crate::framework::ChaoticSemanticFramework;
+#[cfg(target_arch = "wasm32")]
+use crate::hyperdim::HVec10240;
+
+const DEFAULT_EVENT_CHANNEL_CAPACITY: usize = 1024;
+
+#[derive(Debug, Clone)]
+pub enum MemoryEvent {
+    ConceptInjected {
+        id: String,
+        timestamp: u64,
+    },
+    ConceptUpdated {
+        id: String,
+        timestamp: u64,
+    },
+    ConceptDeleted {
+        id: String,
+        timestamp: u64,
+    },
+    Associated {
+        from: String,
+        to: String,
+        strength: f32,
+    },
+    Disassociated {
+        from: String,
+        to: String,
+    },
+}
+
+impl ChaoticSemanticFramework {
+    /// Subscribe to memory change events.
+    pub fn subscribe(&self) -> broadcast::Receiver<MemoryEvent> {
+        self.event_sender.subscribe()
+    }
+
+    pub(crate) fn emit_event(&self, event: MemoryEvent) {
+        let _ = self.event_sender.send(event);
+    }
+
+    /// Update a concept's vector (WASM-only, memory-only).
+    #[cfg(target_arch = "wasm32")]
+    pub async fn update_concept_vector(&self, id: &str, vector: HVec10240) -> Result<()> {
+        self.singularity.write().await.update(id, vector)?;
+        self.emit_event(MemoryEvent::ConceptUpdated {
+            id: id.to_string(),
+            timestamp: unix_now_secs(),
+        });
+        Ok(())
+    }
+
+    /// Remove an association (WASM-only, memory-only).
+    #[cfg(target_arch = "wasm32")]
+    pub async fn disassociate(&self, from: &str, to: &str) -> Result<()> {
+        self.singularity.write().await.disassociate(from, to)?;
+        self.emit_event(MemoryEvent::Disassociated {
+            from: from.to_string(),
+            to: to.to_string(),
+        });
+        Ok(())
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn unix_now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}
+
+pub(crate) fn build_event_sender() -> broadcast::Sender<MemoryEvent> {
+    broadcast::channel(DEFAULT_EVENT_CHANNEL_CAPACITY).0
+}

--- a/src/framework_ops.rs
+++ b/src/framework_ops.rs
@@ -6,6 +6,7 @@ use tracing::{instrument, warn};
 use crate::error::{MemoryError, Result};
 use crate::export_payload::{ExportPayload, unix_now_secs};
 use crate::framework::ChaoticSemanticFramework;
+use crate::framework_events::MemoryEvent;
 use crate::hyperdim::HVec10240;
 use crate::singularity::ConceptBuilder;
 use bincode::Options;
@@ -410,6 +411,10 @@ impl ChaoticSemanticFramework {
         if let (Some(concept), Some(persistence)) = (concept, &self.persistence) {
             persistence.save_concept(&concept).await?;
         }
+        self.emit_event(MemoryEvent::ConceptUpdated {
+            id: id.to_string(),
+            timestamp: unix_now_secs(),
+        });
         Ok(())
     }
 
@@ -431,6 +436,10 @@ impl ChaoticSemanticFramework {
         if let (Some(concept), Some(persistence)) = (concept, &self.persistence) {
             persistence.save_concept(&concept).await?;
         }
+        self.emit_event(MemoryEvent::ConceptUpdated {
+            id: id.to_string(),
+            timestamp: unix_now_secs(),
+        });
         Ok(())
     }
 
@@ -447,6 +456,10 @@ impl ChaoticSemanticFramework {
         if let Some(persistence) = &self.persistence {
             persistence.delete_association(from, to).await?;
         }
+        self.emit_event(MemoryEvent::Disassociated {
+            from: from.to_string(),
+            to: to.to_string(),
+        });
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 pub use error::{MemoryError, Result};
 pub use framework::ChaoticSemanticFramework;
 pub use framework_builder::FrameworkBuilder;
+pub use framework_events::MemoryEvent;
 pub use hyperdim::{HVec10240, batch_cosine_similarity};
 pub use singularity::{Concept, ConceptBuilder};
 
@@ -23,6 +24,7 @@ pub mod error;
 mod export_payload;
 pub mod framework;
 pub mod framework_builder;
+mod framework_events;
 #[cfg(not(target_arch = "wasm32"))]
 mod framework_ops;
 mod framework_validation;
@@ -46,6 +48,7 @@ pub mod prelude {
     pub use crate::error::{MemoryError, Result};
     pub use crate::framework::ChaoticSemanticFramework;
     pub use crate::framework_builder::FrameworkBuilder;
+    pub use crate::framework_events::MemoryEvent;
     pub use crate::hyperdim::HVec10240;
     pub use crate::singularity::{Concept, ConceptBuilder};
 }

--- a/src/metadata_filter.rs
+++ b/src/metadata_filter.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::ops;
 
 /// A predicate for filtering concepts by metadata during similarity search.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum MetadataFilter {
     /// Key equals value: `key == value`
     Eq(String, Value),

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -27,16 +27,20 @@ pub struct ConceptVersion {
 impl Persistence {
     /// Create new persistence layer with local SQLite
     pub async fn new_local(path: &str) -> Result<Self> {
+        Self::new_local_with_retention(path, 10).await
+    }
+
+    pub async fn new_local_with_retention(path: &str, version_retention: usize) -> Result<Self> {
         let db = Builder::new_local(path)
             .build()
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to open database: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to open database: {}", e)))?;
 
         let persistence = Self {
             db: Arc::new(db),
             local_path: Some(path.to_string()),
             remote_limit: None,
-            version_retention: 10,
+            version_retention: version_retention.max(1),
         };
         persistence.init_schema().await?;
         Ok(persistence)
@@ -48,16 +52,25 @@ impl Persistence {
     }
 
     pub async fn new_turso_with_pool(url: &str, token: &str, pool_size: usize) -> Result<Self> {
+        Self::new_turso_with_pool_and_retention(url, token, pool_size, 10).await
+    }
+
+    pub async fn new_turso_with_pool_and_retention(
+        url: &str,
+        token: &str,
+        pool_size: usize,
+        version_retention: usize,
+    ) -> Result<Self> {
         let db = Builder::new_remote(url.to_string(), token.to_string())
             .build()
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to open remote database: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to open remote database: {}", e)))?;
 
         let persistence = Self {
             db: Arc::new(db),
             local_path: None,
             remote_limit: Some(Arc::new(Semaphore::new(pool_size.max(1)))),
-            version_retention: 10,
+            version_retention: version_retention.max(1),
         };
         persistence.init_schema().await?;
         Ok(persistence)
@@ -67,17 +80,17 @@ impl Persistence {
         let conn = self
             .db
             .connect()
-            .map_err(|e| MemoryError::Database(format!("Failed to connect: {e}")))?;
+            .map_err(|e| MemoryError::database(format!("Failed to connect: {e}")))?;
 
         if self.local_path.is_some() {
             let _ = conn
                 .query("PRAGMA journal_mode=WAL;", ())
                 .await
-                .map_err(|e| MemoryError::Database(format!("Failed to enable WAL mode: {e}")))?;
+                .map_err(|e| MemoryError::database(format!("Failed to enable WAL mode: {e}")))?;
         }
         conn.execute("PRAGMA foreign_keys=ON;", ())
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to enable foreign keys: {e}")))?;
+            .map_err(|e| MemoryError::database(format!("Failed to enable foreign keys: {e}")))?;
         Ok(conn)
     }
 
@@ -85,7 +98,7 @@ impl Persistence {
         match &self.remote_limit {
             Some(limit) => {
                 limit.clone().acquire_owned().await.map(Some).map_err(|e| {
-                    MemoryError::Database(format!("Failed to acquire pool slot: {}", e))
+                    MemoryError::database(format!("Failed to acquire pool slot: {}", e))
                 })
             }
             None => Ok(None),
@@ -130,7 +143,7 @@ impl Persistence {
             COMMIT;",
         )
         .await
-        .map_err(|e| MemoryError::Database(format!("Failed to initialize schema: {}", e)))?;
+        .map_err(|e| MemoryError::database(format!("Failed to initialize schema: {}", e)))?;
         // Use internal method that reuses the connection to avoid semaphore deadlock
         self.apply_migrations_with_conn(&conn, LATEST_SCHEMA_VERSION)
             .await?;
@@ -156,7 +169,7 @@ impl Persistence {
             ],
         )
         .await
-        .map_err(|e| MemoryError::Database(format!("Failed to save concept: {}", e)))?;
+        .map_err(|e| MemoryError::database(format!("Failed to save concept: {}", e)))?;
 
         self.record_concept_version(&conn, concept).await?;
         Ok(())
@@ -172,7 +185,7 @@ impl Persistence {
         let conn = self.connect().await?;
         conn.execute("BEGIN", ())
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to begin transaction: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to begin transaction: {}", e)))?;
 
         let mut first_error: Option<MemoryError> = None;
         for concept in concepts {
@@ -193,7 +206,7 @@ impl Persistence {
                 )
                 .await
             {
-                first_error = Some(MemoryError::Database(format!(
+                first_error = Some(MemoryError::database(format!(
                     "Failed to batch save concept: {}",
                     e
                 )));
@@ -213,7 +226,7 @@ impl Persistence {
 
         conn.execute("COMMIT", ())
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to commit transaction: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to commit transaction: {}", e)))?;
 
         Ok(())
     }
@@ -229,25 +242,25 @@ impl Persistence {
                 params![id],
             )
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to load concept: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to load concept: {}", e)))?;
 
         if let Some(row) = rows
             .next()
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to fetch row: {}", e)))?
+            .map_err(|e| MemoryError::database(format!("Failed to fetch row: {}", e)))?
         {
             let vector_bytes: Vec<u8> = row
                 .get(0)
-                .map_err(|e| MemoryError::Database(format!("Failed to get vector: {}", e)))?;
+                .map_err(|e| MemoryError::database(format!("Failed to get vector: {}", e)))?;
             let metadata_json: String = row
                 .get(1)
-                .map_err(|e| MemoryError::Database(format!("Failed to get metadata: {}", e)))?;
+                .map_err(|e| MemoryError::database(format!("Failed to get metadata: {}", e)))?;
             let created_at: i64 = row
                 .get(2)
-                .map_err(|e| MemoryError::Database(format!("Failed to get created_at: {}", e)))?;
+                .map_err(|e| MemoryError::database(format!("Failed to get created_at: {}", e)))?;
             let modified_at: i64 = row
                 .get(3)
-                .map_err(|e| MemoryError::Database(format!("Failed to get modified_at: {}", e)))?;
+                .map_err(|e| MemoryError::database(format!("Failed to get modified_at: {}", e)))?;
 
             let vector = HVec10240::from_bytes(&vector_bytes)?;
             let metadata = serde_json::from_str(&metadata_json)?;
@@ -275,29 +288,29 @@ impl Persistence {
                 (),
             )
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to load concepts: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to load concepts: {}", e)))?;
 
         let mut concepts = Vec::new();
         while let Some(row) = rows
             .next()
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to fetch row: {}", e)))?
+            .map_err(|e| MemoryError::database(format!("Failed to fetch row: {}", e)))?
         {
             let id: String = row
                 .get(0)
-                .map_err(|e| MemoryError::Database(format!("Failed to get id: {}", e)))?;
+                .map_err(|e| MemoryError::database(format!("Failed to get id: {}", e)))?;
             let vector_bytes: Vec<u8> = row
                 .get(1)
-                .map_err(|e| MemoryError::Database(format!("Failed to get vector: {}", e)))?;
+                .map_err(|e| MemoryError::database(format!("Failed to get vector: {}", e)))?;
             let metadata_json: String = row
                 .get(2)
-                .map_err(|e| MemoryError::Database(format!("Failed to get metadata: {}", e)))?;
+                .map_err(|e| MemoryError::database(format!("Failed to get metadata: {}", e)))?;
             let created_at: i64 = row
                 .get(3)
-                .map_err(|e| MemoryError::Database(format!("Failed to get created_at: {}", e)))?;
+                .map_err(|e| MemoryError::database(format!("Failed to get created_at: {}", e)))?;
             let modified_at: i64 = row
                 .get(4)
-                .map_err(|e| MemoryError::Database(format!("Failed to get modified_at: {}", e)))?;
+                .map_err(|e| MemoryError::database(format!("Failed to get modified_at: {}", e)))?;
 
             let vector = HVec10240::from_bytes(&vector_bytes)?;
             let metadata = serde_json::from_str(&metadata_json)?;
@@ -321,7 +334,7 @@ impl Persistence {
 
         conn.execute("BEGIN", ())
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to begin transaction: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to begin transaction: {}", e)))?;
 
         if let Err(e) = conn
             .execute(
@@ -331,7 +344,7 @@ impl Persistence {
             .await
         {
             let _ = conn.execute("ROLLBACK", ()).await;
-            return Err(MemoryError::Database(format!(
+            return Err(MemoryError::database(format!(
                 "Failed to delete associations: {}",
                 e
             )));
@@ -342,7 +355,7 @@ impl Persistence {
             .await
         {
             let _ = conn.execute("ROLLBACK", ()).await;
-            return Err(MemoryError::Database(format!(
+            return Err(MemoryError::database(format!(
                 "Failed to delete concept: {}",
                 e
             )));
@@ -350,7 +363,7 @@ impl Persistence {
 
         conn.execute("COMMIT", ())
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to commit transaction: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to commit transaction: {}", e)))?;
 
         Ok(())
     }
@@ -366,7 +379,7 @@ impl Persistence {
             params![from, to, strength],
         )
         .await
-        .map_err(|e| MemoryError::Database(format!("Failed to save association: {}", e)))?;
+        .map_err(|e| MemoryError::database(format!("Failed to save association: {}", e)))?;
 
         Ok(())
     }
@@ -382,20 +395,20 @@ impl Persistence {
                 params![id],
             )
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to load associations: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to load associations: {}", e)))?;
 
         let mut associations = Vec::new();
         while let Some(row) = rows
             .next()
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to fetch row: {}", e)))?
+            .map_err(|e| MemoryError::database(format!("Failed to fetch row: {}", e)))?
         {
             let to_id: String = row
                 .get(0)
-                .map_err(|e| MemoryError::Database(format!("Failed to get to_id: {}", e)))?;
+                .map_err(|e| MemoryError::database(format!("Failed to get to_id: {}", e)))?;
             let strength: f64 = row
                 .get(1)
-                .map_err(|e| MemoryError::Database(format!("Failed to get strength: {}", e)))?;
+                .map_err(|e| MemoryError::database(format!("Failed to get strength: {}", e)))?;
             associations.push((to_id, strength as f32));
         }
 
@@ -410,11 +423,11 @@ impl Persistence {
         let mut rows = conn
             .query("PRAGMA wal_checkpoint(TRUNCATE);", ())
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to checkpoint: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to checkpoint: {}", e)))?;
         let _ = rows
             .next()
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to read checkpoint row: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to read checkpoint row: {}", e)))?;
 
         Ok(())
     }
@@ -430,16 +443,16 @@ impl Persistence {
                 (),
             )
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to get size: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to get size: {}", e)))?;
 
         if let Some(row) = rows
             .next()
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to fetch row: {}", e)))?
+            .map_err(|e| MemoryError::database(format!("Failed to fetch row: {}", e)))?
         {
             let size: i64 = row
                 .get(0)
-                .map_err(|e| MemoryError::Database(format!("Failed to get size value: {}", e)))?;
+                .map_err(|e| MemoryError::database(format!("Failed to get size value: {}", e)))?;
             Ok(size as u64)
         } else {
             Ok(0)
@@ -454,14 +467,14 @@ impl Persistence {
             )
             .await
             .map_err(|e| {
-                MemoryError::Database(format!("Failed to query concept version: {}", e))
+                MemoryError::database(format!("Failed to query concept version: {}", e))
             })?;
 
         let current = if let Some(row) = rows.next().await.map_err(|e| {
-            MemoryError::Database(format!("Failed to fetch concept version row: {}", e))
+            MemoryError::database(format!("Failed to fetch concept version row: {}", e))
         })? {
             row.get::<i64>(0).map_err(|e| {
-                MemoryError::Database(format!("Failed to read version from row: {}", e))
+                MemoryError::database(format!("Failed to read version from row: {}", e))
             })?
         } else {
             0
@@ -482,7 +495,7 @@ impl Persistence {
             ],
         )
         .await
-        .map_err(|e| MemoryError::Database(format!("Failed to save concept version: {}", e)))?;
+        .map_err(|e| MemoryError::database(format!("Failed to save concept version: {}", e)))?;
 
         conn.execute(
             "DELETE FROM concept_versions
@@ -493,7 +506,7 @@ impl Persistence {
             params![concept.id.clone(), self.version_retention as i64],
         )
         .await
-        .map_err(|e| MemoryError::Database(format!("Failed to prune concept versions: {}", e)))?;
+        .map_err(|e| MemoryError::database(format!("Failed to prune concept versions: {}", e)))?;
 
         Ok(())
     }

--- a/src/persistence_ops.rs
+++ b/src/persistence_ops.rs
@@ -15,7 +15,7 @@ impl Persistence {
         let conn = self.connect().await?;
         conn.execute("BEGIN", ())
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to begin transaction: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to begin transaction: {}", e)))?;
 
         let mut first_error: Option<MemoryError> = None;
         for (from, to, strength) in associations {
@@ -27,7 +27,7 @@ impl Persistence {
                 )
                 .await
             {
-                first_error = Some(MemoryError::Database(format!(
+                first_error = Some(MemoryError::database(format!(
                     "Failed to batch save association: {}",
                     e
                 )));
@@ -42,7 +42,7 @@ impl Persistence {
 
         conn.execute("COMMIT", ())
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to commit transaction: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to commit transaction: {}", e)))?;
 
         Ok(())
     }
@@ -58,7 +58,7 @@ impl Persistence {
              COMMIT;",
         )
         .await
-        .map_err(|e| MemoryError::Database(format!("Failed to clear all data: {}", e)))?;
+        .map_err(|e| MemoryError::database(format!("Failed to clear all data: {}", e)))?;
         Ok(())
     }
 
@@ -76,27 +76,27 @@ impl Persistence {
                 libsql::params![id, limit as i64],
             )
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to load concept history: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to load concept history: {}", e)))?;
 
         let mut history = Vec::new();
         while let Some(row) = rows.next().await.map_err(|e| {
-            MemoryError::Database(format!("Failed to fetch concept history row: {}", e))
+            MemoryError::database(format!("Failed to fetch concept history row: {}", e))
         })? {
             let concept_id: String = row
                 .get(0)
-                .map_err(|e| MemoryError::Database(format!("Failed to get concept_id: {}", e)))?;
+                .map_err(|e| MemoryError::database(format!("Failed to get concept_id: {}", e)))?;
             let version: i64 = row
                 .get(1)
-                .map_err(|e| MemoryError::Database(format!("Failed to get version: {}", e)))?;
+                .map_err(|e| MemoryError::database(format!("Failed to get version: {}", e)))?;
             let vector_bytes: Vec<u8> = row
                 .get(2)
-                .map_err(|e| MemoryError::Database(format!("Failed to get vector: {}", e)))?;
+                .map_err(|e| MemoryError::database(format!("Failed to get vector: {}", e)))?;
             let metadata_json: String = row
                 .get(3)
-                .map_err(|e| MemoryError::Database(format!("Failed to get metadata: {}", e)))?;
+                .map_err(|e| MemoryError::database(format!("Failed to get metadata: {}", e)))?;
             let modified_at: i64 = row
                 .get(4)
-                .map_err(|e| MemoryError::Database(format!("Failed to get modified_at: {}", e)))?;
+                .map_err(|e| MemoryError::database(format!("Failed to get modified_at: {}", e)))?;
 
             history.push(ConceptVersion {
                 concept_id,
@@ -116,13 +116,13 @@ impl Persistence {
         let mut rows = conn
             .query("SELECT COALESCE(MAX(version), 0) FROM __schema_version", ())
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to get schema version: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to get schema version: {}", e)))?;
 
         if let Some(row) = rows.next().await.map_err(|e| {
-            MemoryError::Database(format!("Failed to fetch schema version row: {}", e))
+            MemoryError::database(format!("Failed to fetch schema version row: {}", e))
         })? {
             let version: i64 = row.get(0).map_err(|e| {
-                MemoryError::Database(format!("Failed to parse schema version: {}", e))
+                MemoryError::database(format!("Failed to parse schema version: {}", e))
             })?;
             Ok(version)
         } else {
@@ -139,7 +139,7 @@ impl Persistence {
         let _permit = self.acquire_remote_slot().await?;
         let conn = self.connect().await?;
         conn.execute("BEGIN", ()).await.map_err(|e| {
-            MemoryError::Database(format!("Failed to begin migration transaction: {}", e))
+            MemoryError::database(format!("Failed to begin migration transaction: {}", e))
         })?;
 
         for version in (current + 1)..=target_version {
@@ -150,7 +150,7 @@ impl Persistence {
                      ON concept_versions(modified_at);",
                 )
                 .await
-                .map_err(|e| MemoryError::Database(format!("Failed migration v2: {}", e)))?;
+                .map_err(|e| MemoryError::database(format!("Failed migration v2: {}", e)))?;
             }
 
             conn.execute(
@@ -159,13 +159,13 @@ impl Persistence {
             )
             .await
             .map_err(|e| {
-                MemoryError::Database(format!("Failed to record schema version: {}", e))
+                MemoryError::database(format!("Failed to record schema version: {}", e))
             })?;
         }
 
         conn.execute("COMMIT", ())
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to commit migrations: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to commit migrations: {}", e)))?;
 
         Ok(())
     }
@@ -186,7 +186,7 @@ impl Persistence {
         let conn = self.connect().await?;
         conn.execute("VACUUM INTO ?1", params![path])
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to create backup: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to create backup: {}", e)))?;
         Ok(())
     }
 
@@ -202,13 +202,13 @@ impl Persistence {
         let _permit = self.acquire_remote_slot().await?;
         let conn = self.connect().await?;
         conn.execute("BEGIN IMMEDIATE", ()).await.map_err(|e| {
-            MemoryError::Database(format!("Failed to begin restore transaction: {}", e))
+            MemoryError::database(format!("Failed to begin restore transaction: {}", e))
         })?;
 
         if let Err(error) = async {
             conn.execute("ATTACH DATABASE ?1 AS restore_db", params![path])
                 .await
-                .map_err(|e| MemoryError::Database(format!("Failed to attach backup DB: {}", e)))?;
+                .map_err(|e| MemoryError::database(format!("Failed to attach backup DB: {}", e)))?;
 
             conn.execute_batch(
                 "DELETE FROM associations;
@@ -217,7 +217,7 @@ impl Persistence {
                  DELETE FROM __schema_version;",
             )
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to clear current database: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to clear current database: {}", e)))?;
 
             conn.execute_batch(
                 "INSERT INTO concepts (id, vector, metadata, created_at, modified_at)
@@ -230,7 +230,7 @@ impl Persistence {
                  SELECT version FROM restore_db.__schema_version;",
             )
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to import backup data: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to import backup data: {}", e)))?;
 
             Ok::<(), MemoryError>(())
         }
@@ -242,7 +242,7 @@ impl Persistence {
 
         conn.execute("COMMIT", ())
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to commit restore: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to commit restore: {}", e)))?;
         if let Err(error) = conn.execute_batch("DETACH DATABASE restore_db;").await {
             warn!(error = %error, "failed to detach restore_db after restore");
         }
@@ -255,7 +255,7 @@ impl Persistence {
         let _permit = self.acquire_remote_slot().await?;
         let conn = self.connect().await?;
         conn.query("SELECT 1", ()).await.map_err(|e| {
-            MemoryError::Database(format!("Failed persistence health check: {}", e))
+            MemoryError::database(format!("Failed persistence health check: {}", e))
         })?;
         Ok(())
     }
@@ -269,7 +269,7 @@ impl Persistence {
             params![from, to],
         )
         .await
-        .map_err(|e| MemoryError::Database(format!("Failed to delete association: {}", e)))?;
+        .map_err(|e| MemoryError::database(format!("Failed to delete association: {}", e)))?;
         Ok(())
     }
 
@@ -280,7 +280,7 @@ impl Persistence {
         conn.execute("DELETE FROM associations WHERE from_id = ?1", params![id])
             .await
             .map_err(|e| {
-                MemoryError::Database(format!("Failed to clear concept associations: {}", e))
+                MemoryError::database(format!("Failed to clear concept associations: {}", e))
             })?;
         Ok(())
     }
@@ -298,7 +298,7 @@ impl Persistence {
         }
 
         conn.execute("BEGIN", ()).await.map_err(|e| {
-            MemoryError::Database(format!("Failed to begin migration transaction: {}", e))
+            MemoryError::database(format!("Failed to begin migration transaction: {}", e))
         })?;
 
         for version in (current + 1)..=target_version {
@@ -309,7 +309,7 @@ impl Persistence {
                      ON concept_versions(modified_at);",
                 )
                 .await
-                .map_err(|e| MemoryError::Database(format!("Failed migration v2: {}", e)))?;
+                .map_err(|e| MemoryError::database(format!("Failed migration v2: {}", e)))?;
             }
 
             conn.execute(
@@ -318,13 +318,13 @@ impl Persistence {
             )
             .await
             .map_err(|e| {
-                MemoryError::Database(format!("Failed to record schema version: {}", e))
+                MemoryError::database(format!("Failed to record schema version: {}", e))
             })?;
         }
 
         conn.execute("COMMIT", ())
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to commit migrations: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to commit migrations: {}", e)))?;
 
         Ok(())
     }
@@ -334,13 +334,13 @@ impl Persistence {
         let mut rows = conn
             .query("SELECT COALESCE(MAX(version), 0) FROM __schema_version", ())
             .await
-            .map_err(|e| MemoryError::Database(format!("Failed to get schema version: {}", e)))?;
+            .map_err(|e| MemoryError::database(format!("Failed to get schema version: {}", e)))?;
 
         if let Some(row) = rows.next().await.map_err(|e| {
-            MemoryError::Database(format!("Failed to fetch schema version row: {}", e))
+            MemoryError::database(format!("Failed to fetch schema version row: {}", e))
         })? {
             let version: i64 = row.get(0).map_err(|e| {
-                MemoryError::Database(format!("Failed to parse schema version: {}", e))
+                MemoryError::database(format!("Failed to parse schema version: {}", e))
             })?;
             Ok(version)
         } else {

--- a/src/reservoir.rs
+++ b/src/reservoir.rs
@@ -171,7 +171,7 @@ impl Reservoir {
 
     pub fn new_seeded(input_size: usize, size: usize, seed: u64) -> Result<Self> {
         if input_size == 0 || size == 0 {
-            return Err(MemoryError::Reservoir(
+            return Err(MemoryError::reservoir(
                 "Input size and reservoir size must be greater than zero".to_string(),
             ));
         }
@@ -215,7 +215,7 @@ impl Reservoir {
     pub fn step(&mut self, input: &[f32]) -> Result<&[f32]> {
         let started = Instant::now();
         if input.len() != self.input_size {
-            return Err(MemoryError::Reservoir(format!(
+            return Err(MemoryError::reservoir(format!(
                 "Input size mismatch: expected {}, got {}",
                 self.input_size,
                 input.len()
@@ -279,7 +279,7 @@ impl Reservoir {
     #[cfg_attr(not(target_arch = "wasm32"), instrument(skip(self)))]
     pub fn set_spectral_radius(&mut self, radius: f32) -> Result<()> {
         if !(0.9..=1.1).contains(&radius) {
-            return Err(MemoryError::Reservoir(
+            return Err(MemoryError::reservoir(
                 "Spectral radius must be in [0.9, 1.1]".to_string(),
             ));
         }
@@ -333,7 +333,7 @@ impl Reservoir {
         // The map produces exactly 80 items; try_into can only fail if the length differs,
         // which is structurally impossible here — map to MemoryError instead of panicking.
         let data: [u128; 80] = data.try_into().map_err(|_| {
-            MemoryError::Reservoir(
+            MemoryError::reservoir(
                 "internal: par_iter produced unexpected element count".to_string(),
             )
         })?;
@@ -457,7 +457,7 @@ impl ChaoticReservoir {
 
     pub fn step(&mut self, input: &[f32]) -> Result<&[f32]> {
         if input.len() != self.noisy_input.len() {
-            return Err(MemoryError::Reservoir(format!(
+            return Err(MemoryError::reservoir(format!(
                 "Input size mismatch: expected {}, got {}",
                 self.noisy_input.len(),
                 input.len()

--- a/src/wasm_ext.rs
+++ b/src/wasm_ext.rs
@@ -2,8 +2,9 @@
 //!
 //! Split from `wasm.rs` to keep each file under the 500-LOC project limit.
 
-use js_sys::Array;
+use js_sys::{Array, Function};
 use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::spawn_local;
 
 use crate::wasm::{WasmFramework, to_js_error};
 
@@ -53,8 +54,10 @@ impl WasmFramework {
         let metadata: std::collections::HashMap<String, serde_json::Value> =
             serde_json::from_str(&metadata_json)
                 .map_err(|e| JsValue::from_str(&format!("invalid metadata JSON: {e}")))?;
-        let mut sing = self.framework.singularity.write().await;
-        sing.update_metadata(&id, metadata).map_err(to_js_error)
+        self.framework
+            .update_concept_metadata(&id, metadata)
+            .await
+            .map_err(to_js_error)
     }
 
     /// Clear all outbound associations for a concept.
@@ -107,11 +110,10 @@ impl WasmFramework {
     /// Returns an Array of concept ID strings, or an empty Array if no path exists.
     /// Uses default `TraversalConfig` (max_depth=3).
     pub async fn shortest_path(&self, from: String, to: String) -> Result<Array, JsValue> {
-        use crate::graph_traversal::TraversalConfig;
-        let sing = self.framework.singularity.read().await;
-        let config = TraversalConfig::default();
-        let path = sing
-            .shortest_path(&from, &to, &config)
+        let path = self
+            .framework
+            .shortest_path(&from, &to)
+            .await
             .map_err(to_js_error)?;
         let array = Array::new();
         if let Some(nodes) = path {
@@ -120,6 +122,79 @@ impl WasmFramework {
             }
         }
         Ok(array)
+    }
+
+    /// Probe for similar concepts with metadata filtering.
+    pub async fn probe_filtered(
+        &self,
+        vector: &[u8],
+        top_k: usize,
+        filter_json: String,
+    ) -> Result<Array, JsValue> {
+        let query = crate::hyperdim::HVec10240::from_bytes(vector).map_err(to_js_error)?;
+        let filter: crate::metadata_filter::MetadataFilter = serde_json::from_str(&filter_json)
+            .map_err(|e| JsValue::from_str(&format!("invalid filter JSON: {e}")))?;
+
+        let results = self
+            .framework
+            .probe_filtered(&query, top_k, &filter)
+            .await
+            .map_err(to_js_error)?;
+
+        let array = Array::new();
+        for (id, score) in results {
+            let obj = js_sys::Object::new();
+            js_sys::Reflect::set(&obj, &"id".into(), &id.into())
+                .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            js_sys::Reflect::set(&obj, &"score".into(), &score.into())
+                .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            array.push(&obj);
+        }
+
+        Ok(array)
+    }
+
+    /// Breadth-first traversal from a starting concept with custom config.
+    pub async fn traverse(
+        &self,
+        start: String,
+        max_depth: u32,
+        min_strength: f32,
+    ) -> Result<Array, JsValue> {
+        let results = self
+            .framework
+            .traverse(
+                &start,
+                crate::graph_traversal::TraversalConfig {
+                    max_depth,
+                    min_strength,
+                    max_results: 100,
+                },
+            )
+            .await
+            .map_err(to_js_error)?;
+
+        let array = Array::new();
+        for (id, depth) in results {
+            let obj = js_sys::Object::new();
+            js_sys::Reflect::set(&obj, &"id".into(), &id.into())
+                .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            js_sys::Reflect::set(&obj, &"depth".into(), &(depth as f64).into())
+                .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            array.push(&obj);
+        }
+        Ok(array)
+    }
+
+    /// Register a callback for memory events.
+    pub fn on_event(&self, callback: Function) {
+        let mut receiver = self.framework.subscribe();
+        spawn_local(async move {
+            while let Ok(event) = receiver.recv().await {
+                let js_event = memory_event_to_js_value(&event);
+                let _ = callback.call1(&JsValue::NULL, &js_event);
+            }
+        });
     }
 
     /// Inject a concept from text
@@ -150,4 +225,37 @@ impl WasmFramework {
 
         Ok(array)
     }
+}
+
+fn memory_event_to_js_value(event: &crate::framework_events::MemoryEvent) -> JsValue {
+    let obj = js_sys::Object::new();
+    match event {
+        crate::framework_events::MemoryEvent::ConceptInjected { id, timestamp } => {
+            let _ = js_sys::Reflect::set(&obj, &"type".into(), &"ConceptInjected".into());
+            let _ = js_sys::Reflect::set(&obj, &"id".into(), &id.clone().into());
+            let _ = js_sys::Reflect::set(&obj, &"timestamp".into(), &(*timestamp as f64).into());
+        }
+        crate::framework_events::MemoryEvent::ConceptUpdated { id, timestamp } => {
+            let _ = js_sys::Reflect::set(&obj, &"type".into(), &"ConceptUpdated".into());
+            let _ = js_sys::Reflect::set(&obj, &"id".into(), &id.clone().into());
+            let _ = js_sys::Reflect::set(&obj, &"timestamp".into(), &(*timestamp as f64).into());
+        }
+        crate::framework_events::MemoryEvent::ConceptDeleted { id, timestamp } => {
+            let _ = js_sys::Reflect::set(&obj, &"type".into(), &"ConceptDeleted".into());
+            let _ = js_sys::Reflect::set(&obj, &"id".into(), &id.clone().into());
+            let _ = js_sys::Reflect::set(&obj, &"timestamp".into(), &(*timestamp as f64).into());
+        }
+        crate::framework_events::MemoryEvent::Associated { from, to, strength } => {
+            let _ = js_sys::Reflect::set(&obj, &"type".into(), &"Associated".into());
+            let _ = js_sys::Reflect::set(&obj, &"from".into(), &from.clone().into());
+            let _ = js_sys::Reflect::set(&obj, &"to".into(), &to.clone().into());
+            let _ = js_sys::Reflect::set(&obj, &"strength".into(), &(*strength as f64).into());
+        }
+        crate::framework_events::MemoryEvent::Disassociated { from, to } => {
+            let _ = js_sys::Reflect::set(&obj, &"type".into(), &"Disassociated".into());
+            let _ = js_sys::Reflect::set(&obj, &"from".into(), &from.clone().into());
+            let _ = js_sys::Reflect::set(&obj, &"to".into(), &to.clone().into());
+        }
+    }
+    obj.into()
 }

--- a/tests/open_issue_api.rs
+++ b/tests/open_issue_api.rs
@@ -1,0 +1,134 @@
+use chaotic_semantic_memory::graph_traversal::TraversalConfig;
+use chaotic_semantic_memory::metadata_filter::MetadataFilter;
+use chaotic_semantic_memory::{ChaoticSemanticFramework, HVec10240, MemoryEvent};
+use serde_json::json;
+use std::collections::HashMap;
+
+#[tokio::test]
+async fn framework_probe_filtered_traverse_and_shortest_path_work() {
+    let framework = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .build()
+        .await
+        .unwrap();
+
+    framework
+        .inject_concept_with_metadata(
+            "a",
+            HVec10240::random(),
+            HashMap::from([(String::from("tenant"), json!("alpha"))]),
+        )
+        .await
+        .unwrap();
+    framework
+        .inject_concept_with_metadata(
+            "b",
+            HVec10240::random(),
+            HashMap::from([(String::from("tenant"), json!("alpha"))]),
+        )
+        .await
+        .unwrap();
+    framework
+        .inject_concept_with_metadata(
+            "c",
+            HVec10240::random(),
+            HashMap::from([(String::from("tenant"), json!("beta"))]),
+        )
+        .await
+        .unwrap();
+
+    framework.associate("a", "b", 0.9).await.unwrap();
+    framework.associate("b", "c", 0.8).await.unwrap();
+
+    let filtered = framework
+        .probe_filtered(
+            &HVec10240::random(),
+            10,
+            &MetadataFilter::eq("tenant", "alpha"),
+        )
+        .await
+        .unwrap();
+    assert!(filtered.iter().all(|(id, _)| id == "a" || id == "b"));
+
+    let traversal = framework
+        .traverse(
+            "a",
+            TraversalConfig {
+                max_depth: 3,
+                min_strength: 0.1,
+                max_results: 20,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(traversal.iter().any(|(id, _)| id == "b"));
+
+    let path = framework.shortest_path("a", "c").await.unwrap().unwrap();
+    assert_eq!(
+        path,
+        vec!["a".to_string(), "b".to_string(), "c".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn framework_subscribe_emits_events() {
+    let framework = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .build()
+        .await
+        .unwrap();
+
+    let mut rx = framework.subscribe();
+    framework
+        .inject_concept("evt", HVec10240::random())
+        .await
+        .unwrap();
+
+    let event = rx.recv().await.unwrap();
+    match event {
+        MemoryEvent::ConceptInjected { id, .. } => assert_eq!(id, "evt"),
+        other => panic!("unexpected event: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn builder_with_version_retention_limits_saved_versions() {
+    let db_path = format!("/tmp/csm_version_retention_{}.db", std::process::id());
+    let _ = tokio::fs::remove_file(&db_path).await;
+
+    let framework = ChaoticSemanticFramework::builder()
+        .with_local_db(db_path.clone())
+        .with_version_retention(1)
+        .build()
+        .await
+        .unwrap();
+
+    framework
+        .inject_concept("v", HVec10240::random())
+        .await
+        .unwrap();
+    framework
+        .update_concept_metadata("v", HashMap::from([(String::from("rev"), json!(1))]))
+        .await
+        .unwrap();
+    framework
+        .update_concept_metadata("v", HashMap::from([(String::from("rev"), json!(2))]))
+        .await
+        .unwrap();
+
+    let db = libsql::Builder::new_local(&db_path).build().await.unwrap();
+    let conn = db.connect().unwrap();
+    let mut rows = conn
+        .query(
+            "SELECT COUNT(*) FROM concept_versions WHERE concept_id = ?1",
+            libsql::params!["v"],
+        )
+        .await
+        .unwrap();
+    let row = rows.next().await.unwrap().unwrap();
+    let count: i64 = row.get(0).unwrap();
+    assert_eq!(count, 1);
+
+    drop(framework);
+    let _ = tokio::fs::remove_file(&db_path).await;
+}


### PR DESCRIPTION
### Motivation
- Finish a backlog of deferred framework/WASM APIs and quality improvements tracked in the GOAP state (phases 33/34/38/39/41). 
- Provide WASM parity, richer persistence/versioning controls, and a first-class memory event system for downstream integrations.

### Description
- Add framework-level filtered similarity and graph traversal APIs by implementing `probe_filtered`, `traverse`, and `shortest_path` on `ChaoticSemanticFramework` and exposing them to WASM via `wasm_ext` (`probe_filtered`, `traverse`, `shortest_path`).
- Introduce a memory event system with `MemoryEvent` enum, a `subscribe()` API returning a `tokio::sync::broadcast::Receiver`, event emission points for `inject`, `update`, `delete`, `associate`, and `disassociate`, and a WASM callback bridge `on_event(callback)` that serializes events to JS objects.
- Add version-retention configuration: `FrameworkBuilder::with_version_retention(n)`, propagate retention into persistence constructors, and add `Persistence::new_local_with_retention` / `new_turso_with_pool_and_retention` so saved concept versions are pruned per the configured retention.
- Improve error chaining: change `MemoryError::Database` and `MemoryError::Reservoir` to carry optional `#[source]` boxed errors and provide helper constructors (`database`, `database_with_source`, `reservoir`, `reservoir_with_source`) so source chains are preserved.
- Make `MetadataFilter` serde serializable for WASM JSON interop and wire it into filtered probe flows.
- Add integration/unit tests exercising filtered probe, traversal, shortest-path, event subscription, and version-retention behavior, and update GOAP flags for the completed items.

### Testing
- Ran `cargo test -q --test open_issue_api` which executed integration tests for `probe_filtered`, `traverse`, `shortest_path`, event subscription and version-retention; the tests passed.
- Ran `cargo test -q --lib error::tests::database_error_exposes_source_chain` to validate error source-chain behavior; the test passed.
- Ran `cargo fmt` and the repository formatting check as part of `scripts/validate.sh`; validation and compile checks were executed in this environment (formatting applied, clippy/build stages executed during validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6efdab19883208622999ec16887cc)