### PR TITLE
⚡ Optimize N+1 Insert Query in Save Canonical Concepts Loop

### DIFF
--- a/src/bridge_persistence.rs
+++ b/src/bridge_persistence.rs
@@ -158,6 +158,23 @@ impl Persistence {
 
         // Insert all concepts
         let mut first_error: Option<MemoryError> = None;
+        let stmt = match conn
+            .prepare(
+                "INSERT INTO csm_canonical (id, version, labels_json, related_json)
+                 VALUES (?1, ?2, ?3, ?4)",
+            )
+            .await
+        {
+            Ok(s) => s,
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                return Err(MemoryError::database(format!(
+                    "Failed to prepare insert statement: {}",
+                    e
+                )));
+            }
+        };
+
         for concept in graph.all_concepts() {
             let labels_json = match serde_json::to_string(&concept.labels) {
                 Ok(j) => j,
@@ -174,17 +191,13 @@ impl Persistence {
                 }
             };
 
-            if let Err(e) = conn
-                .execute(
-                    "INSERT INTO csm_canonical (id, version, labels_json, related_json)
-                     VALUES (?1, ?2, ?3, ?4)",
-                    params![
-                        concept.id.clone(),
-                        concept.version as i64,
-                        labels_json,
-                        related_json
-                    ],
-                )
+            if let Err(e) = stmt
+                .execute(params![
+                    concept.id.clone(),
+                    concept.version as i64,
+                    labels_json,
+                    related_json
+                ])
                 .await
             {
                 first_error = Some(MemoryError::database(format!(

--- a/src/bridge_persistence.rs
+++ b/src/bridge_persistence.rs
@@ -148,7 +148,7 @@ impl Persistence {
             .map_err(|e| MemoryError::database(format!("Failed to begin transaction: {}", e)))?;
 
         // Clear existing concepts
-        if let Err(e) = conn.execute("DELETE FROM csm_canonical", params![]).await {
+        if let Err(e) = conn.execute("DELETE FROM csm_canonical", ()).await {
             let _ = conn.execute("ROLLBACK", ()).await;
             return Err(MemoryError::database(format!(
                 "Failed to clear canonical concepts: {}",
@@ -156,7 +156,7 @@ impl Persistence {
             )));
         }
 
-        // Insert all concepts
+        // Insert all concepts with prepared statement for efficiency
         let mut first_error: Option<MemoryError> = None;
         let stmt = match conn
             .prepare(
@@ -190,6 +190,9 @@ impl Persistence {
                     break;
                 }
             };
+
+            // Reset statement before each execution for proper parameter binding
+            stmt.reset();
 
             if let Err(e) = stmt
                 .execute(params![


### PR DESCRIPTION
This PR optimizes the `save_concept_graph` function in `src/bridge_persistence.rs` by preparing the SQL `INSERT` statement once before the loop and reusing it for each concept. This significantly reduces the overhead of parsing the same SQL statement multiple times during a bulk save operation.

💡 **What:** Replaced repeated `conn.execute` calls with a single `conn.prepare` call followed by repeated `stmt.execute` calls within the `save_concept_graph` loop.
🎯 **Why:** To eliminate the N+1 SQL parsing overhead that occurs when saving a large number of canonical concepts.
📊 **Measured Improvement:** While environmental constraints prevented running a full benchmark suite, this is a standard SQLite optimization that typically yields significant performance gains for bulk inserts by moving statement compilation outside the hot loop.


---
*PR created automatically by Jules for task [9655569374298571344](https://jules.google.com/task/9655569374298571344) started by @d-o-hub*