### PR TITLE
🧪 Add unit tests for code-aware tokenization

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -327,3 +327,69 @@ impl TextEncoder {
         HVec10240::bundle(&ngram_vectors).unwrap_or_else(|_| HVec10240::zero())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tokenize_code_basic() {
+        let tokens = TextEncoder::tokenize_code("hello world");
+        assert_eq!(tokens, vec!["hello", "world"]);
+    }
+
+    #[test]
+    fn test_tokenize_code_with_multiple_spaces() {
+        let tokens = TextEncoder::tokenize_code("  hello \t world \n ");
+        assert_eq!(tokens, vec!["hello", "world"]);
+    }
+
+    #[test]
+    fn test_split_on_separators_single_chars() {
+        let tokens = TextEncoder::split_on_separators("a_b-c.d/e");
+        assert_eq!(tokens, vec!["a", "b", "c", "d", "e"]);
+    }
+
+    #[test]
+    fn test_split_on_separators_double_colon() {
+        let tokens = TextEncoder::split_on_separators("std::collections::HashMap");
+        assert_eq!(tokens, vec!["std", "collections", "HashMap"]);
+    }
+
+    #[test]
+    fn test_split_on_separators_consecutive() {
+        // Consecutive separators should just be skipped (no empty tokens produced)
+        let tokens = TextEncoder::split_on_separators("a__b--c..d//e::::f");
+        assert_eq!(tokens, vec!["a", "b", "c", "d", "e", "f"]);
+    }
+
+    #[test]
+    fn test_split_on_separators_leading_trailing() {
+        let tokens = TextEncoder::split_on_separators("_hello_");
+        assert_eq!(tokens, vec!["hello"]);
+    }
+
+    #[test]
+    fn test_tokenize_code_mixed() {
+        let tokens = TextEncoder::tokenize_code("  foo::bar_baz-qux.abc/def  ");
+        assert_eq!(tokens, vec!["foo", "bar", "baz", "qux", "abc", "def"]);
+    }
+
+    #[test]
+    fn test_split_on_separators_empty() {
+        let tokens = TextEncoder::split_on_separators("");
+        assert!(tokens.is_empty());
+    }
+
+    #[test]
+    fn test_split_on_separators_only_separators() {
+        let tokens = TextEncoder::split_on_separators("_.-/::");
+        assert!(tokens.is_empty());
+    }
+
+    #[test]
+    fn test_split_on_separators_colon_not_double() {
+        let tokens = TextEncoder::split_on_separators("single:colon");
+        assert_eq!(tokens, vec!["single:colon"]);
+    }
+}


### PR DESCRIPTION
🎯 **What:**
The internal code-aware tokenization methods in `src/encoder.rs` (`tokenize_code` and `split_on_separators`) were previously only tested indirectly via `TextEncoder::tokenize`. This PR adds targeted unit tests directly within `src/encoder.rs`.

📊 **Coverage:**
New tests cover:
- Basic and mixed text tokenization.
- Handling of single-character code separators (`_`, `-`, `.`, `/`).
- Handling of double colons (`::`).
- Robustness against consecutive separators.
- Robustness against leading/trailing separators.
- Robustness against empty/separator-only inputs.

✨ **Result:**
The `TextEncoder` now features robust direct unit tests for its core tokenization helpers, increasing confidence in code-aware feature extraction.

---
*PR created automatically by Jules for task [13668022136729153715](https://jules.google.com/task/13668022136729153715) started by @d-o-hub*