### PR TITLE
fix: sync versions across codebase and add CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,10 @@ jobs:
     
     - name: Check formatting
       run: cargo fmt -- --check
-    
+
+    - name: Check version sync
+      run: bash scripts/verify-version-sync.sh
+
     - name: Run clippy
       run: cargo clippy --all-targets --all-features -- -D warnings
     

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ csm_test*
 .tmp/
 *.tmp
 .claude/settings.local.json
+.claude/skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+# CLAUDE.md - Claude Code Specific Instructions
+
+This file contains instructions specific to Claude Code CLI. For general project instructions, see [AGENTS.md](AGENTS.md).
+
+## Claude Code Features
+
+- **Auto-memory**: `~/.claude/projects/-home-do-git-chaotic-semantic-memory/memory/`
+- **Agent Teams**: See https://code.claude.com/docs/en/agent-teams
+- **Swarm Mode**: Use `TeamCreate` to spawn coordinated agents
+
+## Session Continuity
+
+When continuing from a compacted session, clean up stale resources:
+
+```bash
+rm -rf ~/.claude/teams/<team-name> ~/.claude/tasks/<team-name>
+```
+
+Or use `/exit` to terminate all in-process agents.
+
+## In-Process Agents
+
+Agents with `backendType: "in-process"` share the main Claude process. They:
+- Cannot be killed by shutdown requests
+- Persist until the session ends
+- Should be cleaned up via `TeamDelete` or session exit

--- a/agents-docs/quick-reference.md
+++ b/agents-docs/quick-reference.md
@@ -2,9 +2,17 @@
 
 ## Version Sync (Before Release)
 ```bash
+# Check version synchronization (runs in CI)
+./scripts/verify-version-sync.sh
+
 # Sync version across all files (prevents stale docs)
-./scripts/sync-version.sh 0.2.0
+./scripts/sync-version.sh 0.2.5
 ```
+
+**Version must match in:**
+- `Cargo.toml` - `version = "X.Y.Z"`
+- `wasm/package.json` - `"version": "X.Y.Z"`
+- Test fixtures (grep `"version":` in tests/ and examples/)
 
 ## Validation Gates
 Run before commit (see `git-workflow` skill for details):

--- a/examples/cli/12_metadata_limits.sh
+++ b/examples/cli/12_metadata_limits.sh
@@ -126,7 +126,7 @@ echo "The import/export format supports metadata in the JSON payload:"
 echo ""
 cat << 'JSON_EXAMPLE'
 {
-  "version": "0.2.3",
+  "version": "0.2.5",
   "exported_at": 1234567890,
   "concepts": [
     {

--- a/examples/cli/13_import_missing_file.sh
+++ b/examples/cli/13_import_missing_file.sh
@@ -46,7 +46,7 @@ echo "  Creating valid import JSON..."
 # This demonstrates the import structure without serialization issues
 cat > "$VALID_IMPORT_FILE" << 'EOF'
 {
-  "version": "0.2.3",
+  "version": "0.2.5",
   "exported_at": 1700000000,
   "concepts": [],
   "associations": []
@@ -99,7 +99,7 @@ echo "  - Handle the error gracefully in automation pipelines"
 echo ""
 echo "Import file format:"
 echo '  {'
-echo '    "version": "0.2.3",'
+echo '    "version": "0.2.5",'
 echo '    "exported_at": <unix_timestamp>,'
 echo '    "concepts": [...],'
 echo '    "associations": [...]'

--- a/examples/cli/16_batch_operations.sh
+++ b/examples/cli/16_batch_operations.sh
@@ -43,7 +43,7 @@ echo ""
 # ============================================================================
 echo -e "${YELLOW}Edge Case 1: Empty Import${NC}"
 echo "  Creating and importing an empty concepts/associations file..."
-echo '  {"version": "0.2.1","exported_at":0,"concepts":[],"associations":[]}' > "$IMPORT_FILE"
+echo '  {"version": "0.2.5","exported_at":0,"concepts":[],"associations":[]}' > "$IMPORT_FILE"
 echo "  Command: csm import $IMPORT_FILE"
 ./target/debug/csm import "$IMPORT_FILE" --output-format json
 echo ""

--- a/scripts/verify-version-sync.sh
+++ b/scripts/verify-version-sync.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# verify-version-sync.sh - Ensure all version numbers are synchronized
+# Run this before releases to catch version drift
+
+set -e
+
+# Extract version from Cargo.toml
+CARGO_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+
+# Extract version from wasm/package.json
+NPM_VERSION=$(grep '"version":' wasm/package.json | sed 's/.*"version": "\(.*\)".*/\1/')
+
+echo "Cargo.toml version: $CARGO_VERSION"
+echo "wasm/package.json version: $NPM_VERSION"
+
+# Check if versions match
+if [ "$CARGO_VERSION" != "$NPM_VERSION" ]; then
+    echo "ERROR: Version mismatch!"
+    echo "  Cargo.toml: $CARGO_VERSION"
+    echo "  wasm/package.json: $NPM_VERSION"
+    exit 1
+fi
+
+# Check for hardcoded old versions in test fixtures
+echo ""
+echo "Checking for hardcoded versions in tests/examples..."
+
+OLD_VERSIONS=$(grep -r '"version":.*"0\.2\.[0-4]"' tests/ examples/ 2>/dev/null || true)
+
+if [ -n "$OLD_VERSIONS" ]; then
+    echo "WARNING: Found old version references (should be $CARGO_VERSION):"
+    echo "$OLD_VERSIONS"
+    echo ""
+    echo "Update these to the current version: $CARGO_VERSION"
+    exit 1
+fi
+
+echo ""
+echo "✓ All versions synchronized: $CARGO_VERSION"

--- a/tests/framework_lifecycle.rs
+++ b/tests/framework_lifecycle.rs
@@ -72,7 +72,7 @@ async fn framework_import_skips_orphan_associations_without_failing() {
     let import_path = import_file.path().to_str().unwrap().to_string();
 
     let payload = serde_json::json!({
-        "version": "0.2.3",
+        "version": "0.2.5",
         "exported_at": 1u64,
         "concepts": [],
         "associations": [["a", "missing", 0.7]]


### PR DESCRIPTION
## Summary
- Fix hardcoded `0.2.3` versions in tests/examples to `0.2.5`
- Add `scripts/verify-version-sync.sh` to catch version drift
- Add CI step to run version sync check on every PR
- Add `CLAUDE.md` for Claude Code-specific instructions

## Why
Version numbers were out of sync between Cargo.toml (0.2.5) and test fixtures (0.2.3), which could cause confusion and test failures.

## Prevention
The new CI step will fail if:
1. Cargo.toml and wasm/package.json versions don't match
2. Any test/example has a hardcoded old version

🤖 Generated with [Claude Code](https://claude.com/claude-code)