### PR TITLE
🧪 Add unit tests for code-aware tokenizer in encoder.rs

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -327,3 +327,92 @@ impl TextEncoder {
         HVec10240::bundle(&ngram_vectors).unwrap_or_else(|_| HVec10240::zero())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_on_separators_basic() {
+        assert_eq!(
+            TextEncoder::split_on_separators("my_func"),
+            vec!["my", "func"]
+        );
+        assert_eq!(
+            TextEncoder::split_on_separators("my-func"),
+            vec!["my", "func"]
+        );
+        assert_eq!(
+            TextEncoder::split_on_separators("my.func"),
+            vec!["my", "func"]
+        );
+        assert_eq!(
+            TextEncoder::split_on_separators("my/func"),
+            vec!["my", "func"]
+        );
+        assert_eq!(
+            TextEncoder::split_on_separators("my::func"),
+            vec!["my", "func"]
+        );
+    }
+
+    #[test]
+    fn test_split_on_separators_consecutive() {
+        assert_eq!(
+            TextEncoder::split_on_separators("my__func"),
+            vec!["my", "func"]
+        );
+        assert_eq!(
+            TextEncoder::split_on_separators("my--func"),
+            vec!["my", "func"]
+        );
+        assert_eq!(
+            TextEncoder::split_on_separators("my..func"),
+            vec!["my", "func"]
+        );
+        assert_eq!(
+            TextEncoder::split_on_separators("my//func"),
+            vec!["my", "func"]
+        );
+        assert_eq!(
+            TextEncoder::split_on_separators("my::::func"),
+            vec!["my", "func"]
+        );
+        assert_eq!(
+            TextEncoder::split_on_separators("my._-func"),
+            vec!["my", "func"]
+        );
+    }
+
+    #[test]
+    fn test_split_on_separators_edge_cases() {
+        assert_eq!(TextEncoder::split_on_separators(""), Vec::<String>::new());
+        assert_eq!(TextEncoder::split_on_separators("_"), Vec::<String>::new());
+        assert_eq!(TextEncoder::split_on_separators("__"), Vec::<String>::new());
+        assert_eq!(TextEncoder::split_on_separators("::"), Vec::<String>::new());
+        assert_eq!(
+            TextEncoder::split_on_separators(":::"),
+            Vec::<String>::new()
+        );
+        assert_eq!(TextEncoder::split_on_separators("word_"), vec!["word"]);
+        assert_eq!(TextEncoder::split_on_separators("_word"), vec!["word"]);
+        assert_eq!(TextEncoder::split_on_separators(":word"), vec![":word"]);
+        assert_eq!(TextEncoder::split_on_separators("word:"), vec!["word:"]);
+    }
+
+    #[test]
+    fn test_tokenize_code_interaction() {
+        assert_eq!(
+            TextEncoder::tokenize_code("hello_world std::vector"),
+            vec!["hello", "world", "std", "vector"]
+        );
+        assert_eq!(
+            TextEncoder::tokenize_code("  leading whitespace  "),
+            vec!["leading", "whitespace"]
+        );
+        assert_eq!(
+            TextEncoder::tokenize_code("path/to/file.rs"),
+            vec!["path", "to", "file", "rs"]
+        );
+    }
+}

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -392,7 +392,7 @@ mod tests {
         assert_eq!(TextEncoder::split_on_separators("::"), Vec::<String>::new());
         assert_eq!(
             TextEncoder::split_on_separators(":::"),
-            Vec::<String>::new()
+            vec![":"] // :: splits, remaining : is part of the word
         );
         assert_eq!(TextEncoder::split_on_separators("word_"), vec!["word"]);
         assert_eq!(TextEncoder::split_on_separators("_word"), vec!["word"]);


### PR DESCRIPTION
This PR adds unit tests for the code-aware tokenizer in `src/encoder.rs`. The tokenizer is responsible for splitting text into tokens while respecting code-specific separators like `::`, `_`, `-`, `.`, and `/`. 

### 🎯 What:
Added a `mod tests` block to `src/encoder.rs` containing targeted unit tests for the private methods `tokenize_code` and `split_on_separators`.

### 📊 Coverage:
The new tests cover:
- Standard code separators: `my_func`, `std::vector`, `file.rs`, etc.
- Consecutive separators: `my__func`, `my::::func`.
- Boundary conditions: Leading and trailing separators.
- Whitespace interaction: Mixed whitespace and code separators.
- Edge cases: Empty strings, strings with only separators, and preserving single colons (not a separator).

### ✨ Result:
Improved reliability and verification of the core tokenization logic used for encoding code-related text into hypervectors. The module remains well within the 500 LOC limit (current: 418 lines).

---
*PR created automatically by Jules for task [15625984224056970976](https://jules.google.com/task/15625984224056970976) started by @d-o-hub*