### PR TITLE
fix(singularity): add security bounds to graph traversal

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8,28 +8,28 @@
 **Homepage:** https://github.com/d-o-hub/chaotic_semantic_memory
 **Keywords:** ai, memory, hypervector, reservoir, wasm
 **Dependencies:**
-- rand (0.10.1)
+- colored (2.2.0)
 - serde_json (1.0.149)
-- base64 (0.22)
-- tracing-subscriber (0.3.19)
 - thiserror (2.0.11)
 - tracing (0.1.41)
-- rand_chacha (0.10.0)
-- anyhow (1.0.102)
-- colored (2.2.0)
-- bincode (1.3.3)
-- glob (0.3.2)
-- clap (4.5.60) [features: derive, env, string]
-- clap_complete (4.5.42)
 - serde (1.0.219) [features: derive]
+- base64 (0.22)
+- bincode (1.3.3)
+- anyhow (1.0.102)
+- rand (0.10.1)
+- clap_complete (4.5.42)
+- glob (0.3.2)
+- rand_chacha (0.10.0)
+- clap (4.5.60) [features: derive, env, string]
+- tracing-subscriber (0.3.19)
 **Features:**
-- wasm: []
-- parallel: [dep:rayon]
-- persistence: [dep:libsql]
 - default: [cli, persistence, parallel]
+- wasm: []
+- persistence: [dep:libsql]
 - cli: [dep:clap, dep:clap_complete, dep:anyhow, dep:colored, dep:glob]
+- parallel: [dep:rayon]
 
-Generated: 2026-04-22 08:03:34 UTC
+Generated: 2026-04-23 21:18:32 UTC
 Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 
 ## Table of Contents
@@ -273,7 +273,6 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub struct Bm25Config
 - impl Default for Bm25Config
 - pub struct Bm25Index
-- impl Default for Bm25Index
 - impl Bm25Index
 
 ### src/singularity.rs
@@ -2312,14 +2311,14 @@ pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, norma
 ### Bm25Config
 
 ```rust
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct Bm25Config {
     pub k1: f32,
     pub b: f32,
 }
 ```
 
-BM25 parameters.
+Configuration for BM25 ranking algorithm.
 
 ### impl Default for Bm25Config
 
@@ -2332,20 +2331,12 @@ impl Default for Bm25Config {
 ### Bm25Index
 
 ```rust
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Bm25Index {
 }
 ```
 
-BM25 keyword search index.
-
-### impl Default for Bm25Index
-
-```rust
-impl Default for Bm25Index {
-}
-```
-
+BM25-based document index for keyword search.
 
 ### impl Bm25Index
 

--- a/llms.txt
+++ b/llms.txt
@@ -8,28 +8,28 @@
 **Homepage:** https://github.com/d-o-hub/chaotic_semantic_memory
 **Keywords:** ai, memory, hypervector, reservoir, wasm
 **Dependencies:**
-- rand (0.10.1)
+- colored (2.2.0)
 - serde_json (1.0.149)
-- base64 (0.22)
-- tracing-subscriber (0.3.19)
 - thiserror (2.0.11)
 - tracing (0.1.41)
-- rand_chacha (0.10.0)
-- anyhow (1.0.102)
-- colored (2.2.0)
-- bincode (1.3.3)
-- glob (0.3.2)
-- clap (4.5.60) [features: derive, env, string]
-- clap_complete (4.5.42)
 - serde (1.0.219) [features: derive]
+- base64 (0.22)
+- bincode (1.3.3)
+- anyhow (1.0.102)
+- rand (0.10.1)
+- clap_complete (4.5.42)
+- glob (0.3.2)
+- rand_chacha (0.10.0)
+- clap (4.5.60) [features: derive, env, string]
+- tracing-subscriber (0.3.19)
 **Features:**
-- wasm: []
-- parallel: [dep:rayon]
-- persistence: [dep:libsql]
 - default: [cli, persistence, parallel]
+- wasm: []
+- persistence: [dep:libsql]
 - cli: [dep:clap, dep:clap_complete, dep:anyhow, dep:colored, dep:glob]
+- parallel: [dep:rayon]
 
-Generated: 2026-04-22 08:03:34 UTC
+Generated: 2026-04-23 21:18:32 UTC
 Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 
 ## Core Documentation
@@ -279,7 +279,6 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub struct Bm25Config
 - impl Default for Bm25Config
 - pub struct Bm25Index
-- impl Default for Bm25Index
 - impl Bm25Index
 
 ### src/singularity.rs

--- a/src/framework_validation.rs
+++ b/src/framework_validation.rs
@@ -2,11 +2,14 @@ use std::collections::HashMap;
 
 use crate::error::{MemoryError, Result};
 use crate::framework::ChaoticSemanticFramework;
+use crate::graph_traversal::TraversalConfig;
 use crate::singularity::Concept;
 use crate::singularity_retrieval::RetrievalConfig;
 
 const MAX_CONCEPT_ID_BYTES: usize = 256;
 const MAX_BUCKET_PROBE_WIDTH: usize = 16;
+const MAX_TRAVERSAL_DEPTH: usize = 32;
+const MAX_TRAVERSAL_RESULTS: usize = 10_000;
 
 impl ChaoticSemanticFramework {
     pub(crate) fn validate_retrieval_config(config: &RetrievalConfig) -> Result<()> {
@@ -14,6 +17,22 @@ impl ChaoticSemanticFramework {
             return Err(MemoryError::InvalidInput {
                 field: "bucket_probe_width".to_string(),
                 reason: format!("bucket_probe_width exceeds {}", MAX_BUCKET_PROBE_WIDTH),
+            });
+        }
+        Ok(())
+    }
+
+    pub(crate) fn validate_traversal_config(config: &TraversalConfig) -> Result<()> {
+        if config.max_depth > MAX_TRAVERSAL_DEPTH {
+            return Err(MemoryError::InvalidInput {
+                field: "max_depth".to_string(),
+                reason: format!("max_depth exceeds {}", MAX_TRAVERSAL_DEPTH),
+            });
+        }
+        if config.max_results > MAX_TRAVERSAL_RESULTS {
+            return Err(MemoryError::InvalidInput {
+                field: "max_results".to_string(),
+                reason: format!("max_results exceeds {}", MAX_TRAVERSAL_RESULTS),
             });
         }
         Ok(())
@@ -180,5 +199,27 @@ mod tests {
             ..RetrievalConfig::default()
         };
         assert!(ChaoticSemanticFramework::validate_retrieval_config(&config).is_err());
+    }
+
+    #[test]
+    fn test_validate_traversal_config() {
+        let config = TraversalConfig {
+            max_depth: 32,
+            max_results: 10_000,
+            ..Default::default()
+        };
+        assert!(ChaoticSemanticFramework::validate_traversal_config(&config).is_ok());
+
+        let config = TraversalConfig {
+            max_depth: 33,
+            ..Default::default()
+        };
+        assert!(ChaoticSemanticFramework::validate_traversal_config(&config).is_err());
+
+        let config = TraversalConfig {
+            max_results: 10_001,
+            ..Default::default()
+        };
+        assert!(ChaoticSemanticFramework::validate_traversal_config(&config).is_err());
     }
 }

--- a/src/graph_traversal.rs
+++ b/src/graph_traversal.rs
@@ -67,6 +67,7 @@ impl Singularity {
     /// Returns nodes reachable within `config.max_depth` hops, along with their depths.
     /// Nodes are returned in BFS order.
     pub fn bfs(&self, start: &str, config: &TraversalConfig) -> Result<Vec<(String, u32)>> {
+        crate::framework::ChaoticSemanticFramework::validate_traversal_config(config)?;
         if !self.concepts.contains_key(start) {
             return Err(MemoryError::NotFound {
                 entity: "Concept".to_string(),
@@ -117,6 +118,7 @@ impl Singularity {
         to: &str,
         config: &TraversalConfig,
     ) -> Result<Option<Vec<String>>> {
+        crate::framework::ChaoticSemanticFramework::validate_traversal_config(config)?;
         if !self.concepts.contains_key(from) {
             return Err(MemoryError::NotFound {
                 entity: "Concept".to_string(),
@@ -204,6 +206,7 @@ impl Singularity {
         to: &str,
         config: &TraversalConfig,
     ) -> Result<Option<Vec<String>>> {
+        crate::framework::ChaoticSemanticFramework::validate_traversal_config(config)?;
         if !self.concepts.contains_key(from) {
             return Err(MemoryError::NotFound {
                 entity: "Concept".to_string(),


### PR DESCRIPTION
**Severity:** MEDIUM
**Finding:** Missing input bounds on graph traversal parameters (`max_depth`, `max_results`).
**Impact:** An attacker could provide a very large depth or result limit to cause excessive CPU/memory consumption, leading to a Denial of Service (DoS).
**Fix:** Added security constants (MAX_TRAVERSAL_DEPTH=32, MAX_TRAVERSAL_RESULTS=10,000) and validation logic to enforce these bounds in all public graph traversal APIs.
**Verification:** All gates pass — verified with new unit tests for boundary conditions and full `scripts/validate.sh` suite.

---
*PR created automatically by Jules for task [13299151873315674638](https://jules.google.com/task/13299151873315674638) started by @d-o-hub*