### PR TITLE
Clarify CSM table names in documentation and verification scripts

### DIFF
--- a/.agents/skills/memory-lifecycle-verification/references/sql_checks.sql
+++ b/.agents/skills/memory-lifecycle-verification/references/sql_checks.sql
@@ -3,23 +3,23 @@
 
 -- Concept existence checks
 SELECT COUNT(*) AS concept_count
-FROM concepts
+FROM csm_concepts
 WHERE id IN ('test::lifecycle::alpha', 'test::lifecycle::beta');
 
 -- Association existence check
 SELECT COUNT(*) AS association_count
-FROM associations
-WHERE source_id = 'test::lifecycle::alpha'
-  AND target_id = 'test::lifecycle::beta';
+FROM csm_associations
+WHERE from_id = 'test::lifecycle::alpha'
+  AND to_id = 'test::lifecycle::beta';
 
 -- Archive marker check
 SELECT COUNT(*) AS archive_marker_count
-FROM concepts
+FROM csm_concepts
 WHERE id = 'archive::test::lifecycle::alpha';
 
 -- Orphan association check
 SELECT COUNT(*) AS orphan_associations
-FROM associations a
-LEFT JOIN concepts c1 ON c1.id = a.source_id
-LEFT JOIN concepts c2 ON c2.id = a.target_id
+FROM csm_associations a
+LEFT JOIN csm_concepts c1 ON c1.id = a.from_id
+LEFT JOIN csm_concepts c2 ON c2.id = a.to_id
 WHERE c1.id IS NULL OR c2.id IS NULL;

--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -2125,7 +2125,7 @@ actions:
     description: |
       Add disassociate(from, to) to framework + singularity + persistence:
       - Singularity: remove from HashMap<String, HashMap<String, f32>>
-      - Persistence: DELETE FROM associations WHERE from_id=? AND to_id=?
+      - Persistence: DELETE FROM csm_associations WHERE from_id=? AND to_id=?
       - Framework: orchestrate both + validate IDs
 
   - name: add_framework_clear_associations
@@ -2140,7 +2140,7 @@ actions:
     description: |
       Add clear_associations(from) to framework + singularity + persistence:
       - Singularity: remove all entries for from_id
-      - Persistence: DELETE FROM associations WHERE from_id=?
+      - Persistence: DELETE FROM csm_associations WHERE from_id=?
       - Framework: orchestrate + cache invalidation
 
   - name: add_singularity_bundle_strict

--- a/plans/handoffs/analysis_group_a_testing.md
+++ b/plans/handoffs/analysis_group_a_testing.md
@@ -171,7 +171,7 @@ async fn persistence_corrupted_vector_bytes() {
     // Manually insert corrupted vector data
     let conn = persistence.connect().await.unwrap();
     conn.execute(
-        "INSERT INTO concepts (id, vector, metadata, created_at, modified_at) 
+        "INSERT INTO csm_concepts (id, vector, metadata, created_at, modified_at)
          VALUES (?1, ?2, ?3, ?4, ?5)",
         libsql::params![
             "corrupted",
@@ -288,10 +288,10 @@ async fn db_schema_tables_exist() {
         tables.push(row.get::<String>(0).unwrap());
     }
     
-    assert!(tables.contains(&"concepts".to_string()));
-    assert!(tables.contains(&"associations".to_string()));
-    assert!(tables.contains(&"concept_versions".to_string()));
-    assert!(tables.contains(&"__schema_version".to_string()));
+    assert!(tables.contains(&"csm_concepts".to_string()));
+    assert!(tables.contains(&"csm_associations".to_string()));
+    assert!(tables.contains(&"csm_versions".to_string()));
+    assert!(tables.contains(&"csm_schema_version".to_string()));
 }
 
 #[tokio::test]
@@ -313,7 +313,7 @@ async fn db_foreign_key_constraints_active() {
     // Direct SQL: Try to delete concept without cascade (should fail due to FK)
     let conn = get_raw_connection(path).await;
     let result = conn
-        .execute("DELETE FROM concepts WHERE id = 'test'", ())
+        .execute("DELETE FROM csm_concepts WHERE id = 'test'", ())
         .await;
     
     // Should fail due to foreign key constraint
@@ -321,7 +321,7 @@ async fn db_foreign_key_constraints_active() {
 }
 
 #[tokio::test]
-async fn db_concept_versions_cascade_delete() {
+async fn db_csm_versions_cascade_delete() {
     let temp = NamedTempFile::new().unwrap();
     let path = temp.path().to_str().unwrap();
     let persistence = Persistence::new_local(path).await.unwrap();
@@ -340,7 +340,7 @@ async fn db_concept_versions_cascade_delete() {
     // Verify versions exist
     let conn = get_raw_connection(path).await;
     let mut rows = conn
-        .query("SELECT COUNT(*) FROM concept_versions WHERE concept_id = 'versioned'", ())
+        .query("SELECT COUNT(*) FROM csm_versions WHERE concept_id = 'versioned'", ())
         .await
         .unwrap();
     
@@ -352,7 +352,7 @@ async fn db_concept_versions_cascade_delete() {
     
     // Verify versions were cascade deleted
     let mut rows = conn
-        .query("SELECT COUNT(*) FROM concept_versions WHERE concept_id = 'versioned'", ())
+        .query("SELECT COUNT(*) FROM csm_versions WHERE concept_id = 'versioned'", ())
         .await
         .unwrap();
     
@@ -375,7 +375,7 @@ async fn db_vector_blob_exact_size() {
     // Direct SQL: Verify vector blob is exactly 1280 bytes
     let conn = get_raw_connection(path).await;
     let mut rows = conn
-        .query("SELECT LENGTH(vector) as vec_len FROM concepts WHERE id = 'sized'", ())
+        .query("SELECT LENGTH(vector) as vec_len FROM csm_concepts WHERE id = 'sized'", ())
         .await
         .unwrap();
     
@@ -414,12 +414,12 @@ async fn db_index_usage_verification() {
         indexes.push(row.get::<String>(0).unwrap());
     }
     
-    assert!(indexes.iter().any(|i| i.contains("associations")));
-    assert!(indexes.iter().any(|i| i.contains("concept_versions")));
+    assert!(indexes.iter().any(|i| i.contains("csm_associations")));
+    assert!(indexes.iter().any(|i| i.contains("csm_versions")));
     
     // EXPLAIN QUERY PLAN to verify index usage
     let mut rows = conn
-        .query("EXPLAIN QUERY PLAN SELECT * FROM associations WHERE from_id = 'c1'", ())
+        .query("EXPLAIN QUERY PLAN SELECT * FROM csm_associations WHERE from_id = 'c1'", ())
         .await
         .unwrap();
     
@@ -510,7 +510,7 @@ async fn db_schema_version_integrity() {
     // Verify through direct SQL
     let conn = get_raw_connection(path).await;
     let mut rows = conn
-        .query("SELECT MAX(version) FROM __schema_version", ())
+        .query("SELECT MAX(version) FROM csm_schema_version", ())
         .await
         .unwrap();
     
@@ -552,7 +552,7 @@ async fn db_concept_timestamps_monotonic() {
     let db = libsql::Builder::new_local(path).build().await.unwrap();
     let conn = db.connect().unwrap();
     let mut rows = conn
-        .query("SELECT created_at, modified_at FROM concepts WHERE id = 'timed'", ())
+        .query("SELECT created_at, modified_at FROM csm_concepts WHERE id = 'timed'", ())
         .await
         .unwrap();
     
@@ -573,7 +573,7 @@ async fn db_concept_timestamps_monotonic() {
     persistence.save_concept(&updated).await.unwrap();
     
     let mut rows = conn
-        .query("SELECT created_at, modified_at FROM concepts WHERE id = 'timed'", ())
+        .query("SELECT created_at, modified_at FROM csm_concepts WHERE id = 'timed'", ())
         .await
         .unwrap();
     
@@ -615,7 +615,7 @@ async fn db_association_strength_precision() {
         let conn = db.connect().unwrap();
         let mut rows = conn
             .query(
-                "SELECT strength FROM associations WHERE from_id = 'assoc_test' AND to_id = ?1",
+                "SELECT strength FROM csm_associations WHERE from_id = 'assoc_test' AND to_id = ?1",
                 [target]
             )
             .await
@@ -653,7 +653,7 @@ async fn db_version_retention_policy() {
     let conn = db.connect().unwrap();
     let mut rows = conn
         .query(
-            "SELECT COUNT(*) FROM concept_versions WHERE concept_id = 'versioned_retention'",
+            "SELECT COUNT(*) FROM csm_versions WHERE concept_id = 'versioned_retention'",
             ()
         )
         .await

--- a/plans/handoffs/analysis_memory_leaks.md
+++ b/plans/handoffs/analysis_memory_leaks.md
@@ -186,10 +186,10 @@ async fn record_concept_version(&self, conn: &Connection, concept: &Concept) -> 
     // ... creates new version record
     
     conn.execute(
-        "DELETE FROM concept_versions
+        "DELETE FROM csm_versions
          WHERE concept_id = ?1
          AND version <= (
-            SELECT MAX(version) - ?2 FROM concept_versions WHERE concept_id = ?1
+            SELECT MAX(version) - ?2 FROM csm_versions WHERE concept_id = ?1
          )",
         params![concept.id.clone(), self.version_retention as i64],
     )
@@ -210,14 +210,14 @@ async fn record_concept_version(&self, conn: &Connection, concept: &Concept) -> 
     
     // First check total version count
     let count: i64 = conn.query(
-        "SELECT COUNT(*) FROM concept_versions WHERE concept_id = ?1",
+        "SELECT COUNT(*) FROM csm_versions WHERE concept_id = ?1",
         params![concept.id.clone()]
     ).await?.next().await?.get(0)?;
     
     if count >= retention as i64 * 2 {
         // Emergency cleanup if somehow exceeded
         conn.execute(
-            "DELETE FROM concept_versions WHERE concept_id = ?1 
+            "DELETE FROM csm_versions WHERE concept_id = ?1
              ORDER BY version ASC LIMIT ?2",
             params![concept.id.clone(), count - retention as i64]
         ).await?;


### PR DESCRIPTION
This submission updates documentation, checklists, and plan files to use the correct prefixed table names (`csm_concepts`, `csm_associations`, etc.) instead of legacy names. This fixes issues where verification SQL queries failed because they targeted non-existent tables.

Key changes:
- Updated `.agents/skills/memory-lifecycle-verification/references/sql_checks.sql` with correct table and column names.
- Updated `plans/handoffs/analysis_group_a_testing.md` and `plans/handoffs/analysis_memory_leaks.md` code examples.
- Updated `plans/ACTIONS.md` persistence task descriptions.
- Verified that `src/persistence_migrations.rs` correctly retains legacy names for migration support.
- Confirmed all existing tests pass.

Fixes #78

---
*PR created automatically by Jules for task [10104631629693542462](https://jules.google.com/task/10104631629693542462) started by @d-o-hub*