### PR TITLE
docs(review): add PR #77 CLI install validation report

### DIFF
--- a/progress/reviews/PR_77_VALIDATION.md
+++ b/progress/reviews/PR_77_VALIDATION.md
@@ -1,0 +1,42 @@
+# PR #77 Validation Report (d-o-hub/chaotic_semantic_memory)
+
+Date: 2026-04-14
+Reviewer: Codex
+
+## Scope
+Validated the changes introduced by PR #77:
+- `cli-npm/postinstall.js`
+- `scripts/sync-version.sh`
+
+## Findings
+
+### 1) `cli-npm/postinstall.js`
+- **Change reviewed**: Removed `createGunzip()` from stream pipeline before passing data to `tar -xz`.
+- **Assessment**: ✅ Correct fix.
+- **Why**: `tar -xz` already performs gzip decompression. Pre-decompressing with `createGunzip()` causes a double-decompression path and extraction failures.
+
+### 2) `scripts/sync-version.sh`
+- **Change reviewed**: Updated duplicate-version detection to use:
+  - `grep -c "^## \[${ver}\]" "$changelog" || true`
+  - `if [ "${existing_count:-0}" -gt 0 ]; then`
+- **Assessment**: ✅ Correct hardening.
+- **Why**: Avoids brittle behavior under strict shell settings and handles empty/unset counts safely.
+
+## Validation Executed
+
+### Repro of gzip extraction behavior
+A local repro showed:
+- `gunzip | tar -xz` → exit code 2 (fails)
+- `tar -xz` on `.tar.gz` stream → exit code 0 (succeeds)
+
+This supports the `postinstall.js` change.
+
+### npm install path test
+Attempted package install from packed tarball (`npm pack` + `npm install --foreground-scripts`).
+- Result: install failed during postinstall because the release artifact URL returned 404 for `v0.3.2/csm-linux-x64.tar.gz`.
+- Interpretation: failure is due to missing release artifact, not the stream pipeline change.
+
+## Conclusion
+- PR #77 changes are sound for the code paths modified.
+- CLI install success still depends on GitHub release assets existing for the package version/platform.
+- Recommended follow-up: add a CI/Release check that validates all expected `csm-<platform>.tar.gz` assets exist before publishing `@d-o-hub/csm`.


### PR DESCRIPTION
### Motivation
- Provide a persistent, auditable validation of PR #77 that reviews the `csm` CLI postinstall behavior and the version sync script hardening. 
- Capture the remaining installation blocker (missing GitHub release artifact) so it is visible to maintainers and release engineers.

### Description
- Added a validation report at `progress/reviews/PR_77_VALIDATION.md` summarizing the review scope, findings, and recommendations. 
- Documented that `cli-npm/postinstall.js` was corrected by removing `createGunzip()` to avoid double-decompression when piping into `tar -xz`. 
- Documented that `scripts/sync-version.sh` was hardened to safely handle empty/unset counts and avoid brittle behavior in duplicate-version checks. 

### Testing
- Verified repository refs with `git ls-remote` and fetched PR refs with `git fetch` to inspect the proposed changes. (succeeded) 
- Ran `git diff` on the changed files to confirm the exact edits applied to `cli-npm/postinstall.js` and `scripts/sync-version.sh`. (succeeded) 
- Created an npm package with `npm pack` from `cli-npm` to validate packaging. (succeeded) 
- Attempted an install via `npm install <packed-tarball>` which ran the `postinstall` script and failed because the release asset URL returned HTTP 404, indicating a missing GitHub release artifact (failure due to missing asset, not code regression). 
- Reproduced archive extraction behavior with a Node + shell repro showing that `gunzip | tar -xz` fails while streaming the `.tar.gz` directly to `tar -xz` succeeds, validating the `createGunzip()` removal. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de9ea786f883208678bd1970c0de48)