### PR TITLE
Add Distribution Channel Selection Skill

### DIFF
--- a/.agents/skills/dist-channel-selection/SKILL.md
+++ b/.agents/skills/dist-channel-selection/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: dist-channel-selection
+description: Artifact-aware decision logic for selecting the correct distribution channel (cargo crate vs WASM npm vs CLI npm). Use when validating, installing, or publishing.
+---
+
+# Distribution Channel Selection
+
+This repository publishes three distinct artifacts. They are NOT interchangeable. Before performing any install, publish, or verification task, you MUST identify which artifact is the target.
+
+## Artifact Decision Matrix
+
+| Artifact | Distribution Channel | Package/Crate Name | Primary Use Case |
+|----------|----------------------|--------------------|------------------|
+| **Rust Library** | crates.io / cargo | `chaotic_semantic_memory` | Native Rust development, performance-critical backends, crate validation. |
+| **JS/WASM Library** | npm (WASM) | `@d-o-hub/chaotic_semantic_memory` | Web browsers, Node.js applications, TypeScript consumption. |
+| **CLI Tool** | npm (CLI) | `@d-o-hub/csm` | End-user CLI installation, binary distribution via npm. |
+
+---
+
+## 1. Rust Crate Path (Source of Truth)
+
+Use this path for repo-native developer workflows and core library validation.
+
+### Canonical Commands
+- **Check:** `cargo check`
+- **Test:** `cargo test --all-features`
+- **Build CLI (Local):** `cargo install --path . --features cli`
+- **Publish Dry-run:** `cargo publish --dry-run`
+
+### Decision Logic
+Choose this path if:
+- You are modifying `.rs` files in `src/`.
+- You are adding a new feature to the core engine.
+- You are fixing a bug in the HVec or Reservoir logic.
+
+---
+
+## 2. WASM npm Path
+
+Use this path for browser/JS/TypeScript consumption and registry verification of the WASM bindings.
+
+### Canonical Commands
+- **Check Version:** `npm view @d-o-hub/chaotic_semantic_memory version`
+- **Install Test:** `npm install @d-o-hub/chaotic_semantic_memory`
+- **Build (Local):** `wasm-pack build --target web --out-dir wasm/pkg -- --features wasm`
+- **Validation:** Verify `wasm/package.json` alignment.
+
+### Decision Logic
+Choose this path if:
+- You are testing the JS API surface.
+- You are investigating an issue with the WASM build.
+- The task explicitly mentions "npm package for WASM" or "JS library".
+
+---
+
+## 3. CLI npm Path
+
+Use this path for end-user CLI installation experience and binary distribution validation.
+
+### Canonical Commands
+- **Check Version:** `npm view @d-o-hub/csm version`
+- **Install Test:** `npm install -g @d-o-hub/csm`
+- **Check Binary:** `csm --version` / `csm --help`
+- **Validation:** Verify `cli-npm/package.json` and postinstall behavior.
+
+### Decision Logic
+Choose this path if:
+- You are testing how users install the `csm` tool globally via npm.
+- You are validating the `postinstall.js` binary fetcher.
+- The task explicitly mentions "CLI npm package" or binary distribution.
+
+---
+
+## Examples
+
+### Rust Developer Flow
+"I just added a new similarity metric to `src/hyperdim.rs`. How do I verify it?"
+- **Artifact:** Rust Library
+- **Channel:** cargo
+- **Action:** `cargo test`
+
+### JS/WASM Consumer Flow
+"A web developer is reporting that `Similarity` enum is missing in the npm package."
+- **Artifact:** JS/WASM Library
+- **Channel:** `@d-o-hub/chaotic_semantic_memory`
+- **Action:** `npm view @d-o-hub/chaotic_semantic_memory` and check `wasm/package.json`.
+
+### CLI User Flow
+"How do I install the latest CSM tool on my machine without compiling from source?"
+- **Artifact:** CLI Tool
+- **Channel:** `@d-o-hub/csm`
+- **Action:** `npm install -g @d-o-hub/csm`
+
+---
+
+## Anti-Patterns (DO NOT DO)
+- ❌ Using `@d-o-hub/csm` when the task is about the JS/WASM library.
+- ❌ Recommending `npm install` for core Rust validation.
+- ❌ Recommending `cargo install` for a JS consumer install path.
+- ❌ Documenting "the npm package" as if there were only one.

--- a/.agents/skills/release-management/SKILL.md
+++ b/.agents/skills/release-management/SKILL.md
@@ -135,6 +135,14 @@ VERSION=$(grep '^version =' Cargo.toml | head -1 | cut -d'"' -f2)
 grep -q "^\[${VERSION}\]:" CHANGELOG.md || echo "❌ Missing version link"
 ```
 
+## Distribution Channels (CRITICAL)
+
+Before publishing or validating, you MUST use the `dist-channel-selection` skill to identify the correct target. This repository distributes three distinct artifacts:
+
+1. **Rust Library:** `chaotic_semantic_memory` (crates.io)
+2. **JS/WASM Library:** `@d-o-hub/chaotic_semantic_memory` (npm)
+3. **CLI Tool:** `@d-o-hub/csm` (npm)
+
 ## Publishing Targets
 
 | Target | Method | Trigger |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,69 @@ Before completing any task, verify:
 ## Hard Constraints
 See: [agents-docs/hard-constraints.md](agents-docs/hard-constraints.md)
 
+---
+
+## Release Safety Requirements
+
+**CRITICAL: Never release with failing CI. The release workflow now has a guardrail that waits for CI to pass.**
+
+### Artifact Selection (REQUIRED)
+
+Before validating, installing, or publishing, identify the correct channel:
+- **Rust Library:** `chaotic_semantic_memory` (crates.io / cargo)
+- **JS/WASM Library:** `@d-o-hub/chaotic_semantic_memory` (npm WASM)
+- **CLI Tool:** `@d-o-hub/csm` (npm CLI)
+
+Refer to the `dist-channel-selection` skill for canonical commands.
+
+### Pre-Release Checklist (MANDATORY)
+
+1. **Verify CI passes on all platforms**:
+   ```bash
+   gh run list --workflow=ci.yml --limit 3
+   gh run view --log  # Check all jobs: macos-arm64, windows-x64, linux
+   ```
+
+2. **Ensure Cargo.lock is synchronized**:
+   ```bash
+   cargo build --release  # Regenerates Cargo.lock after version bump
+   git add Cargo.lock     # Must be committed with version changes
+   ```
+
+3. **Check existing releases**:
+   ```bash
+   gh release list --limit 5
+   gh release view --json tagName,isLatest
+   ```
+
+4. **Validate changelog entry exists**:
+   ```bash
+   grep -q "^## \[${VERSION}\]" CHANGELOG.md
+   ```
+
+### Version Bump Workflow
+
+1. Update `Cargo.toml` version
+2. Update `wasm/package.json` version
+3. Update `CHANGELOG.md` with new section
+4. Run `cargo build --release` to sync Cargo.lock
+5. Commit all version files together (atomic)
+6. Push and wait for CI to pass
+7. Only then create tag/release
+
+### Platform-Specific Considerations
+
+- **macOS arm64**: NEON SIMD intrinsics require explicit unsafe blocks
+- **Windows x64**: CI uses `--locked` flag, Cargo.lock must match Cargo.toml
+- **WASM**: Size gate checks library (~870KB), not CLI binary (~5KB)
+
+### Reference Files
+
+- `.github/workflows/release.yml` — Has `wait-for-ci` guardrail job
+- `.agents/skills/release-management/` — Full release skill
+- `scripts/validate.sh` — Pre-commit validation gates
+
+---
 ## Key Files
 **Core**: `src/singularity.rs`, `src/reservoir.rs`, `src/reservoir_inertial.rs`, `src/framework.rs`, `src/persistence.rs`
 **Bridge**: `src/semantic_bridge.rs`, `src/bridge_retrieval.rs`
@@ -161,8 +224,8 @@ See: [agents-docs/hard-constraints.md](agents-docs/hard-constraints.md)
 **CLI**: `src/cli/commands/query.rs`, `src/cli/commands/index_dir.rs`
 **State**: `plans/GOAP_STATE.md`, `plans/ACTIONS.md`
 
-## Skills (19 Total)
-**Core**: `rust-development`, `testing-validation`, `goap-planning`, `adr-creation`, `github-ci-guardrails`, `git-workflow`, `release-management`, `benchmarking-perf`, `debugging-reservoir`, `skill-memory-internal`, `memory-lifecycle-verification`, `turso-memory-verification`, `drawio`
+## Skills (20 Total)
+**Core**: `rust-development`, `testing-validation`, `goap-planning`, `adr-creation`, `github-ci-guardrails`, `git-workflow`, `release-management`, `dist-channel-selection`, `benchmarking-perf`, `debugging-reservoir`, `skill-memory-internal`, `memory-lifecycle-verification`, `turso-memory-verification`, `drawio`
 
 **Swarm**: `swarm-testing-quality`, `swarm-performance`, `swarm-observability`, `swarm-advanced-features`, `analysis-swarm`
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ For library-only consumers who don't need the CLI binary or its dependencies:
 chaotic_semantic_memory = { version = "0.3", default-features = false }
 ```
 
+### WASM npm Package (for JS/TS)
+
+```bash
+npm install @d-o-hub/chaotic_semantic_memory
+```
+
 ### CLI Binary
 
 **via npm (recommended for Node.js users):**


### PR DESCRIPTION
Introduces a new agent skill for selecting the correct distribution channel (cargo vs WASM npm vs CLI npm). Updates AGENTS.md, README.md, and release-management skill to ensure explicit artifact-aware decision logic across the repository.

Fixes #110

---
*PR created automatically by Jules for task [4025200448372263113](https://jules.google.com/task/4025200448372263113) started by @d-o-hub*