### PR TITLE
release: v0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.7] - 2026-04-05
+
+### Fixed
+
+- **npm publish workflow**: Corrected wasm-pack build path to run from repository root
+  instead of `wasm/` subdirectory, fixing "pkg/: Not a directory" error.
+
 ## [0.2.6] - 2026-04-05
 
 ### Added
@@ -233,7 +240,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated CI workflow with security permissions and concurrency controls
 - Trusted Publishing eliminates need for long-lived API tokens
 
-[unreleased]: https://github.com/d-o-hub/chaotic_semantic_memory/compare/v0.2.6...HEAD
+[unreleased]: https://github.com/d-o-hub/chaotic_semantic_memory/compare/v0.2.7...HEAD
+[0.2.7]: https://github.com/d-o-hub/chaotic_semantic_memory/releases/tag/v0.2.7
 [0.2.6]: https://github.com/d-o-hub/chaotic_semantic_memory/releases/tag/v0.2.6
 [0.2.5]: https://github.com/d-o-hub/chaotic_semantic_memory/releases/tag/v0.2.5
 [0.2.4]: https://github.com/d-o-hub/chaotic_semantic_memory/releases/tag/v0.2.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,7 +355,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chaotic_semantic_memory"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chaotic_semantic_memory"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2024"
 rust-version = "1.85"
 description = "AI memory systems with hyperdimensional vectors and chaotic reservoirs"

--- a/examples/cli/12_metadata_limits.sh
+++ b/examples/cli/12_metadata_limits.sh
@@ -126,7 +126,7 @@ echo "The import/export format supports metadata in the JSON payload:"
 echo ""
 cat << 'JSON_EXAMPLE'
 {
-  "version": "0.2.6",
+  "version": "0.2.7",
   "exported_at": 1234567890,
   "concepts": [
     {

--- a/examples/cli/13_import_missing_file.sh
+++ b/examples/cli/13_import_missing_file.sh
@@ -46,7 +46,7 @@ echo "  Creating valid import JSON..."
 # This demonstrates the import structure without serialization issues
 cat > "$VALID_IMPORT_FILE" << 'EOF'
 {
-  "version": "0.2.6",
+  "version": "0.2.7",
   "exported_at": 1700000000,
   "concepts": [],
   "associations": []
@@ -99,7 +99,7 @@ echo "  - Handle the error gracefully in automation pipelines"
 echo ""
 echo "Import file format:"
 echo '  {'
-echo '    "version": "0.2.6",'
+echo '    "version": "0.2.7",'
 echo '    "exported_at": <unix_timestamp>,'
 echo '    "concepts": [...],'
 echo '    "associations": [...]'

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2,33 +2,33 @@
 
 > AI memory systems with hyperdimensional vectors and chaotic reservoirs
 
-**Version:** 0.2.6
+**Version:** 0.2.7
 **License:** MIT
 **Repository:** https://github.com/d-o-hub/chaotic_semantic_memory
 **Homepage:** https://github.com/d-o-hub/chaotic_semantic_memory
 **Keywords:** ai, memory, hypervector, reservoir, wasm
 **Dependencies:**
-- tracing (0.1.41)
-- clap_complete (4.5.42)
+- glob (0.3.2)
+- anyhow (1.0.102)
+- base64 (0.22)
+- thiserror (2.0.11)
+- serde_json (1.0.149)
+- rand (0.8.5)
 - serde (1.0.219) [features: derive]
 - bincode (1.3.3)
-- tracing-subscriber (0.3.19)
-- anyhow (1.0.102)
-- thiserror (2.0.11)
 - clap (4.5.60) [features: derive, env, string]
-- base64 (0.22)
-- rand (0.8.5)
+- clap_complete (4.5.42)
+- tracing-subscriber (0.3.19)
+- tracing (0.1.41)
 - colored (2.2.0)
-- glob (0.3.2)
-- serde_json (1.0.149)
 **Features:**
 - default: [cli, persistence, parallel]
-- wasm: []
-- parallel: [dep:rayon]
 - persistence: [dep:libsql]
 - cli: [dep:clap, dep:clap_complete, dep:anyhow, dep:colored, dep:glob]
+- parallel: [dep:rayon]
+- wasm: []
 
-Generated: 2026-04-05 10:50:03 UTC  
+Generated: 2026-04-05 11:16:50 UTC  
 Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 
 ## Table of Contents

--- a/llms.txt
+++ b/llms.txt
@@ -2,33 +2,33 @@
 
 > AI memory systems with hyperdimensional vectors and chaotic reservoirs
 
-**Version:** 0.2.6
+**Version:** 0.2.7
 **License:** MIT
 **Repository:** https://github.com/d-o-hub/chaotic_semantic_memory
 **Homepage:** https://github.com/d-o-hub/chaotic_semantic_memory
 **Keywords:** ai, memory, hypervector, reservoir, wasm
 **Dependencies:**
-- tracing (0.1.41)
-- clap_complete (4.5.42)
+- glob (0.3.2)
+- anyhow (1.0.102)
+- base64 (0.22)
+- thiserror (2.0.11)
+- serde_json (1.0.149)
+- rand (0.8.5)
 - serde (1.0.219) [features: derive]
 - bincode (1.3.3)
-- tracing-subscriber (0.3.19)
-- anyhow (1.0.102)
-- thiserror (2.0.11)
 - clap (4.5.60) [features: derive, env, string]
-- base64 (0.22)
-- rand (0.8.5)
+- clap_complete (4.5.42)
+- tracing-subscriber (0.3.19)
+- tracing (0.1.41)
 - colored (2.2.0)
-- glob (0.3.2)
-- serde_json (1.0.149)
 **Features:**
 - default: [cli, persistence, parallel]
-- wasm: []
-- parallel: [dep:rayon]
 - persistence: [dep:libsql]
 - cli: [dep:clap, dep:clap_complete, dep:anyhow, dep:colored, dep:glob]
+- parallel: [dep:rayon]
+- wasm: []
 
-Generated: 2026-04-05 10:50:03 UTC  
+Generated: 2026-04-05 11:16:50 UTC  
 Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 
 ## Core Documentation
@@ -808,7 +808,7 @@ Contributions are welcome! Please read our [Contributing Guide](CONTRIBUTING.md)
 ```toml
 [package]
 name = "chaotic_semantic_memory"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2024"
 rust-version = "1.85"
 description = "AI memory systems with hyperdimensional vectors and chaotic reservoirs"

--- a/tests/framework_lifecycle.rs
+++ b/tests/framework_lifecycle.rs
@@ -72,7 +72,7 @@ async fn framework_import_skips_orphan_associations_without_failing() {
     let import_path = import_file.path().to_str().unwrap().to_string();
 
     let payload = serde_json::json!({
-        "version": "0.2.6",
+        "version": "0.2.7",
         "exported_at": 1u64,
         "concepts": [],
         "associations": [["a", "missing", 0.7]]

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d-o-hub/chaotic_semantic_memory",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "AI memory systems with hyperdimensional vectors and chaotic reservoirs - WASM bindings",
   "main": "chaotic_semantic_memory.js",
   "types": "chaotic_semantic_memory.d.ts",


### PR DESCRIPTION
## Summary

- Fixes npm publish workflow: corrected wasm-pack build path to run from repository root instead of `wasm/` subdirectory

## Test plan

- [ ] CI checks pass (build, test, clippy, fmt)
- [ ] crates.io publish succeeds
- [ ] npm publish succeeds (the fix being validated)
- [ ] GitHub release created with artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)