### PR TITLE
fix(ci): correct wasm-pack build path for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,10 +267,9 @@ jobs:
       env:
         WASM_OPT_FLAGS: "--enable-bulk-memory --enable-sign-ext"
       run: |
-        cd wasm
-        wasm-pack build --target web --out-dir pkg -- --features wasm
-        cp ../LICENSE pkg/
-        cp ../README.md pkg/
+        wasm-pack build --target web --out-dir wasm/pkg -- --features wasm
+        cp LICENSE wasm/pkg/
+        cp README.md wasm/pkg/
 
     - name: Publish to npm
       if: steps.npm-check.outputs.already-published != 'true'


### PR DESCRIPTION
## Summary

Fixes the npm publish job in the release workflow by correcting the wasm-pack build path.

The wasm-pack build was being run from the `wasm/` subdirectory, but the Cargo.toml is at the repository root. This caused the output to be created at `./pkg` instead of `wasm/pkg`, and the subsequent `cp` commands failed with "Not a directory".

## Test plan

- [ ] Merge this PR
- [ ] Manually re-run the npm publish job or release 0.2.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)