### PR TITLE
docs: add version sync learnings and release checklist

### DIFF
--- a/agents-docs/hard-constraints.md
+++ b/agents-docs/hard-constraints.md
@@ -18,3 +18,8 @@
   ```bash
   gh repo view <owner>/<repo> --json isArchived,pushedAt
   ```
+- **Version numbers must be synchronized across all files before release.**
+  Run `scripts/verify-version-sync.sh` to verify. Files checked:
+  - `Cargo.toml` - `version = "X.Y.Z"`
+  - `wasm/package.json` - `"version": "X.Y.Z"`
+  - Test fixtures and examples with `"version":` literals

--- a/agents-docs/quick-reference.md
+++ b/agents-docs/quick-reference.md
@@ -13,6 +13,15 @@
 - `Cargo.toml` - `version = "X.Y.Z"`
 - `wasm/package.json` - `"version": "X.Y.Z"`
 - Test fixtures (grep `"version":` in tests/ and examples/)
+- npm registry (after publishing WASM package)
+
+## Release Checklist
+1. Update version in `Cargo.toml` and `wasm/package.json`
+2. Run `./scripts/verify-version-sync.sh`
+3. Build WASM: `cargo build --target wasm32-unknown-unknown --release --features wasm`
+4. Publish crates.io: `cargo publish`
+5. Publish npm: `cd wasm && npm publish`
+6. Create GitHub release: `gh release create vX.Y.Z`
 
 ## Validation Gates
 Run before commit (see `git-workflow` skill for details):

--- a/agents-docs/self-learning-patterns.md
+++ b/agents-docs/self-learning-patterns.md
@@ -13,6 +13,7 @@ Key patterns recorded from iterations (see @progress/LEARNINGS.md for full histo
 7. Using seeded RNG (`StdRng::seed_from_u64(42)`) in tests for determinism
 8. Migrating to `libsql::Builder` to remove deprecated API usage
 9. Enabling `PRAGMA foreign_keys = ON` per-connection for deterministic FK behavior
+10. CI-enforced version synchronization — catches drift before merge
 
 ## Technical Insights
 
@@ -36,6 +37,7 @@ Key patterns recorded from iterations (see @progress/LEARNINGS.md for full histo
 - Do not make versioning mandatory (should be opt-in)
 - Do not create multiple scripts with overlapping functionality — merge related scripts (e.g., version checking into link checking)
 - Do not use archived GitHub repositories as dependencies — always find an active alternative or fork and maintain
+- Do not hardcode version numbers in test fixtures or examples — use current version or verify sync
 
 ## Learning Loop
 

--- a/scripts/verify-version-sync.sh
+++ b/scripts/verify-version-sync.sh
@@ -8,16 +8,16 @@ set -e
 CARGO_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
 
 # Extract version from wasm/package.json
-NPM_VERSION=$(grep '"version":' wasm/package.json | sed 's/.*"version": "\(.*\)".*/\1/')
+NPM_LOCAL_VERSION=$(grep '"version":' wasm/package.json | sed 's/.*"version": "\(.*\)".*/\1/')
 
 echo "Cargo.toml version: $CARGO_VERSION"
-echo "wasm/package.json version: $NPM_VERSION"
+echo "wasm/package.json version: $NPM_LOCAL_VERSION"
 
 # Check if versions match
-if [ "$CARGO_VERSION" != "$NPM_VERSION" ]; then
+if [ "$CARGO_VERSION" != "$NPM_LOCAL_VERSION" ]; then
     echo "ERROR: Version mismatch!"
     echo "  Cargo.toml: $CARGO_VERSION"
-    echo "  wasm/package.json: $NPM_VERSION"
+    echo "  wasm/package.json: $NPM_LOCAL_VERSION"
     exit 1
 fi
 
@@ -35,5 +35,19 @@ if [ -n "$OLD_VERSIONS" ]; then
     exit 1
 fi
 
+# Check npm registry version (warning only)
 echo ""
-echo "✓ All versions synchronized: $CARGO_VERSION"
+echo "Checking npm registry..."
+NPM_REGISTRY_VERSION=$(npm view @d-o-hub/chaotic_semantic_memory version 2>/dev/null || echo "not published")
+
+if [ "$NPM_REGISTRY_VERSION" = "not published" ]; then
+    echo "⚠ WASM package not yet published to npm"
+elif [ "$NPM_REGISTRY_VERSION" != "$CARGO_VERSION" ]; then
+    echo "⚠ npm registry version ($NPM_REGISTRY_VERSION) differs from local ($CARGO_VERSION)"
+    echo "  Run: cd wasm && npm publish"
+else
+    echo "✓ npm registry version: $NPM_REGISTRY_VERSION"
+fi
+
+echo ""
+echo "✓ All local versions synchronized: $CARGO_VERSION"


### PR DESCRIPTION
## Summary
- Add version sync to hard constraints (must match across all files)
- Add npm registry check to `verify-version-sync.sh` script
- Add release checklist with npm publish step
- Add learnings from this session

## Changes
- `agents-docs/hard-constraints.md` - Added version sync requirement
- `agents-docs/quick-reference.md` - Added release checklist with npm publish step
- `agents-docs/self-learning-patterns.md` - Added version sync learnings
- `scripts/verify-version-sync.sh` - Added npm registry version check

## Why
Version numbers were out of sync between Cargo.toml (0.2.5) and npm registry (0.2.3), causing confusion. This PR adds:
1. CI check for version drift
2. Release checklist with npm publish step
3. Learnings to prevent future issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)