### PR TITLE
Fix security issues: input bounds and sensitive data disclosure

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8,28 +8,28 @@
 **Homepage:** https://github.com/d-o-hub/chaotic_semantic_memory
 **Keywords:** ai, memory, hypervector, reservoir, wasm
 **Dependencies:**
-- glob (0.3.2)
-- rand_chacha (0.10.0)
-- colored (2.2.0)
-- base64 (0.22)
-- bincode (1.3.3)
 - tracing-subscriber (0.3.19)
-- thiserror (2.0.11)
-- serde_json (1.0.149)
-- serde (1.0.219) [features: derive]
 - tracing (0.1.41)
+- serde (1.0.219) [features: derive]
+- clap_complete (4.5.42)
 - rand (0.10.1)
 - clap (4.5.60) [features: derive, env, string]
-- clap_complete (4.5.42)
 - anyhow (1.0.102)
+- colored (2.2.0)
+- glob (0.3.2)
+- thiserror (2.0.11)
+- base64 (0.22)
+- bincode (1.3.3)
+- serde_json (1.0.149)
+- rand_chacha (0.10.0)
 **Features:**
-- cli: [dep:clap, dep:clap_complete, dep:anyhow, dep:colored, dep:glob]
-- persistence: [dep:libsql]
 - wasm: []
-- parallel: [dep:rayon]
 - default: [cli, persistence, parallel]
+- cli: [dep:clap, dep:clap_complete, dep:anyhow, dep:colored, dep:glob]
+- parallel: [dep:rayon]
+- persistence: [dep:libsql]
 
-Generated: 2026-04-16 19:36:36 UTC
+Generated: 2026-04-16 22:28:33 UTC
 Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 
 ## Table of Contents
@@ -1317,6 +1317,8 @@ pub struct FrameworkConfig {
     pub max_probe_top_k: usize,
     pub max_metadata_bytes: Option<usize>,
     pub max_cached_top_k: usize,
+    pub max_batch_size: usize,
+    pub max_sequence_length: usize,
 }
 ```
 
@@ -1365,6 +1367,8 @@ impl FrameworkBuilder {
     pub fn with_max_probe_top_k(self, max_probe_top_k: usize) -> Self;
     pub fn with_max_metadata_bytes(self, max_metadata_bytes: usize) -> Self;
     pub fn with_max_cached_top_k(self, max_cached_top_k: usize) -> Self;
+    pub fn with_max_batch_size(self, max_batch_size: usize) -> Self;
+    pub fn with_max_sequence_length(self, max_sequence_length: usize) -> Self;
     pub fn with_version_retention(self, retention: usize) -> Self;
     pub fn with_local_db(self, path: impl Trait) -> Self;
     pub fn with_turso(self, url: impl Trait, token: impl Trait) -> Self;

--- a/llms.txt
+++ b/llms.txt
@@ -8,28 +8,28 @@
 **Homepage:** https://github.com/d-o-hub/chaotic_semantic_memory
 **Keywords:** ai, memory, hypervector, reservoir, wasm
 **Dependencies:**
-- glob (0.3.2)
-- rand_chacha (0.10.0)
-- colored (2.2.0)
-- base64 (0.22)
-- bincode (1.3.3)
 - tracing-subscriber (0.3.19)
-- thiserror (2.0.11)
-- serde_json (1.0.149)
-- serde (1.0.219) [features: derive]
 - tracing (0.1.41)
+- serde (1.0.219) [features: derive]
+- clap_complete (4.5.42)
 - rand (0.10.1)
 - clap (4.5.60) [features: derive, env, string]
-- clap_complete (4.5.42)
 - anyhow (1.0.102)
+- colored (2.2.0)
+- glob (0.3.2)
+- thiserror (2.0.11)
+- base64 (0.22)
+- bincode (1.3.3)
+- serde_json (1.0.149)
+- rand_chacha (0.10.0)
 **Features:**
-- cli: [dep:clap, dep:clap_complete, dep:anyhow, dep:colored, dep:glob]
-- persistence: [dep:libsql]
 - wasm: []
-- parallel: [dep:rayon]
 - default: [cli, persistence, parallel]
+- cli: [dep:clap, dep:clap_complete, dep:anyhow, dep:colored, dep:glob]
+- parallel: [dep:rayon]
+- persistence: [dep:libsql]
 
-Generated: 2026-04-16 19:36:36 UTC
+Generated: 2026-04-16 22:28:33 UTC
 Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 
 ## Core Documentation

--- a/plans/handoffs/W5_C_to_D_wasm_size_report.md
+++ b/plans/handoffs/W5_C_to_D_wasm_size_report.md
@@ -6,7 +6,7 @@
 ## Measurement
 - Command: `cargo build --target wasm32-unknown-unknown --release --features wasm`
 - Artifact: `target/wasm32-unknown-unknown/release/chaotic_semantic_memory.wasm`
-- Size: `864260` bytes (`844.00` KiB)
+- Size: `860434` bytes (`840.27` KiB)
 - Threshold: `1048576` bytes (configurable via `CSM_WASM_SIZE_MAX_BYTES`)
 
 ## Result

--- a/src/framework.rs
+++ b/src/framework.rs
@@ -239,6 +239,7 @@ impl ChaoticSemanticFramework {
     /// Process temporal sequence through reservoir
     #[instrument(err, skip(self, sequence))]
     pub async fn process_sequence(&self, sequence: &[Vec<f32>]) -> Result<HVec10240> {
+        self.validate_sequence_length(sequence.len())?;
         let mut reservoir = self.reservoir.write().await;
 
         if reservoir.is_none() {

--- a/src/framework_builder.rs
+++ b/src/framework_builder.rs
@@ -12,6 +12,8 @@ use crate::singularity::{Singularity, SingularityConfig};
 
 const DEFAULT_MAX_PROBE_TOP_K: usize = 10_000;
 const DEFAULT_MAX_CACHED_TOP_K: usize = 100;
+const DEFAULT_MAX_BATCH_SIZE: usize = 1000;
+const DEFAULT_MAX_SEQUENCE_LENGTH: usize = 1024;
 
 /// Runtime configuration for [`ChaoticSemanticFramework`], tuned via [`FrameworkBuilder`].
 #[derive(Clone, Debug)]
@@ -37,6 +39,10 @@ pub struct FrameworkConfig {
     /// Maximum top_k for cache eligibility (default: `100`).
     /// Queries with top_k > this value bypass the cache.
     pub max_cached_top_k: usize,
+    /// Maximum items in a batch operation (default: `1000`).
+    pub max_batch_size: usize,
+    /// Maximum steps in a temporal sequence (default: `1024`).
+    pub max_sequence_length: usize,
 }
 
 impl Default for FrameworkConfig {
@@ -52,6 +58,8 @@ impl Default for FrameworkConfig {
             max_probe_top_k: DEFAULT_MAX_PROBE_TOP_K,
             max_metadata_bytes: None,
             max_cached_top_k: DEFAULT_MAX_CACHED_TOP_K,
+            max_batch_size: DEFAULT_MAX_BATCH_SIZE,
+            max_sequence_length: DEFAULT_MAX_SEQUENCE_LENGTH,
         }
     }
 }
@@ -135,6 +143,16 @@ impl FrameworkBuilder {
 
     pub fn with_max_cached_top_k(mut self, max_cached_top_k: usize) -> Self {
         self.config.max_cached_top_k = max_cached_top_k.max(1);
+        self
+    }
+
+    pub fn with_max_batch_size(mut self, max_batch_size: usize) -> Self {
+        self.config.max_batch_size = max_batch_size.max(1);
+        self
+    }
+
+    pub fn with_max_sequence_length(mut self, max_sequence_length: usize) -> Self {
+        self.config.max_sequence_length = max_sequence_length.max(1);
         self
     }
 

--- a/src/framework_ops.rs
+++ b/src/framework_ops.rs
@@ -83,6 +83,8 @@ impl ChaoticSemanticFramework {
     /// Batch inject multiple concepts into memory.
     #[instrument(err, skip(self, concepts))]
     pub async fn inject_concepts(&self, concepts: &[(String, HVec10240)]) -> Result<()> {
+        self.validate_batch_size(concepts.len())?;
+
         if concepts.is_empty() {
             return Ok(());
         }
@@ -111,6 +113,8 @@ impl ChaoticSemanticFramework {
     /// Batch create associations between concepts.
     #[instrument(err, skip(self, associations))]
     pub async fn associate_many(&self, associations: &[(String, String, f32)]) -> Result<()> {
+        self.validate_batch_size(associations.len())?;
+
         if associations.is_empty() {
             return Ok(());
         }
@@ -142,6 +146,7 @@ impl ChaoticSemanticFramework {
         top_k: usize,
     ) -> Result<Vec<Vec<(String, f32)>>> {
         self.validate_top_k(top_k)?;
+        self.validate_batch_size(queries.len())?;
         let sing = self.singularity.read().await;
         let mut out = Vec::with_capacity(queries.len());
         for query in queries {
@@ -159,6 +164,7 @@ impl ChaoticSemanticFramework {
         top_k: usize,
     ) -> Result<Vec<Arc<[(String, f32)]>>> {
         self.validate_top_k(top_k)?;
+        self.validate_batch_size(queries.len())?;
         let sing = self.singularity.read().await;
         let mut out = Vec::with_capacity(queries.len());
         for query in queries {

--- a/src/framework_validation.rs
+++ b/src/framework_validation.rs
@@ -101,6 +101,32 @@ impl ChaoticSemanticFramework {
         }
         Ok(())
     }
+
+    pub(crate) fn validate_batch_size(&self, batch_size: usize) -> Result<()> {
+        if batch_size > self.config.max_batch_size {
+            return Err(MemoryError::InvalidInput {
+                field: "batch_size".to_string(),
+                reason: format!(
+                    "batch size exceeds configured limit {} (got {})",
+                    self.config.max_batch_size, batch_size
+                ),
+            });
+        }
+        Ok(())
+    }
+
+    pub(crate) fn validate_sequence_length(&self, length: usize) -> Result<()> {
+        if length > self.config.max_sequence_length {
+            return Err(MemoryError::InvalidInput {
+                field: "sequence_length".to_string(),
+                reason: format!(
+                    "sequence length exceeds configured limit {} (got {})",
+                    self.config.max_sequence_length, length
+                ),
+            });
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -32,7 +32,7 @@ impl WasmFramework {
             .without_persistence()
             .build()
             .await
-            .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
+            .map_err(to_js_error)?;
 
         Ok(WasmFramework { framework })
     }
@@ -135,6 +135,10 @@ impl WasmFramework {
 
     /// Inject multiple concepts in batch
     pub async fn inject_concepts(&self, ids: Array, vectors: Array) -> Result<(), JsValue> {
+        self.framework
+            .validate_batch_size(ids.length() as usize)
+            .map_err(to_js_error)?;
+
         if ids.length() != vectors.length() {
             return Err(JsValue::from_str(
                 "ids and vectors arrays must have the same length",
@@ -164,6 +168,10 @@ impl WasmFramework {
 
     /// Create multiple associations in batch
     pub async fn associate_many(&self, associations: Array) -> Result<(), JsValue> {
+        self.framework
+            .validate_batch_size(associations.length() as usize)
+            .map_err(to_js_error)?;
+
         for i in 0..associations.length() {
             let assoc = associations.get(i);
             let from = js_sys::Reflect::get(&assoc, &"from".into())
@@ -191,6 +199,10 @@ impl WasmFramework {
 
     /// Probe for similar concepts with multiple queries in batch
     pub async fn probe_batch(&self, vectors: Array, top_k: usize) -> Result<Array, JsValue> {
+        self.framework
+            .validate_batch_size(vectors.length() as usize)
+            .map_err(to_js_error)?;
+
         let results = Array::new();
 
         for i in 0..vectors.length() {
@@ -292,6 +304,10 @@ impl WasmFramework {
     /// Process a temporal sequence and return the resulting hypervector bytes.
     #[wasm_bindgen(js_name = processSequence)]
     pub async fn process_sequence(&self, sequence: Array) -> Result<Box<[u8]>, JsValue> {
+        self.framework
+            .validate_sequence_length(sequence.length() as usize)
+            .map_err(to_js_error)?;
+
         let mut parsed_sequence = Vec::with_capacity(sequence.length() as usize);
         for item in sequence.iter() {
             let step = item

--- a/tests/batch_operations.rs
+++ b/tests/batch_operations.rs
@@ -662,6 +662,7 @@ async fn probe_batch_cached_large_corpus_keeps_exact_semantics() {
     let framework = ChaoticSemanticFramework::builder()
         .without_persistence()
         .with_concept_cache_size(64)
+        .with_max_batch_size(2001)
         .build()
         .await
         .unwrap();


### PR DESCRIPTION
**Severity:** MEDIUM
**Finding:** Missing input bounds on batch and sequence APIs in both the core framework and WASM bindings, and sensitive data (internal paths/debug info) returned to callers in WASM error messages.
**Impact:** An attacker or malicious input could trigger excessive memory allocation via `Vec::with_capacity` or high CPU usage, leading to a Denial of Service (DoS). Additionally, `Debug` formatting in WASM errors could leak internal environment details.
**Fix:**
- Introduced configurable `max_batch_size` (default 1000) and `max_sequence_length` (default 1024) in `FrameworkConfig`.
- Added `validate_batch_size` and `validate_sequence_length` methods to `ChaoticSemanticFramework`.
- Applied validation checks to `inject_concepts`, `associate_many`, `probe_batch`, and `process_sequence` across `src/framework_ops.rs`, `src/framework.rs`, and `src/wasm.rs`.
- Replaced `format!("{:?}", e)` with `to_js_error(e)` in `WasmFramework::new` to ensure errors only contain `Display` strings.
**Verification:**
- Ran `cargo test --all-features` (all 105 core tests and integration tests passed).
- Ran `scripts/validate.sh` (all LOC, clippy, and smoke tests passed).
- Updated `tests/batch_operations.rs` to verify that large batches work when configured correctly.

---
*PR created automatically by Jules for task [14023698617258556275](https://jules.google.com/task/14023698617258556275) started by @d-o-hub*