### PR TITLE
fix(singularity): bound bucket_probe_width to prevent overflow panic

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -353,7 +353,7 @@ fn bench_retrieval_baseline(c: &mut Criterion) {
         let mut singularity_bucket = build_probe_benchmark_singularity(concept_count, false);
         let mut ret_config = singularity_bucket.retrieval_config().clone();
         ret_config.enable_bucket_candidates = true;
-        singularity_bucket.set_retrieval_config(ret_config);
+        let _ = singularity_bucket.set_retrieval_config(ret_config);
 
         group.bench_function(format!("reduced_bucket_{concept_count}"), |b| {
             b.iter(|| {

--- a/src/framework_validation.rs
+++ b/src/framework_validation.rs
@@ -3,10 +3,22 @@ use std::collections::HashMap;
 use crate::error::{MemoryError, Result};
 use crate::framework::ChaoticSemanticFramework;
 use crate::singularity::Concept;
+use crate::singularity_retrieval::RetrievalConfig;
 
 const MAX_CONCEPT_ID_BYTES: usize = 256;
+const MAX_BUCKET_PROBE_WIDTH: usize = 16;
 
 impl ChaoticSemanticFramework {
+    pub(crate) fn validate_retrieval_config(config: &RetrievalConfig) -> Result<()> {
+        if config.bucket_probe_width > MAX_BUCKET_PROBE_WIDTH {
+            return Err(MemoryError::InvalidInput {
+                field: "bucket_probe_width".to_string(),
+                reason: format!("bucket_probe_width exceeds {}", MAX_BUCKET_PROBE_WIDTH),
+            });
+        }
+        Ok(())
+    }
+
     pub(crate) fn validate_concept_id(id: &str) -> Result<()> {
         if id.is_empty() {
             return Err(MemoryError::InvalidInput {
@@ -127,5 +139,20 @@ mod tests {
         assert!(ChaoticSemanticFramework::validate_concept_id(&long_id).is_err());
         let edge_id = "a".repeat(256);
         assert!(ChaoticSemanticFramework::validate_concept_id(&edge_id).is_ok());
+    }
+
+    #[test]
+    fn test_validate_retrieval_config_bucket_width() {
+        let config = RetrievalConfig {
+            bucket_probe_width: 16,
+            ..RetrievalConfig::default()
+        };
+        assert!(ChaoticSemanticFramework::validate_retrieval_config(&config).is_ok());
+
+        let config = RetrievalConfig {
+            bucket_probe_width: 17,
+            ..RetrievalConfig::default()
+        };
+        assert!(ChaoticSemanticFramework::validate_retrieval_config(&config).is_err());
     }
 }

--- a/src/singularity_retrieval.rs
+++ b/src/singularity_retrieval.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 #[cfg(all(not(target_arch = "wasm32"), feature = "parallel"))]
 use rayon::prelude::*;
 
+use crate::error::Result;
 use crate::hyperdim::HVec10240;
 use crate::singularity::{Singularity, unix_now_ns};
 
@@ -58,6 +59,12 @@ pub struct RetrievalConfig {
     pub enable_bucket_candidates: bool,
 }
 
+impl RetrievalConfig {
+    pub fn validate(&self) -> Result<()> {
+        crate::framework::ChaoticSemanticFramework::validate_retrieval_config(self)
+    }
+}
+
 impl Default for RetrievalConfig {
     fn default() -> Self {
         Self {
@@ -74,8 +81,10 @@ impl Default for RetrievalConfig {
 
 impl Singularity {
     /// Set the retrieval configuration.
-    pub fn set_retrieval_config(&mut self, config: RetrievalConfig) {
+    pub fn set_retrieval_config(&mut self, config: RetrievalConfig) -> Result<()> {
+        config.validate()?;
         self.retrieval_config = config;
+        Ok(())
     }
 
     /// Get the retrieval configuration.


### PR DESCRIPTION
**Severity:** HIGH
**Finding:** Missing input bound on `bucket_probe_width` in `RetrievalConfig` (src/singularity_retrieval.rs)
**Impact:** Setting `bucket_probe_width >= 64` (on 64-bit systems) causes an "attempt to shift left with overflow" panic during candidate generation, leading to Denial of Service (DoS).
**Fix:** Introduced `MAX_BUCKET_PROBE_WIDTH = 16` and enforced it in `Singularity::set_retrieval_config`.
**Verification:** all gates pass — available tests and lints are clean, and new regression test `test_validate_retrieval_config_bucket_width` passes.

---
*PR created automatically by Jules for task [5539937280301755812](https://jules.google.com/task/5539937280301755812) started by @d-o-hub*