### PR TITLE
release: v0.3.5 — CI fixes (release/pages workflows) + GOAP/changelog sync

### DIFF
--- a/.agents/skills/release-management/references/release-workflow.md
+++ b/.agents/skills/release-management/references/release-workflow.md
@@ -202,7 +202,8 @@ jobs:
 ### npm Trusted Publishing Setup
 
 1. First publish must be manual: `npm publish`
-2. Navigate to `https://www.npmjs.com/package/chaotic_semantic_memory/access`
+2. Navigate to `https://www.npmjs.com/package/@d-o-hub/chaotic_semantic_memory/access`
+   (and `https://www.npmjs.com/package/@d-o-hub/csm/access` for the CLI)
 3. Enable "Trusted Publishing"
 4. Configure GitHub repository
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,22 +44,20 @@ jobs:
         else
           echo "No book directory found, creating placeholder"
           mkdir -p _site
-          cat <<'HTML' > _site/index.html
-          <!DOCTYPE html>
-          <html lang="en">
-            <head>
-              <meta charset="utf-8" />
-              <title>chaotic_semantic_memory Documentation</title>
-              <style>
-                body { font-family: Arial, sans-serif; margin: 2rem; line-height: 1.6; }
-              </style>
-            </head>
-            <body>
-              <h1>chaotic_semantic_memory Documentation</h1>
-              <p>Documentation will be added soon.</p>
-            </body>
-          </html>
-          HTML
+          printf '%s\n' \
+            '<!DOCTYPE html>' \
+            '<html lang="en">' \
+            '  <head>' \
+            '    <meta charset="utf-8" />' \
+            '    <title>chaotic_semantic_memory Documentation</title>' \
+            '    <style>body { font-family: Arial, sans-serif; margin: 2rem; line-height: 1.6; }</style>' \
+            '  </head>' \
+            '  <body>' \
+            '    <h1>chaotic_semantic_memory Documentation</h1>' \
+            '    <p>Documentation will be added soon.</p>' \
+            '  </body>' \
+            '</html>' \
+            > _site/index.html
         fi
 
     - name: Generate API documentation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ concurrency:
 permissions:
   contents: write
   id-token: write
+  actions: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -35,10 +36,13 @@ jobs:
 
         while [ $ELAPSED -lt $MAX_WAIT ]; do
           # Get the CI workflow run for this commit
-          CI_RUN=$(gh run list --workflow=ci.yml --commit ${{ github.sha }} --limit 1 --json conclusion,status --jq '.[0]' 2>/dev/null || echo '{"status":"queued"}')
+          CI_RUN=$(gh run list --workflow=ci.yml --commit ${{ github.sha }} --limit 1 --json conclusion,status --jq '.[0]' || echo '')
+          if [ -z "$CI_RUN" ] || [ "$CI_RUN" = "null" ]; then
+            CI_RUN='{"status":"queued","conclusion":null}'
+          fi
 
-          CI_STATUS=$(echo "$CI_RUN" | jq -r '.status')
-          CI_CONCLUSION=$(echo "$CI_RUN" | jq -r '.conclusion')
+          CI_STATUS=$(echo "$CI_RUN" | jq -r '.status // "queued"')
+          CI_CONCLUSION=$(echo "$CI_RUN" | jq -r '.conclusion // "null"')
 
           echo "CI status: $CI_STATUS, conclusion: $CI_CONCLUSION"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ concurrency:
 permissions:
   contents: write
   id-token: write
-  actions: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -23,6 +22,9 @@ jobs:
   # Guardrail: Wait for CI workflow to complete successfully before releasing
   wait-for-ci:
     runs-on: ubuntu-24.04
+    permissions:
+      actions: read    # required by `gh run list` to query CI workflow status
+      contents: read
     outputs:
       ci-passed: ${{ steps.check-ci.outputs.passed }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.5] - 2026-04-28
 
 ### Fixed
 - **Reservoir**: Prevent panic on unsanitized `chaos_strength` and enforce bounds (#126).
-- **CI**: `release.yml` `wait-for-ci` guardrail now grants `actions: read`, surfaces
-  `gh run list` errors, and tolerates empty/null responses (no more 600s timeouts).
-- **CI**: `pages.yml` placeholder heredoc terminator de-indented; resolves
-  `syntax error: unexpected end of file` on `book/**` pushes.
+- **CI (Release workflow)**: `wait-for-ci` guardrail now grants `actions: read`
+  (scoped to the job), surfaces `gh run list` errors, and tolerates empty/null
+  responses. Resolves 600 s timeouts that failed every push to `main` since v0.3.4.
+- **CI (GitHub Pages)**: Placeholder fallback heredoc replaced with a `printf`
+  array; the previous indented heredoc broke both bash and YAML block-scalar
+  parsing on `book/**` pushes.
+- **Docs**: Corrected stale npm package URL in release-management skill
+  (`@d-o-hub/chaotic_semantic_memory`, `@d-o-hub/csm`) per issue #106.
 
 ### Performance
 - **Retrieval**: Optimize parallel task granularity in BM25 search (#127).
+
+### Internal
+- **GOAP state**: Synced 3 stale `queued` actions to `complete`
+  (inertial reservoir tests + benches, selectivity-aware retrieval tests).
+- **CHANGELOG**: Back-filled `[0.3.3] [YANKED]` entry documenting the yanked
+  release (NEON intrinsic build break on macOS arm64).
 
 ## [0.3.3] - 2026-04-24 [YANKED]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Reservoir**: Prevent panic on unsanitized `chaos_strength` and enforce bounds (#126).
+- **CI**: `release.yml` `wait-for-ci` guardrail now grants `actions: read`, surfaces
+  `gh run list` errors, and tolerates empty/null responses (no more 600s timeouts).
+- **CI**: `pages.yml` placeholder heredoc terminator de-indented; resolves
+  `syntax error: unexpected end of file` on `book/**` pushes.
+
+### Performance
+- **Retrieval**: Optimize parallel task granularity in BM25 search (#127).
+
+## [0.3.3] - 2026-04-24 [YANKED]
+
+> **Yanked**: this version was tagged from buggy code that broke the macOS arm64
+> build (`E0432` from non-existent NEON intrinsics `veorq_u128`/`vld1q_u128`/
+> `vst1q_u128`). Use `0.3.4` instead.
+
+### Fixed
+- See `0.3.4` for the corrected NEON intrinsic types.
+
 ## [0.3.4] - 2026-04-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,9 +113,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
 dependencies = [
  "anstyle",
  "bstr",
@@ -237,7 +237,7 @@ version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -277,9 +277,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-padding"
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "chaotic_semantic_memory"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -491,18 +491,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.0"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -596,7 +596,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -617,7 +617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -709,9 +709,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -895,7 +895,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -940,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -1092,12 +1092,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1139,6 +1139,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,9 +1155,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1176,9 +1185,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -1201,7 +1210,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "bincode",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "chrono",
  "crc32fast",
@@ -1259,7 +1268,7 @@ version = "0.9.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b646f94fc1d266e481c38a2d44d6d9d1be3ad04b56b90457acfb310dc450030e"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "fallible-iterator 0.2.0",
  "fallible-streaming-iterator",
  "hashlink",
@@ -1273,10 +1282,10 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15a90128c708356af8f7d767c9ac2946692c9112b4f74f07b99a01a60680e413"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cc",
  "fallible-iterator 0.3.0",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "memchr",
  "phf",
@@ -1500,7 +1509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1633,9 +1642,9 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -1661,7 +1670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -1696,9 +1705,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1707,9 +1716,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -1791,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1815,7 +1824,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1859,7 +1868,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1872,7 +1881,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -2054,7 +2063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -2127,9 +2136,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -2245,7 +2254,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -2260,7 +2269,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2352,9 +2361,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unarray"
@@ -2391,9 +2400,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -2467,9 +2476,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2480,9 +2489,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2490,9 +2499,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2500,9 +2509,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2513,9 +2522,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -2537,7 +2546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -2548,17 +2557,17 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2769,7 +2778,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -2799,8 +2808,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.1",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -2819,7 +2828,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chaotic_semantic_memory"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 rust-version = "1.85"
 description = "AI memory systems with hyperdimensional vectors and chaotic reservoirs"

--- a/cli-npm/package.json
+++ b/cli-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d-o-hub/csm",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "CLI for chaotic semantic memory - AI memory systems with hyperdimensional vectors",
   "bin": {
     "csm": "./index.js"

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8,42 +8,35 @@
 **Homepage:** https://github.com/d-o-hub/chaotic_semantic_memory
 **Keywords:** ai, memory, hypervector, reservoir, wasm
 **Dependencies:**
-- serde_json (1.0.149)
-- clap (4.5.60) [features: derive, env, string]
-- tracing (0.1.41)
 - rand (0.10.1)
-- bincode (1.3.3)
-- base64 (0.22)
-- tracing-subscriber (0.3.19)
-- anyhow (1.0.102)
-- glob (0.3.2)
+- clap_complete (4.5.42)
 - colored (2.2.0)
+- base64 (0.22)
+- glob (0.3.2)
+- tracing (0.1.41)
 - serde (1.0.219) [features: derive]
 - rand_chacha (0.10.0)
-- clap_complete (4.5.42)
+- anyhow (1.0.102)
+- clap (4.5.60) [features: derive, env, string]
+- serde_json (1.0.149)
+- tracing-subscriber (0.3.19)
+- bincode (1.3.3)
 - thiserror (2.0.11)
 **Features:**
-- parallel: [dep:rayon]
-- cli: [dep:clap, dep:clap_complete, dep:anyhow, dep:colored, dep:glob]
-- persistence: [dep:libsql]
-- wasm: []
 - default: [cli, persistence, parallel]
+- cli: [dep:clap, dep:clap_complete, dep:anyhow, dep:colored, dep:glob]
+- wasm: []
+- parallel: [dep:rayon]
+- persistence: [dep:libsql]
 
-Generated: 2026-04-28 05:25:24 UTC
+Generated: 2026-04-28 08:44:41 UTC  
 Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 
 ## Table of Contents
 
-### src/framework_bridge.rs
+### src/reservoir_inertial.rs
 
-- impl ChaoticSemanticFramework
-
-### src/semantic_triples.rs
-
-- pub struct SemanticTriple
-- impl SemanticTriple
-- pub struct StructuredMemoryPayload
-- impl StructuredMemoryPayload
+- impl Reservoir
 
 ### src/reservoir.rs
 
@@ -54,10 +47,14 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub struct ChaoticReservoir
 - impl ChaoticReservoir
 
-### src/concept_builder.rs
+### src/framework_events.rs
 
-- pub struct ConceptBuilder
-- impl ConceptBuilder
+- pub enum MemoryEvent
+- impl ChaoticSemanticFramework
+
+### src/reservoir_sparse.rs
+
+- impl SparseWeights
 
 ### src/hyperdim.rs
 
@@ -69,56 +66,57 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - impl Deserialize for HVec10240
 - pub use crate::bundle::BundleAccumulator
 
-### src/bundle.rs
-
-- pub struct BundleAccumulator
-- impl Default for BundleAccumulator
-- impl BundleAccumulator
-
-### src/metadata_filter.rs
-
-- pub enum MetadataFilter
-- impl MetadataFilter
-- impl ops::Not for MetadataFilter
-
-### src/persistence.rs
-
-- pub struct Persistence
-- pub struct ConceptVersion
-- impl Persistence
-
-### src/reservoir_sparse.rs
-
-- impl SparseWeights
-
-### src/singularity_ttl.rs
-
-- impl Default for Concept
-- impl Singularity
-
-### src/singularity_cache.rs
-
-- impl QueryCache
-- pub struct CacheMetricsSnapshot
-- impl CacheMetrics
-
 ### src/framework_ttl.rs
 
 - impl crate::framework::ChaoticSemanticFramework
 
-### src/framework_builder.rs
+### src/concept_builder.rs
 
-- pub struct FrameworkConfig
-- impl Default for FrameworkConfig
-- pub struct FrameworkStats
-- pub struct FrameworkBuilder
-- impl FrameworkBuilder
+- pub struct ConceptBuilder
+- impl ConceptBuilder
 
-### src/graph_traversal.rs
+### src/persistence_ops.rs
 
-- pub struct TraversalConfig
-- impl Default for TraversalConfig
-- impl Singularity
+- impl Persistence
+
+### src/framework.rs
+
+- pub struct ChaoticSemanticFramework
+- pub struct FrameworkMetrics
+- pub struct FrameworkMetricsSnapshot
+- impl FrameworkMetrics
+- impl ChaoticSemanticFramework
+
+### src/hyperdim_batch.rs
+
+- pub fn batch_cosine_similarity
+
+### src/framework_validation.rs
+
+- impl ChaoticSemanticFramework
+
+### src/semantic_bridge.rs
+
+- pub struct CanonicalConcept
+- impl CanonicalConcept
+- pub struct BridgeConfig
+- impl Default for BridgeConfig
+- pub struct ScoreBreakdown
+- impl ScoreBreakdown
+- pub struct BridgeHit
+- pub struct MemoryPacket
+- impl MemoryPacket
+- pub trait SemanticReranker
+- pub struct ConceptGraph
+- impl ConceptGraph
+
+### src/framework_ops.rs
+
+- impl ChaoticSemanticFramework
+
+### src/bridge_persistence.rs
+
+- impl Persistence
 
 ### src/singularity_retrieval.rs
 
@@ -130,222 +128,10 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - impl Default for RetrievalConfig
 - impl Singularity
 
-### src/cli/commands/index_dir.rs
-
-- pub fn run_index_dir
-- pub struct MarkdownChunk
-- pub fn chunk_by_heading
-
-### src/cli/commands/associate.rs
-
-- pub fn run_associate
-- pub fn run_associate_batch
-
-### src/cli/commands/import.rs
-
-- pub fn run_import
-
-### src/cli/commands/inject.rs
-
-- pub fn run_inject
-
-### src/cli/commands/probe.rs
-
-- pub fn run_probe
-- pub fn run_probe_with_vector
-
-### src/cli/commands/index_jsonl.rs
-
-- pub fn run_index_jsonl
-
-### src/cli/commands/query.rs
-
-- pub fn run_query
-
-### src/cli/commands/export.rs
-
-- pub fn run_export
-
-### src/cli/commands/mod.rs
-
-- pub mod associate
-- pub mod completions
-- pub mod export
-- pub mod import
-- pub mod index_dir
-- pub mod index_jsonl
-- pub mod inject
-- pub mod probe
-- pub mod query
-- pub use associate::run_associate
-- pub use completions::run_completions
-- pub use export::run_export
-- pub use import::run_import
-- pub use index_dir::run_index_dir
-- pub use index_jsonl::run_index_jsonl
-- pub use inject::run_inject
-- pub use probe::run_probe
-- pub use query::run_query
-- pub fn print_success
-- pub fn print_error
-- pub fn print_warning
-- pub fn truncate_preview
-- pub fn create_framework
-
-### src/cli/commands/completions.rs
-
-- pub fn run_completions
-
-### src/cli/git_local.rs
-
-- pub fn resolve_git_local_path
-- pub fn ensure_git_local_dir
-
-### src/cli/error.rs
-
-- pub enum CliError
-- impl From for CliError
-- pub type Result
-- pub enum ExitCode
-- impl From for ExitCode
-- impl From for ExitCode
-- impl CliError
-- impl ExitCode
-
-### src/cli/args.rs
-
-- pub struct CliArgs
-- pub enum OutputFormat
-- pub enum Commands
-- pub struct InjectArgs
-- pub enum VectorSource
-- pub struct ProbeArgs
-- pub struct QueryArgs
-- pub struct AssociateArgs
-- pub enum ExportFormat
-- pub struct ExportArgs
-- pub enum ImportFormat
-- pub struct ImportArgs
-- pub struct VersionArgs
-- pub struct CompletionsArgs
-- pub struct IndexJsonlArgs
-- pub struct IndexDirArgs
-
-### src/cli/mod.rs
-
-- pub mod args
-- pub mod commands
-- pub mod error
-- pub mod git_local
-- pub use args::*
-- pub use commands::{run_associate, run_completions, run_export, run_import, run_index_dir, run_index_jsonl, run_inject, run_probe, run_query}
-- pub use error::{CliError, ExitCode, Result}
-- pub use git_local::{ensure_git_local_dir, resolve_git_local_path}
-
-### src/persistence_migrations.rs
-
-- impl Persistence
-
-### src/framework_validation.rs
-
-- impl ChaoticSemanticFramework
-
-### src/persistence_ops.rs
-
-- impl Persistence
-
-### src/reservoir_inertial.rs
-
-- impl Reservoir
-
-### src/hyperdim_batch.rs
-
-- pub fn batch_cosine_similarity
-
-### src/retrieval/hybrid.rs
-
-- pub fn compute_weights
-- pub fn normalize_scores
-- pub fn merge_results
-- pub enum HybridMode
-- pub struct HybridConfig
-- impl Default for HybridConfig
-
-### src/retrieval/mod.rs
-
-- pub mod bm25
-- pub mod hybrid
-- pub use bm25::{Bm25Config, Bm25Index}
-- pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores}
-
-### src/retrieval/bm25.rs
-
-- pub struct Bm25Config
-- impl Default for Bm25Config
-- pub struct Bm25Index
-- impl Bm25Index
-
-### src/singularity.rs
-
-- pub use crate::singularity_cache::CacheMetricsSnapshot
-- pub use crate::singularity_retrieval::{CandidateSource, RetrievalConfig, RetrievalStats}
-- pub const DEFAULT_MAX_CACHED_TOP_K
-- pub struct Concept
-- pub struct SingularityConfig
-- impl Default for SingularityConfig
-- pub struct Singularity
-- impl Singularity
-- impl Default for Singularity
-- pub use crate::concept_builder::ConceptBuilder
-
-### src/framework.rs
-
-- pub struct ChaoticSemanticFramework
-- pub struct FrameworkMetrics
-- pub struct FrameworkMetricsSnapshot
-- impl FrameworkMetrics
-- impl ChaoticSemanticFramework
-
-### src/persistence_wasm.rs
+### src/persistence.rs
 
 - pub struct Persistence
 - pub struct ConceptVersion
-- impl Persistence
-
-### src/framework_ops.rs
-
-- impl ChaoticSemanticFramework
-
-### src/wasm.rs
-
-- pub fn initialize_wasm
-- pub struct WasmFramework
-- impl WasmFramework
-- pub fn random_hypervector
-- pub fn encode_text
-- pub fn cosine_similarity
-
-### src/error.rs
-
-- pub enum MemoryError
-- impl MemoryError
-- pub type Result
-
-### src/wasm_ext.rs
-
-- impl WasmFramework
-
-### src/export_payload.rs
-
-- impl From for BinaryMetadataValue
-- impl From for serde_json::Value
-- impl From for BinaryConcept
-- impl BinaryConcept
-- impl From for BinaryExportPayload
-- impl BinaryExportPayload
-
-### src/persistence_versions.rs
-
 - impl Persistence
 
 ### src/lib.rs
@@ -397,46 +183,234 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub use prelude::crate::singularity_retrieval::{CandidateSource, FilterStrategy, RetrievalConfig, RetrievalStats}
 - pub mod wasm
 
+### src/metadata_filter.rs
+
+- pub enum MetadataFilter
+- impl MetadataFilter
+- impl ops::Not for MetadataFilter
+
+### src/wasm_ext.rs
+
+- impl WasmFramework
+
+### src/singularity.rs
+
+- pub use crate::singularity_cache::CacheMetricsSnapshot
+- pub use crate::singularity_retrieval::{CandidateSource, RetrievalConfig, RetrievalStats}
+- pub const DEFAULT_MAX_CACHED_TOP_K
+- pub struct Concept
+- pub struct SingularityConfig
+- impl Default for SingularityConfig
+- pub struct Singularity
+- impl Singularity
+- impl Default for Singularity
+- pub use crate::concept_builder::ConceptBuilder
+
+### src/singularity_ttl.rs
+
+- impl Default for Concept
+- impl Singularity
+
 ### src/bridge_retrieval.rs
 
 - pub struct BridgeRetrieval
 - impl BridgeRetrieval
 
-### src/semantic_bridge.rs
+### src/persistence_wasm.rs
 
-- pub struct CanonicalConcept
-- impl CanonicalConcept
-- pub struct BridgeConfig
-- impl Default for BridgeConfig
-- pub struct ScoreBreakdown
-- impl ScoreBreakdown
-- pub struct BridgeHit
-- pub struct MemoryPacket
-- impl MemoryPacket
-- pub trait SemanticReranker
-- pub struct ConceptGraph
-- impl ConceptGraph
+- pub struct Persistence
+- pub struct ConceptVersion
+- impl Persistence
 
-### src/framework_events.rs
+### src/error.rs
 
-- pub enum MemoryEvent
-- impl ChaoticSemanticFramework
+- pub enum MemoryError
+- impl MemoryError
+- pub type Result
 
-### src/bridge_persistence.rs
+### src/persistence_versions.rs
 
 - impl Persistence
 
-### src/encoder.rs
+### src/wasm.rs
 
-- pub struct TextEncoderConfig
-- impl Default for TextEncoderConfig
-- pub struct TextEncoder
-- impl Default for TextEncoder
-- impl TextEncoder
+- pub fn initialize_wasm
+- pub struct WasmFramework
+- impl WasmFramework
+- pub fn random_hypervector
+- pub fn encode_text
+- pub fn cosine_similarity
 
 ### src/singularity_ext.rs
 
 - impl Singularity
+
+### src/semantic_triples.rs
+
+- pub struct SemanticTriple
+- impl SemanticTriple
+- pub struct StructuredMemoryPayload
+- impl StructuredMemoryPayload
+
+### src/retrieval/mod.rs
+
+- pub mod bm25
+- pub mod hybrid
+- pub use bm25::{Bm25Config, Bm25Index}
+- pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores}
+
+### src/retrieval/hybrid.rs
+
+- pub fn compute_weights
+- pub fn normalize_scores
+- pub fn merge_results
+- pub enum HybridMode
+- pub struct HybridConfig
+- impl Default for HybridConfig
+
+### src/retrieval/bm25.rs
+
+- pub struct Bm25Config
+- impl Default for Bm25Config
+- pub struct Bm25Index
+- impl Bm25Index
+
+### src/persistence_migrations.rs
+
+- impl Persistence
+
+### src/export_payload.rs
+
+- impl From for BinaryMetadataValue
+- impl From for serde_json::Value
+- impl From for BinaryConcept
+- impl BinaryConcept
+- impl From for BinaryExportPayload
+- impl BinaryExportPayload
+
+### src/framework_builder.rs
+
+- pub struct FrameworkConfig
+- impl Default for FrameworkConfig
+- pub struct FrameworkStats
+- pub struct FrameworkBuilder
+- impl FrameworkBuilder
+
+### src/cli/git_local.rs
+
+- pub fn resolve_git_local_path
+- pub fn ensure_git_local_dir
+
+### src/cli/args.rs
+
+- pub struct CliArgs
+- pub enum OutputFormat
+- pub enum Commands
+- pub struct InjectArgs
+- pub enum VectorSource
+- pub struct ProbeArgs
+- pub struct QueryArgs
+- pub struct AssociateArgs
+- pub enum ExportFormat
+- pub struct ExportArgs
+- pub enum ImportFormat
+- pub struct ImportArgs
+- pub struct VersionArgs
+- pub struct CompletionsArgs
+- pub struct IndexJsonlArgs
+- pub struct IndexDirArgs
+
+### src/cli/error.rs
+
+- pub enum CliError
+- impl From for CliError
+- pub type Result
+- pub enum ExitCode
+- impl From for ExitCode
+- impl From for ExitCode
+- impl CliError
+- impl ExitCode
+
+### src/cli/commands/query.rs
+
+- pub fn run_query
+
+### src/cli/commands/associate.rs
+
+- pub fn run_associate
+- pub fn run_associate_batch
+
+### src/cli/commands/export.rs
+
+- pub fn run_export
+
+### src/cli/commands/probe.rs
+
+- pub fn run_probe
+- pub fn run_probe_with_vector
+
+### src/cli/commands/import.rs
+
+- pub fn run_import
+
+### src/cli/commands/completions.rs
+
+- pub fn run_completions
+
+### src/cli/commands/inject.rs
+
+- pub fn run_inject
+
+### src/cli/commands/mod.rs
+
+- pub mod associate
+- pub mod completions
+- pub mod export
+- pub mod import
+- pub mod index_dir
+- pub mod index_jsonl
+- pub mod inject
+- pub mod probe
+- pub mod query
+- pub use associate::run_associate
+- pub use completions::run_completions
+- pub use export::run_export
+- pub use import::run_import
+- pub use index_dir::run_index_dir
+- pub use index_jsonl::run_index_jsonl
+- pub use inject::run_inject
+- pub use probe::run_probe
+- pub use query::run_query
+- pub fn print_success
+- pub fn print_error
+- pub fn print_warning
+- pub fn truncate_preview
+- pub fn create_framework
+
+### src/cli/commands/index_jsonl.rs
+
+- pub fn run_index_jsonl
+
+### src/cli/commands/index_dir.rs
+
+- pub fn run_index_dir
+- pub struct MarkdownChunk
+- pub fn chunk_by_heading
+
+### src/cli/mod.rs
+
+- pub mod args
+- pub mod commands
+- pub mod error
+- pub mod git_local
+- pub use args::*
+- pub use commands::{run_associate, run_completions, run_export, run_import, run_index_dir, run_index_jsonl, run_inject, run_probe, run_query}
+- pub use error::{CliError, ExitCode, Result}
+- pub use git_local::{ensure_git_local_dir, resolve_git_local_path}
+
+### src/framework_bridge.rs
+
+- impl ChaoticSemanticFramework
 
 ### src/bin/csm.rs
 
@@ -450,6 +424,32 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub fn native::handle_completions
 - pub fn native::resolve_database_path
 - pub fn native::run_async
+
+### src/graph_traversal.rs
+
+- pub struct TraversalConfig
+- impl Default for TraversalConfig
+- impl Singularity
+
+### src/singularity_cache.rs
+
+- impl QueryCache
+- pub struct CacheMetricsSnapshot
+- impl CacheMetrics
+
+### src/encoder.rs
+
+- pub struct TextEncoderConfig
+- impl Default for TextEncoderConfig
+- pub struct TextEncoder
+- impl Default for TextEncoder
+- impl TextEncoder
+
+### src/bundle.rs
+
+- pub struct BundleAccumulator
+- impl Default for BundleAccumulator
+- impl BundleAccumulator
 
 ---
 
@@ -935,64 +935,14 @@ Contributions are welcome! Please read our [Contributing Guide](CONTRIBUTING.md)
 
 ---
 
-## src/framework_bridge.rs
+## src/reservoir_inertial.rs
 
-### impl ChaoticSemanticFramework
-
-```rust
-impl ChaoticSemanticFramework {
-    pub fn probe_bridge_text(&self, query: &str, top_k: usize, bridge: &BridgeRetrieval) -> Result<Vec<BridgeHit>>;
-    pub fn probe_bridge_text_with_reranker(&self, query: &str, top_k: usize, bridge: &BridgeRetrieval, reranker: &dyn Trait) -> Result<Vec<BridgeHit>>;
-    pub fn probe_bridge_text_filtered(&self, query: &str, top_k: usize, bridge: &BridgeRetrieval, filter: &MetadataFilter) -> Result<Vec<BridgeHit>>;
-    pub fn memory_packet_text(&self, query: &str, top_k: usize, bridge: &BridgeRetrieval) -> Result<MemoryPacket>;
-    pub fn memory_packet_text_with_reranker(&self, query: &str, top_k: usize, bridge: &BridgeRetrieval, reranker: &dyn Trait) -> Result<MemoryPacket>;
-}
-```
-
-
-
-## src/semantic_triples.rs
-
-### SemanticTriple
+### impl Reservoir
 
 ```rust
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub struct SemanticTriple {
-    pub subject: String,
-    pub predicate: String,
-    pub object: String,
-}
-```
-
-A semantic triple representing a discrete fact.
-
-### impl SemanticTriple
-
-```rust
-impl SemanticTriple {
-    pub fn new(subject: impl Trait, predicate: impl Trait, object: impl Trait) -> Self;
-    pub fn to_sentence(&self) -> String;
-}
-```
-
-
-### StructuredMemoryPayload
-
-```rust
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StructuredMemoryPayload {
-    pub raw_summary: String,
-    pub triples: Vec<SemanticTriple>,
-}
-```
-
-A structured memory payload that can be stored in a `Concept`'s metadata.
-
-### impl StructuredMemoryPayload
-
-```rust
-impl StructuredMemoryPayload {
-    pub fn to_context_string(&self) -> String;
+impl Reservoir {
+    pub fn with_beta(self, beta: f32) -> Result<Self>;
+    pub fn beta(&self) -> f32;
 }
 ```
 
@@ -1077,41 +1027,41 @@ impl ChaoticReservoir {
 
 
 
-## src/concept_builder.rs
+## src/framework_events.rs
 
-### ConceptBuilder
+### MemoryEvent
 
 ```rust
-#[derive(Debug)]
-pub struct ConceptBuilder {
+#[derive(Debug, Clone)]
+pub enum MemoryEvent {
+    ConceptInjected { id: String, timestamp: u64 },
+    ConceptUpdated { id: String, timestamp: u64 },
+    ConceptDeleted { id: String, timestamp: u64 },
+    Associated { from: String, to: String, strength: f32 },
+    Disassociated { from: String, to: String },
 }
 ```
 
-Builder for constructing [`Concept`] instances with a fluent API.
 
-#### Example
-
-```
-use chaotic_semantic_memory::singularity::ConceptBuilder;
-use chaotic_semantic_memory::HVec10240;
-
-let concept = ConceptBuilder::new("example")
-.with_vector(HVec10240::random())
-.with_metadata("source", "test")
-.build()
-.unwrap();
-```
-
-### impl ConceptBuilder
+### impl ChaoticSemanticFramework
 
 ```rust
-impl ConceptBuilder {
-    pub fn new(id: impl Trait) -> Self;
-    pub fn with_canonical_concepts(self, ids: Vec<String>) -> Self;
-    pub fn with_ttl(self, ttl_seconds: u64) -> Self;
-    pub fn with_vector(self, vector: HVec10240) -> Self;
-    pub fn with_metadata(self, key: impl Trait, value: impl Trait) -> Self;
-    pub fn build(self) -> Result<Concept>;
+impl ChaoticSemanticFramework {
+    pub fn subscribe(&self) -> broadcast::Receiver<MemoryEvent>;
+    pub fn update_concept_vector(&self, id: &str, vector: HVec10240) -> Result<()>;
+    pub fn update_concept_metadata(&self, id: &str, metadata: HashMap<String, serde_json::Value>) -> Result<()>;
+    pub fn disassociate(&self, from: &str, to: &str) -> Result<()>;
+}
+```
+
+
+
+## src/reservoir_sparse.rs
+
+### impl SparseWeights
+
+```rust
+impl SparseWeights {
 }
 ```
 
@@ -1189,199 +1139,6 @@ pub use crate::bundle::BundleAccumulator;
 
 
 
-## src/bundle.rs
-
-### BundleAccumulator
-
-```rust
-#[derive(Debug, Clone)]
-pub struct BundleAccumulator {
-}
-```
-
-Incremental bundle accumulator for streaming/sliding-window memory.
-
-Maintains signed bit counts for efficient add/remove operations.
-Finalize applies majority threshold to produce a bundled hypervector.
-
-### impl Default for BundleAccumulator
-
-```rust
-impl Default for BundleAccumulator {
-}
-```
-
-
-### impl BundleAccumulator
-
-```rust
-impl BundleAccumulator {
-    pub fn new() -> Self;
-    pub fn add(&mut self, hv: &HVec10240);
-    pub fn remove(&mut self, hv: &HVec10240);
-    pub fn try_remove(&mut self, hv: &HVec10240) -> Result<()>;
-    pub fn finalize(&self) -> HVec10240;
-    pub fn len(&self) -> u32;
-    pub fn is_empty(&self) -> bool;
-    pub fn clear(&mut self);
-}
-```
-
-
-
-## src/metadata_filter.rs
-
-### MetadataFilter
-
-```rust
-#[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize)]
-pub enum MetadataFilter {
-    Eq(String, Value),
-    In(String, Vec<Value>),
-    Exists(String),
-    And(Vec<MetadataFilter>),
-    Or(Vec<MetadataFilter>),
-    Not(Box<MetadataFilter>),
-}
-```
-
-A predicate for filtering concepts by metadata during similarity search.
-
-### impl MetadataFilter
-
-```rust
-impl MetadataFilter {
-    pub fn eq(key: impl Trait, value: impl Trait) -> Self;
-    pub fn in_(key: impl Trait, values: Vec<Value>) -> Self;
-    pub fn exists(key: impl Trait) -> Self;
-    pub fn and(filters: Vec<MetadataFilter>) -> Self;
-    pub fn or(filters: Vec<MetadataFilter>) -> Self;
-    pub fn matches(&self, metadata: &HashMap<String, Value>) -> bool;
-}
-```
-
-
-### impl ops::Not for MetadataFilter
-
-```rust
-impl ops::Not for MetadataFilter {
-}
-```
-
-
-
-## src/persistence.rs
-
-### Persistence
-
-```rust
-#[derive(Debug)]
-pub struct Persistence {
-}
-```
-
-
-### ConceptVersion
-
-```rust
-#[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize)]
-pub struct ConceptVersion {
-    pub concept_id: String,
-    pub version: i64,
-    pub vector: HVec10240,
-    pub metadata: serde_json::Value,
-    pub modified_at: u64,
-}
-```
-
-
-### impl Persistence
-
-```rust
-impl Persistence {
-    pub fn new_local(path: &str) -> Result<Self>;
-    pub fn new_local_with_retention(path: &str, version_retention: usize) -> Result<Self>;
-    pub fn new_turso(url: &str, token: &str) -> Result<Self>;
-    pub fn new_turso_with_pool(url: &str, token: &str, pool_size: usize) -> Result<Self>;
-    pub fn new_turso_with_pool_and_retention(url: &str, token: &str, pool_size: usize, version_retention: usize) -> Result<Self>;
-    pub fn save_concept(&self, concept: &Concept) -> Result<()>;
-    pub fn save_concepts(&self, concepts: &[Concept]) -> Result<()>;
-    pub fn load_concept(&self, id: &str) -> Result<Option<Concept>>;
-    pub fn load_all_concepts(&self) -> Result<Vec<Concept>>;
-    pub fn delete_concept(&self, id: &str) -> Result<()>;
-    pub fn save_association(&self, from: &str, to: &str, strength: f32) -> Result<()>;
-    pub fn load_associations(&self, id: &str) -> Result<Vec<(String, f32)>>;
-    pub fn checkpoint(&self) -> Result<()>;
-    pub fn size(&self) -> Result<u64>;
-}
-```
-
-
-
-## src/reservoir_sparse.rs
-
-### impl SparseWeights
-
-```rust
-impl SparseWeights {
-}
-```
-
-
-
-## src/singularity_ttl.rs
-
-### impl Default for Concept
-
-```rust
-impl Default for Concept {
-}
-```
-
-
-### impl Singularity
-
-```rust
-impl Singularity {
-    pub fn purge_expired(&mut self) -> usize;
-    pub fn is_expired(&self, id: &str) -> bool;
-    pub fn active_concept_ids(&self) -> Vec<String>;
-}
-```
-
-
-
-## src/singularity_cache.rs
-
-### impl QueryCache
-
-```rust
-impl QueryCache {
-}
-```
-
-
-### CacheMetricsSnapshot
-
-```rust
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct CacheMetricsSnapshot {
-    pub cache_hits_total: u64,
-    pub cache_misses_total: u64,
-    pub cache_evictions_total: u64,
-}
-```
-
-
-### impl CacheMetrics
-
-```rust
-impl CacheMetrics {
-}
-```
-
-
-
 ## src/framework_ttl.rs
 
 ### impl crate::framework::ChaoticSemanticFramework
@@ -1399,121 +1156,365 @@ impl crate::framework::ChaoticSemanticFramework {
 
 
 
-## src/hyperdim_simd.rs
+## src/concept_builder.rs
 
-
-## src/framework_builder.rs
-
-### FrameworkConfig
+### ConceptBuilder
 
 ```rust
-#[derive(Clone, Debug)]
-pub struct FrameworkConfig {
-    pub reservoir_size: usize,
-    pub reservoir_input_size: usize,
-    pub chaos_strength: f32,
-    pub enable_persistence: bool,
-    pub max_concepts: Option<usize>,
-    pub max_associations_per_concept: Option<usize>,
-    pub connection_pool_size: usize,
-    pub max_probe_top_k: usize,
-    pub max_metadata_bytes: Option<usize>,
-    pub max_cached_top_k: usize,
-    pub max_batch_size: usize,
-    pub max_sequence_length: usize,
+#[derive(Debug)]
+pub struct ConceptBuilder {
 }
 ```
 
-Runtime configuration for [`ChaoticSemanticFramework`], tuned via [`FrameworkBuilder`].
+Builder for constructing [`Concept`] instances with a fluent API.
 
-### impl Default for FrameworkConfig
+#### Example
+
+```
+use chaotic_semantic_memory::singularity::ConceptBuilder;
+use chaotic_semantic_memory::HVec10240;
+
+let concept = ConceptBuilder::new("example")
+.with_vector(HVec10240::random())
+.with_metadata("source", "test")
+.build()
+.unwrap();
+```
+
+### impl ConceptBuilder
 
 ```rust
-impl Default for FrameworkConfig {
+impl ConceptBuilder {
+    pub fn new(id: impl Trait) -> Self;
+    pub fn with_canonical_concepts(self, ids: Vec<String>) -> Self;
+    pub fn with_ttl(self, ttl_seconds: u64) -> Self;
+    pub fn with_vector(self, vector: HVec10240) -> Self;
+    pub fn with_metadata(self, key: impl Trait, value: impl Trait) -> Self;
+    pub fn build(self) -> Result<Concept>;
 }
 ```
 
 
-### FrameworkStats
+
+## src/persistence_ops.rs
+
+### impl Persistence
+
+```rust
+impl Persistence {
+    pub fn save_associations(&self, associations: &[(String, String, f32)]) -> Result<()>;
+    pub fn clear_all(&self) -> Result<()>;
+    pub fn get_concept_history(&self, id: &str, limit: usize) -> Result<Vec<ConceptVersion>>;
+    pub fn schema_version(&self) -> Result<i64>;
+    pub fn apply_migrations(&self, target_version: i64) -> Result<()>;
+    pub fn backup(&self, path: &str) -> Result<()>;
+    pub fn restore(&self, path: &str) -> Result<()>;
+    pub fn health_check(&self) -> Result<()>;
+    pub fn delete_association(&self, from: &str, to: &str) -> Result<()>;
+    pub fn clear_concept_associations(&self, id: &str) -> Result<()>;
+}
+```
+
+
+
+## src/framework.rs
+
+### ChaoticSemanticFramework
+
+```rust
+pub struct ChaoticSemanticFramework {
+}
+```
+
+Main framework for chaotic semantic memory
+
+### FrameworkMetrics
+
+```rust
+#[derive(Debug, Default)]
+pub struct FrameworkMetrics {
+}
+```
+
+
+### FrameworkMetricsSnapshot
 
 ```rust
 #[derive(Debug, Clone)]
-pub struct FrameworkStats {
-    pub concept_count: usize,
-    pub db_size_bytes: Option<u64>,
-}
-```
-
-Framework statistics
-
-### FrameworkBuilder
-
-```rust
-pub struct FrameworkBuilder {
-}
-```
-
-Builder for ChaoticSemanticFramework
-
-### impl FrameworkBuilder
-
-```rust
-impl FrameworkBuilder {
-    pub fn with_reservoir_size(self, size: usize) -> Self;
-    pub fn with_reservoir_input_size(self, size: usize) -> Self;
-    pub fn with_chaos_strength(self, strength: f32) -> Self;
-    pub fn with_max_concepts(self, max_concepts: usize) -> Self;
-    pub fn with_max_associations_per_concept(self, max_associations: usize) -> Self;
-    pub fn with_concept_cache_size(self, size: usize) -> Self;
-    pub fn with_connection_pool_size(self, pool_size: usize) -> Self;
-    pub fn with_max_probe_top_k(self, max_probe_top_k: usize) -> Self;
-    pub fn with_max_metadata_bytes(self, max_metadata_bytes: usize) -> Self;
-    pub fn with_max_cached_top_k(self, max_cached_top_k: usize) -> Self;
-    pub fn with_max_batch_size(self, max_batch_size: usize) -> Self;
-    pub fn with_max_sequence_length(self, max_sequence_length: usize) -> Self;
-    pub fn with_version_retention(self, retention: usize) -> Self;
-    pub fn with_local_db(self, path: impl Trait) -> Self;
-    pub fn with_turso(self, url: impl Trait, token: impl Trait) -> Self;
-    pub fn without_persistence(self) -> Self;
-    pub fn without_persistence(self) -> Self;
-    pub fn build(self) -> Result<ChaoticSemanticFramework>;
+pub struct FrameworkMetricsSnapshot {
+    pub concepts_injected_total: u64,
+    pub associations_created_total: u64,
+    pub probes_total: u64,
+    pub avg_probe_latency_ms: f64,
+    pub cache_hits_total: u64,
+    pub cache_misses_total: u64,
+    pub cache_evictions_total: u64,
+    pub reservoir_steps_total: u64,
+    pub avg_reservoir_step_latency_us: f64,
+    pub reservoir_nodes_active: u64,
 }
 ```
 
 
-
-## src/graph_traversal.rs
-
-### TraversalConfig
+### impl FrameworkMetrics
 
 ```rust
-#[derive(Debug, Clone)]
-pub struct TraversalConfig {
-    pub max_depth: usize,
-    pub min_strength: f32,
-    pub max_results: usize,
-}
-```
-
-Configuration for graph traversal operations.
-
-### impl Default for TraversalConfig
-
-```rust
-impl Default for TraversalConfig {
+impl FrameworkMetrics {
 }
 ```
 
 
-### impl Singularity
+### impl ChaoticSemanticFramework
 
 ```rust
-impl Singularity {
-    pub fn neighbors(&self, id: &str, min_strength: f32) -> Vec<(String, f32)>;
-    pub fn incoming_associations(&self, id: &str) -> Vec<(&str, f32)>;
-    pub fn bfs(&self, start: &str, config: &TraversalConfig) -> Result<Vec<(String, u32)>>;
-    pub fn shortest_path(&self, from: &str, to: &str, config: &TraversalConfig) -> Result<Option<Vec<String>>>;
-    pub fn shortest_path_hops(&self, from: &str, to: &str, config: &TraversalConfig) -> Result<Option<Vec<String>>>;
+impl ChaoticSemanticFramework {
+    pub fn builder() -> FrameworkBuilder;
+    pub fn singularity(&self) -> Arc<RwLock<Singularity>>;
+    pub fn inject_concept(&self, id: impl Trait, vector: HVec10240) -> Result<()>;
+    pub fn inject_concept_with_metadata(&self, id: impl Trait, vector: HVec10240, metadata: std::collections::HashMap<String, serde_json::Value>) -> Result<()>;
+    pub fn probe(&self, query: HVec10240, top_k: usize) -> Result<Vec<(String, f32)>>;
+    pub fn probe_filtered(&self, query: &HVec10240, top_k: usize, filter: &MetadataFilter) -> Result<Vec<(String, f32)>>;
+    pub fn traverse(&self, start: &str, config: TraversalConfig) -> Result<Vec<(String, u32)>>;
+    pub fn shortest_path(&self, from: &str, to: &str) -> Result<Option<Vec<String>>>;
+    pub fn process_sequence(&self, sequence: &[Vec<f32>]) -> Result<HVec10240>;
+    pub fn associate(&self, from: &str, to: &str, strength: f32) -> Result<()>;
+    pub fn delete_concept(&self, id: &str) -> Result<()>;
+    pub fn get_associations(&self, id: &str) -> Result<Vec<(String, f32)>>;
+    pub fn get_concept(&self, id: &str) -> Result<Option<Concept>>;
+    pub fn persist(&self) -> Result<()>;
+    pub fn persistence_health_check(&self) -> Result<()>;
+    pub fn load_replace(&self) -> Result<()>;
+    pub fn load_merge(&self) -> Result<()>;
+    pub fn load(&self) -> Result<()>;
+    pub fn metrics_snapshot(&self) -> FrameworkMetricsSnapshot;
+    pub fn stats(&self) -> Result<FrameworkStats>;
+}
+```
+
+
+
+## src/hyperdim_batch.rs
+
+### batch_cosine_similarity
+
+```rust
+pub fn batch_cosine_similarity(query: &HVec10240, candidates: &[HVec10240]) -> Vec<f32>
+```
+
+Batch similarity computation tuned for cache locality and Rayon overhead.
+
+
+## src/framework_validation.rs
+
+### impl ChaoticSemanticFramework
+
+```rust
+impl ChaoticSemanticFramework {
+}
+```
+
+
+
+## src/semantic_bridge.rs
+
+### CanonicalConcept
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CanonicalConcept {
+    pub id: String,
+    pub version: u32,
+    pub labels: Vec<String>,
+    pub related: Vec<String>,
+}
+```
+
+A canonical concept with symbolic identity relationships.
+
+Canonical concepts represent semantic equivalence classes (e.g., "agent memory"
+≈ "cross-session context" ≈ "ai memory") without modifying stored vectors.
+
+### impl CanonicalConcept
+
+```rust
+impl CanonicalConcept {
+    pub fn new(id: impl Trait) -> Self;
+    pub fn with_label(self, label: impl Trait) -> Self;
+    pub fn with_related(self, related_id: impl Trait) -> Self;
+}
+```
+
+
+### BridgeConfig
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeConfig {
+    pub max_expansion_depth: u8,
+    pub max_packet_facts: usize,
+    pub token_budget: usize,
+    pub deterministic_weight: f32,
+    pub concept_weight: f32,
+    pub semantic_weight: f32,
+}
+```
+
+Configuration for the bridge retrieval pipeline.
+
+### impl Default for BridgeConfig
+
+```rust
+impl Default for BridgeConfig {
+}
+```
+
+
+### ScoreBreakdown
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScoreBreakdown {
+    pub deterministic: f32,
+    pub concept: f32,
+    pub semantic: f32,
+    pub final_score: f32,
+    pub evidence: Vec<String>,
+}
+```
+
+Breakdown of scores for a bridge retrieval hit.
+
+### impl ScoreBreakdown
+
+```rust
+impl ScoreBreakdown {
+    pub fn deterministic_only(score: f32) -> Self;
+}
+```
+
+
+### BridgeHit
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeHit {
+    pub id: String,
+    pub text_preview: Option<String>,
+    pub scores: ScoreBreakdown,
+}
+```
+
+A single hit from bridge retrieval.
+
+### MemoryPacket
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryPacket {
+    pub query_intent: String,
+    pub facts: Vec<String>,
+    pub sources: Vec<String>,
+    pub confidence: f32,
+}
+```
+
+Compressed memory packet for LLM context injection.
+
+### impl MemoryPacket
+
+```rust
+impl MemoryPacket {
+    pub fn estimated_tokens(&self) -> usize;
+    pub fn to_json(&self) -> serde_json::Result<String>;
+    pub fn to_json_pretty(&self) -> serde_json::Result<String>;
+}
+```
+
+
+### SemanticReranker
+
+```rust
+pub trait SemanticReranker: Send + Sync {
+    fn version(&self) -> &str;
+    fn rerank(&self, query: &str, hits: &mut [BridgeHit]);
+}
+```
+
+Trait for optional semantic reranking.
+
+Implementations can wrap local models, remote APIs, or rule-based heuristics.
+The reranker never mutates deterministic scores—only adjusts ordering.
+
+### ConceptGraph
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct ConceptGraph {
+}
+```
+
+In-memory canonical concept graph for symbolic semantic expansion.
+
+### impl ConceptGraph
+
+```rust
+impl ConceptGraph {
+    pub fn new() -> Self;
+    pub fn add_concept(&mut self, concept: CanonicalConcept);
+    pub fn remove_concept(&mut self, id: &str) -> Option<CanonicalConcept>;
+    pub fn get_concept(&self, id: &str) -> Option<&CanonicalConcept>;
+    pub fn match_tokens(&self, tokens: &[String]) -> Vec<String>;
+    pub fn expand(&self, concept_ids: &[String], max_depth: u8) -> Vec<String>;
+    pub fn load_from_json(reader: impl Trait) -> crate::Result<Self>;
+    pub fn save_to_json(&self, writer: impl Trait) -> crate::Result<()>;
+    pub fn concept_count(&self) -> usize;
+    pub fn label_count(&self) -> usize;
+    pub fn all_concepts(&self) -> impl Trait;
+}
+```
+
+
+
+## src/framework_ops.rs
+
+### impl ChaoticSemanticFramework
+
+```rust
+impl ChaoticSemanticFramework {
+    pub fn inject_concepts(&self, concepts: &[(String, HVec10240)]) -> Result<()>;
+    pub fn associate_many(&self, associations: &[(String, String, f32)]) -> Result<()>;
+    pub fn probe_batch(&self, queries: &[HVec10240], top_k: usize) -> Result<Vec<Vec<(String, f32)>>>;
+    pub fn probe_batch_cached(&self, queries: &[HVec10240], top_k: usize) -> Result<Vec<Arc<[(String, f32)]>>>;
+    pub fn export_json(&self, path: &str) -> Result<()>;
+    pub fn import_json(&self, path: &str, merge: bool) -> Result<usize>;
+    pub fn export_binary(&self, path: &str) -> Result<()>;
+    pub fn import_binary(&self, path: &str, merge: bool) -> Result<usize>;
+    pub fn backup(&self, path: &str) -> Result<()>;
+    pub fn restore(&self, path: &str) -> Result<()>;
+    pub fn concept_history(&self, id: &str, limit: usize) -> Result<Vec<crate::persistence::ConceptVersion>>;
+    pub fn update_concept_vector(&self, id: &str, vector: HVec10240) -> Result<()>;
+    pub fn update_concept_metadata(&self, id: &str, metadata: std::collections::HashMap<String, serde_json::Value>) -> Result<()>;
+    pub fn disassociate(&self, from: &str, to: &str) -> Result<()>;
+    pub fn clear_associations(&self, id: &str) -> Result<()>;
+    pub fn clear_similarity_cache(&self);
+    pub fn bundle_concepts_strict(&self, ids: &[String]) -> Result<HVec10240>;
+}
+```
+
+
+
+## src/bridge_persistence.rs
+
+### impl Persistence
+
+```rust
+impl Persistence {
+    pub fn save_canonical_concept(&self, concept: &CanonicalConcept) -> Result<()>;
+    pub fn delete_canonical_concept(&self, id: &str) -> Result<()>;
+    pub fn load_canonical_concept(&self, id: &str) -> Result<Option<CanonicalConcept>>;
+    pub fn load_all_canonical_concepts(&self) -> Result<Vec<CanonicalConcept>>;
+    pub fn save_concept_graph(&self, graph: &ConceptGraph) -> Result<()>;
+    pub fn load_concept_graph(&self) -> Result<ConceptGraph>;
 }
 ```
 
@@ -1611,1026 +1612,16 @@ impl Singularity {
 
 
 
-## src/cli/commands/index_dir.rs
-
-### run_index_dir
-
-```rust
-pub fn run_index_dir(args: IndexDirArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
-```
-
-
-### MarkdownChunk
-
-```rust
-#[derive(Debug, Clone)]
-pub struct MarkdownChunk {
-    pub heading: String,
-    pub level: usize,
-    pub content: String,
-}
-```
-
-A chunk of markdown content.
-
-### chunk_by_heading
-
-```rust
-pub fn chunk_by_heading(content: &str, min_level: usize) -> Vec<MarkdownChunk>
-```
-
-Chunk markdown content by heading boundaries.
-
-Only chunks at headings >= min_level (default 2 for ##).
-Heading level 1 (#) is typically the document title and skipped.
-
-
-## src/cli/commands/associate.rs
-
-### run_associate
-
-```rust
-pub fn run_associate(args: AssociateArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
-```
-
-
-### run_associate_batch
-
-```rust
-pub fn run_associate_batch(associations: Vec<(String, String, f64)>, db_path: Option<&Path>, format: OutputFormat, continue_on_error: bool) -> Result<()>
-```
-
-
-
-## src/cli/commands/import.rs
-
-### run_import
-
-```rust
-pub fn run_import(args: ImportArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
-```
-
-
-
-## src/cli/commands/inject.rs
-
-### run_inject
-
-```rust
-pub fn run_inject(args: InjectArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
-```
-
-
-
-## src/cli/commands/probe.rs
-
-### run_probe
-
-```rust
-pub fn run_probe(args: ProbeArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
-```
-
-
-### run_probe_with_vector
-
-```rust
-pub fn run_probe_with_vector(query_vector: HVec10240, top_k: usize, threshold: Option<f64>, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
-```
-
-
-
-## src/cli/commands/index_jsonl.rs
-
-### run_index_jsonl
-
-```rust
-pub fn run_index_jsonl(args: IndexJsonlArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
-```
-
-
-
-## src/cli/commands/query.rs
-
-### run_query
-
-```rust
-pub fn run_query(args: QueryArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
-```
-
-
-
-## src/cli/commands/export.rs
-
-### run_export
-
-```rust
-pub fn run_export(args: ExportArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
-```
-
-
-
-## src/cli/commands/mod.rs
-
-### associate::run_associate
-
-```rust
-pub use associate::run_associate;
-```
-
-
-### completions::run_completions
-
-```rust
-pub use completions::run_completions;
-```
-
-
-### export::run_export
-
-```rust
-pub use export::run_export;
-```
-
-
-### import::run_import
-
-```rust
-pub use import::run_import;
-```
-
-
-### index_dir::run_index_dir
-
-```rust
-pub use index_dir::run_index_dir;
-```
-
-
-### index_jsonl::run_index_jsonl
-
-```rust
-pub use index_jsonl::run_index_jsonl;
-```
-
-
-### inject::run_inject
-
-```rust
-pub use inject::run_inject;
-```
-
-
-### probe::run_probe
-
-```rust
-pub use probe::run_probe;
-```
-
-
-### query::run_query
-
-```rust
-pub use query::run_query;
-```
-
-
-### print_success
-
-```rust
-pub fn print_success(msg: &str, format: OutputFormat)
-```
-
-
-### print_error
-
-```rust
-pub fn print_error(msg: &str)
-```
-
-
-### print_warning
-
-```rust
-pub fn print_warning(msg: &str, format: OutputFormat)
-```
-
-
-### truncate_preview
-
-```rust
-pub fn truncate_preview(s: &str, max_chars: usize) -> String
-```
-
-Truncate a string to `max_chars` characters, appending "..." if truncated.
-
-Uses `char_indices` to avoid panicking on multi-byte UTF-8 boundaries.
-
-### create_framework
-
-```rust
-pub fn create_framework(db_path: Option<&std::path::Path>) -> Result<ChaoticSemanticFramework>
-```
-
-
-
-## src/cli/commands/completions.rs
-
-### run_completions
-
-```rust
-pub fn run_completions(args: CompletionsArgs) -> Result<()>
-```
-
-
-
-## src/cli/git_local.rs
-
-### resolve_git_local_path
-
-```rust
-pub fn resolve_git_local_path() -> Option<PathBuf>
-```
-
-Resolve the git-local database path for the current repository.
-
-Uses `git rev-parse --git-dir` to find the .git directory and returns
-the path `.git/memory-index/csm.db` for storing the memory index.
-
-#### Returns
-
-- `Some(path)` if inside a git repository, with the path to `.git/memory-index/csm.db`
-- `None` if not inside a git repository or git is not available
-
-#### Example
-
-```
-use chaotic_semantic_memory::cli::git_local::resolve_git_local_path;
-// This test runs in git repo environments
-let path = resolve_git_local_path();
-// In a git repo, should return Some path
-assert!(path.is_some() || path.is_none()); // Always passes, documents behavior
-```
-
-### ensure_git_local_dir
-
-```rust
-pub fn ensure_git_local_dir(path: &Path) -> std::io::Result<()>
-```
-
-Ensure the git-local storage directory exists.
-
-Creates the `.git/memory-index/` directory if it doesn't exist.
-
-#### Errors
-
-Returns an error if the directory cannot be created.
-
-
-## src/cli/error.rs
-
-### CliError
-
-```rust
-#[derive(Error, Debug)]
-pub enum CliError {
-    Config(String),
-    Database(String),
-    Input(String),
-    Output(String),
-    Validation(String),
-    Persistence(String),
-    Memory(MemoryError),
-    Io(std::io::Error),
-    Other(String),
-}
-```
-
-
-### impl From<anyhow::Error> for CliError
-
-```rust
-impl From<anyhow::Error> for CliError {
-}
-```
-
-
-### Result
-
-```rust
-pub type Result<T> = std::result::Result<T, CliError>
-```
-
-
-### ExitCode
-
-```rust
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ExitCode {
-    Success,
-    ConfigError,
-    DatabaseError,
-    InputError,
-    OutputError,
-    ValidationError,
-    MemoryError,
-    IoError,
-    UnknownError,
-}
-```
-
-
-### impl From<&CliError> for ExitCode
-
-```rust
-impl From<&CliError> for ExitCode {
-}
-```
-
-
-### impl From<CliError> for ExitCode
-
-```rust
-impl From<CliError> for ExitCode {
-}
-```
-
-
-### impl CliError
-
-```rust
-impl CliError {
-    pub fn exit_code(&self) -> i32;
-}
-```
-
-
-### impl ExitCode
-
-```rust
-impl ExitCode {
-    pub fn as_i32(self) -> i32;
-}
-```
-
-
-
-## src/cli/args.rs
-
-### CliArgs
-
-```rust
-#[derive(Parser, Debug)]
-pub struct CliArgs {
-    pub command: Commands,
-    pub verbose: u8,
-    pub database: Option<PathBuf>,
-    pub git_local: bool,
-    pub index_path: Option<PathBuf>,
-    pub output_format: OutputFormat,
-}
-```
-
-
-### OutputFormat
-
-```rust
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-pub enum OutputFormat {
-    Json,
-    Table,
-    Quiet,
-}
-```
-
-
-### Commands
-
-```rust
-#[derive(Subcommand, Debug)]
-pub enum Commands {
-    Inject(InjectArgs),
-    Probe(ProbeArgs),
-    Query(QueryArgs),
-    Associate(AssociateArgs),
-    Export(ExportArgs),
-    Import(ImportArgs),
-    Version(VersionArgs),
-    Completions(CompletionsArgs),
-    IndexJsonl(IndexJsonlArgs),
-    IndexDir(IndexDirArgs),
-}
-```
-
-
-### InjectArgs
-
-```rust
-#[derive(Args, Debug, Clone)]
-pub struct InjectArgs {
-    pub concept_id: String,
-    pub from_file: Option<PathBuf>,
-    pub vector_source: VectorSource,
-    pub metadata: Option<String>,
-}
-```
-
-
-### VectorSource
-
-```rust
-#[derive(Debug, Clone, Copy, ValueEnum)]
-pub enum VectorSource {
-    Random,
-    File,
-    Stdin,
-}
-```
-
-
-### ProbeArgs
-
-```rust
-#[derive(Args, Debug, Clone)]
-pub struct ProbeArgs {
-    pub concept_id: String,
-    pub top_k: usize,
-    pub threshold: Option<f64>,
-}
-```
-
-
-### QueryArgs
-
-```rust
-#[derive(Args, Debug, Clone)]
-pub struct QueryArgs {
-    pub text: String,
-    pub top_k: usize,
-    pub min_score: f64,
-    pub code_aware: bool,
-    pub compact: bool,
-    pub semantic_only: bool,
-    pub keyword_only: bool,
-    pub keyword_weight: Option<f64>,
-}
-```
-
-Arguments for text-based similarity query.
-
-### AssociateArgs
-
-```rust
-#[derive(Args, Debug, Clone)]
-pub struct AssociateArgs {
-    pub source_id: String,
-    pub target_id: String,
-    pub strength: f64,
-}
-```
-
-
-### ExportFormat
-
-```rust
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-pub enum ExportFormat {
-    Json,
-    Binary,
-}
-```
-
-
-### ExportArgs
-
-```rust
-#[derive(Args, Debug, Clone)]
-pub struct ExportArgs {
-    pub output: PathBuf,
-    pub format: ExportFormat,
-}
-```
-
-
-### ImportFormat
-
-```rust
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-pub enum ImportFormat {
-    Json,
-    Binary,
-    Auto,
-}
-```
-
-
-### ImportArgs
-
-```rust
-#[derive(Args, Debug, Clone)]
-pub struct ImportArgs {
-    pub input: PathBuf,
-    pub format: ImportFormat,
-    pub merge: bool,
-}
-```
-
-
-### VersionArgs
-
-```rust
-#[derive(Args, Debug, Clone)]
-pub struct VersionArgs {
-    pub detailed: bool,
-}
-```
-
-
-### CompletionsArgs
-
-```rust
-#[derive(Args, Debug, Clone)]
-pub struct CompletionsArgs {
-    pub shell: clap_complete::Shell,
-    pub output: Option<PathBuf>,
-}
-```
-
-
-### IndexJsonlArgs
-
-```rust
-#[derive(Args, Debug, Clone)]
-pub struct IndexJsonlArgs {
-    pub file: PathBuf,
-    pub field: String,
-    pub id_field: Option<String>,
-    pub tag_field: Option<String>,
-    pub code_aware: bool,
-}
-```
-
-Arguments for indexing JSONL files.
-
-### IndexDirArgs
-
-```rust
-#[derive(Args, Debug, Clone)]
-pub struct IndexDirArgs {
-    pub glob: Vec<String>,
-    pub heading_level: usize,
-    pub code_aware: bool,
-}
-```
-
-Arguments for indexing Markdown directory.
-
-
-## src/cli/mod.rs
-
-### args::*
-
-```rust
-pub use args::*;
-```
-
-
-### commands::{run_associate, run_completions, run_export, run_import, run_index_dir, run_index_jsonl, run_inject, run_probe, run_query}
-
-```rust
-pub use commands::{run_associate, run_completions, run_export, run_import, run_index_dir, run_index_jsonl, run_inject, run_probe, run_query};
-```
-
-
-### error::{CliError, ExitCode, Result}
-
-```rust
-pub use error::{CliError, ExitCode, Result};
-```
-
-
-### git_local::{ensure_git_local_dir, resolve_git_local_path}
-
-```rust
-pub use git_local::{ensure_git_local_dir, resolve_git_local_path};
-```
-
-
-
-## src/persistence_migrations.rs
-
-### impl Persistence
-
-```rust
-impl Persistence {
-}
-```
-
-
-
-## src/framework_validation.rs
-
-### impl ChaoticSemanticFramework
-
-```rust
-impl ChaoticSemanticFramework {
-}
-```
-
-
-
-## src/persistence_ops.rs
-
-### impl Persistence
-
-```rust
-impl Persistence {
-    pub fn save_associations(&self, associations: &[(String, String, f32)]) -> Result<()>;
-    pub fn clear_all(&self) -> Result<()>;
-    pub fn get_concept_history(&self, id: &str, limit: usize) -> Result<Vec<ConceptVersion>>;
-    pub fn schema_version(&self) -> Result<i64>;
-    pub fn apply_migrations(&self, target_version: i64) -> Result<()>;
-    pub fn backup(&self, path: &str) -> Result<()>;
-    pub fn restore(&self, path: &str) -> Result<()>;
-    pub fn health_check(&self) -> Result<()>;
-    pub fn delete_association(&self, from: &str, to: &str) -> Result<()>;
-    pub fn clear_concept_associations(&self, id: &str) -> Result<()>;
-}
-```
-
-
-
-## src/reservoir_inertial.rs
-
-### impl Reservoir
-
-```rust
-impl Reservoir {
-    pub fn with_beta(self, beta: f32) -> Result<Self>;
-    pub fn beta(&self) -> f32;
-}
-```
-
-
-
-## src/hyperdim_batch.rs
-
-### batch_cosine_similarity
-
-```rust
-pub fn batch_cosine_similarity(query: &HVec10240, candidates: &[HVec10240]) -> Vec<f32>
-```
-
-Batch similarity computation tuned for cache locality and Rayon overhead.
-
-
-## src/retrieval/hybrid.rs
-
-### compute_weights
-
-```rust
-pub fn compute_weights(token_count: usize) -> (f32, f32)
-```
-
-Compute query-length-dependent weights for hybrid retrieval.
-
-Returns (keyword_weight, semantic_weight) based on token count.
-
-| Query Tokens | Keyword | Semantic | Rationale |
-|-------------|---------|----------|-----------|
-| 1-2 | 0.9 | 0.1 | Exact match dominates |
-| 3-4 | 0.7 | 0.3 | Keyword still strong |
-| 5-8 | 0.4 | 0.6 | Semantic takes over |
-| 9+ | 0.2 | 0.8 | Full semantic mode |
-
-### normalize_scores
-
-```rust
-pub fn normalize_scores(scores: &[(String, f32)]) -> Vec<(String, f32)>
-```
-
-Normalize scores to [0, 1] range using min-max normalization.
-
-If all scores are equal, returns 0.5 for all.
-
-### merge_results
-
-```rust
-pub fn merge_results(bm25_results: &[(String, f32)], hdc_results: &[(String, f32)], weights: (f32, f32)) -> Vec<(String, f32)>
-```
-
-Merge BM25 and HDC results with given weights.
-
-Takes two result sets (from BM25 and HDC), normalizes scores,
-and combines them using weighted sum.
-
-Duplicate IDs are merged by taking the maximum combined score.
-
-### HybridMode
-
-```rust
-#[derive(Debug, Clone, Copy, PartialEq, Default)]
-pub enum HybridMode {
-    Auto,
-    SemanticOnly,
-    KeywordOnly,
-    Custom(f32),
-}
-```
-
-Hybrid retrieval mode.
-
-### HybridConfig
-
-```rust
-#[derive(Debug, Clone)]
-pub struct HybridConfig {
-    pub mode: HybridMode,
-    pub min_score: f32,
-}
-```
-
-Configuration for hybrid retrieval.
-
-### impl Default for HybridConfig
-
-```rust
-impl Default for HybridConfig {
-}
-```
-
-
-
-## src/retrieval/mod.rs
-
-### bm25::{Bm25Config, Bm25Index}
-
-```rust
-pub use bm25::{Bm25Config, Bm25Index};
-```
-
-
-### hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores}
-
-```rust
-pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores};
-```
-
-
-
-## src/retrieval/bm25.rs
-
-### Bm25Config
-
-```rust
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct Bm25Config {
-    pub k1: f32,
-    pub b: f32,
-}
-```
-
-Configuration for BM25 ranking algorithm.
-
-### impl Default for Bm25Config
-
-```rust
-impl Default for Bm25Config {
-}
-```
-
-
-### Bm25Index
-
-```rust
-#[derive(Debug, Clone, Default)]
-pub struct Bm25Index {
-}
-```
-
-BM25-based document index for keyword search.
-
-### impl Bm25Index
-
-```rust
-impl Bm25Index {
-    pub fn new() -> Self;
-    pub fn with_config(config: Bm25Config) -> Self;
-    pub fn add_document<T: AsRef>(&mut self, id: &str, tokens: &[T]);
-    pub fn remove_document(&mut self, id: &str);
-    pub fn search<T: AsRef>(&self, query_tokens: &[T], top_k: usize) -> Vec<(String, f32)>;
-    pub fn clear(&mut self);
-    pub fn len(&self) -> usize;
-    pub fn is_empty(&self) -> bool;
-    pub fn avg_doc_length(&self) -> f32;
-}
-```
-
-
-
-## src/singularity.rs
-
-### crate::singularity_cache::CacheMetricsSnapshot
-
-```rust
-pub use crate::singularity_cache::CacheMetricsSnapshot;
-```
-
-
-### crate::singularity_retrieval::{CandidateSource, RetrievalConfig, RetrievalStats}
-
-```rust
-pub use crate::singularity_retrieval::{CandidateSource, RetrievalConfig, RetrievalStats};
-```
-
-
-### DEFAULT_MAX_CACHED_TOP_K
-
-```rust
-pub const DEFAULT_MAX_CACHED_TOP_K: usize
-```
-
-
-### Concept
-
-```rust
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Concept {
-    pub id: String,
-    pub vector: HVec10240,
-    pub metadata: HashMap<String, serde_json::Value>,
-    pub created_at: u64,
-    pub modified_at: u64,
-    pub expires_at: Option<u64>,
-    pub canonical_concept_ids: Vec<String>,
-}
-```
-
-A concept in semantic memory.
-
-Use [`ConceptBuilder`] to construct instances with proper defaults.
-Direct struct construction is supported but the `expires_at` field should
-default to `None` for backward compatibility.
-
-### SingularityConfig
-
-```rust
-#[derive(Debug, Clone)]
-pub struct SingularityConfig {
-    pub max_concepts: Option<usize>,
-    pub max_associations_per_concept: Option<usize>,
-    pub concept_cache_size: usize,
-    pub max_cached_top_k: usize,
-}
-```
-
-Runtime configuration for [`Singularity`].
-
-### impl Default for SingularityConfig
-
-```rust
-impl Default for SingularityConfig {
-}
-```
-
-
-### Singularity
-
-```rust
-#[derive(Debug)]
-pub struct Singularity {
-}
-```
-
-Episode-free singularity engine
-
-### impl Singularity
-
-```rust
-impl Singularity {
-    pub fn new() -> Self;
-    pub fn with_config(config: SingularityConfig) -> Self;
-    pub fn inject(&mut self, concept: Concept) -> Result<()>;
-    pub fn get(&self, id: &str) -> Option<&Concept>;
-    pub fn delete(&mut self, id: &str) -> Result<()>;
-    pub fn clear(&mut self);
-    pub fn update(&mut self, id: &str, new_vector: HVec10240) -> Result<()>;
-    pub fn find_similar(&self, query: &HVec10240, top_k: usize) -> Vec<(String, f32)>;
-    pub fn find_similar_arc(&self, query: &HVec10240, top_k: usize) -> Arc<[(String, f32)]>;
-    pub fn find_similar_cached(&self, query: &HVec10240, top_k: usize) -> Arc<[(String, f32)]>;
-    pub fn associate(&mut self, from: &str, to: &str, strength: f32) -> Result<()>;
-    pub fn get_associations(&self, id: &str) -> Vec<(String, f32)>;
-    pub fn bundle_concepts(&self, ids: &[String]) -> Result<HVec10240>;
-    pub fn concept_ids(&self) -> Vec<String>;
-    pub fn all_concepts(&self) -> Vec<Concept>;
-    pub fn all_associations(&self) -> Vec<(String, String, f32)>;
-    pub fn len(&self) -> usize;
-    pub fn is_empty(&self) -> bool;
-    pub fn cache_metrics_snapshot(&self) -> CacheMetricsSnapshot;
-}
-```
-
-
-### impl Default for Singularity
-
-```rust
-impl Default for Singularity {
-}
-```
-
-
-### crate::concept_builder::ConceptBuilder
-
-```rust
-pub use crate::concept_builder::ConceptBuilder;
-```
-
-
-
-## src/framework.rs
-
-### ChaoticSemanticFramework
-
-```rust
-pub struct ChaoticSemanticFramework {
-}
-```
-
-Main framework for chaotic semantic memory
-
-### FrameworkMetrics
-
-```rust
-#[derive(Debug, Default)]
-pub struct FrameworkMetrics {
-}
-```
-
-
-### FrameworkMetricsSnapshot
-
-```rust
-#[derive(Debug, Clone)]
-pub struct FrameworkMetricsSnapshot {
-    pub concepts_injected_total: u64,
-    pub associations_created_total: u64,
-    pub probes_total: u64,
-    pub avg_probe_latency_ms: f64,
-    pub cache_hits_total: u64,
-    pub cache_misses_total: u64,
-    pub cache_evictions_total: u64,
-    pub reservoir_steps_total: u64,
-    pub avg_reservoir_step_latency_us: f64,
-    pub reservoir_nodes_active: u64,
-}
-```
-
-
-### impl FrameworkMetrics
-
-```rust
-impl FrameworkMetrics {
-}
-```
-
-
-### impl ChaoticSemanticFramework
-
-```rust
-impl ChaoticSemanticFramework {
-    pub fn builder() -> FrameworkBuilder;
-    pub fn singularity(&self) -> Arc<RwLock<Singularity>>;
-    pub fn inject_concept(&self, id: impl Trait, vector: HVec10240) -> Result<()>;
-    pub fn inject_concept_with_metadata(&self, id: impl Trait, vector: HVec10240, metadata: std::collections::HashMap<String, serde_json::Value>) -> Result<()>;
-    pub fn probe(&self, query: HVec10240, top_k: usize) -> Result<Vec<(String, f32)>>;
-    pub fn probe_filtered(&self, query: &HVec10240, top_k: usize, filter: &MetadataFilter) -> Result<Vec<(String, f32)>>;
-    pub fn traverse(&self, start: &str, config: TraversalConfig) -> Result<Vec<(String, u32)>>;
-    pub fn shortest_path(&self, from: &str, to: &str) -> Result<Option<Vec<String>>>;
-    pub fn process_sequence(&self, sequence: &[Vec<f32>]) -> Result<HVec10240>;
-    pub fn associate(&self, from: &str, to: &str, strength: f32) -> Result<()>;
-    pub fn delete_concept(&self, id: &str) -> Result<()>;
-    pub fn get_associations(&self, id: &str) -> Result<Vec<(String, f32)>>;
-    pub fn get_concept(&self, id: &str) -> Result<Option<Concept>>;
-    pub fn persist(&self) -> Result<()>;
-    pub fn persistence_health_check(&self) -> Result<()>;
-    pub fn load_replace(&self) -> Result<()>;
-    pub fn load_merge(&self) -> Result<()>;
-    pub fn load(&self) -> Result<()>;
-    pub fn metrics_snapshot(&self) -> FrameworkMetricsSnapshot;
-    pub fn stats(&self) -> Result<FrameworkStats>;
-}
-```
-
-
-
-## src/persistence_wasm.rs
+## src/persistence.rs
 
 ### Persistence
 
 ```rust
-pub struct Persistence;
+#[derive(Debug)]
+pub struct Persistence {
+}
 ```
 
-Persistence stub for wasm32 builds.
 
 ### ConceptVersion
 
@@ -2650,251 +1641,20 @@ pub struct ConceptVersion {
 
 ```rust
 impl Persistence {
-    pub fn new_local(_path: &str) -> Result<Self>;
-    pub fn new_local_with_retention(_path: &str, _retention: usize) -> Result<Self>;
-    pub fn new_turso(_url: &str, _token: &str) -> Result<Self>;
-    pub fn new_turso_with_pool(_url: &str, _token: &str, _pool_size: usize) -> Result<Self>;
-    pub fn new_turso_with_pool_and_retention(_url: &str, _token: &str, _pool_size: usize, _retention: usize) -> Result<Self>;
-    pub fn save_concept(&self, _concept: &Concept) -> Result<()>;
-    pub fn save_concepts(&self, _concepts: &[Concept]) -> Result<()>;
-    pub fn load_concept(&self, _id: &str) -> Result<Option<Concept>>;
+    pub fn new_local(path: &str) -> Result<Self>;
+    pub fn new_local_with_retention(path: &str, version_retention: usize) -> Result<Self>;
+    pub fn new_turso(url: &str, token: &str) -> Result<Self>;
+    pub fn new_turso_with_pool(url: &str, token: &str, pool_size: usize) -> Result<Self>;
+    pub fn new_turso_with_pool_and_retention(url: &str, token: &str, pool_size: usize, version_retention: usize) -> Result<Self>;
+    pub fn save_concept(&self, concept: &Concept) -> Result<()>;
+    pub fn save_concepts(&self, concepts: &[Concept]) -> Result<()>;
+    pub fn load_concept(&self, id: &str) -> Result<Option<Concept>>;
     pub fn load_all_concepts(&self) -> Result<Vec<Concept>>;
-    pub fn delete_concept(&self, _id: &str) -> Result<()>;
-    pub fn save_association(&self, _from: &str, _to: &str, _strength: f32) -> Result<()>;
-    pub fn save_associations(&self, _associations: &[(String, String, f32)]) -> Result<()>;
-    pub fn load_associations(&self, _id: &str) -> Result<Vec<(String, f32)>>;
-    pub fn clear_all(&self) -> Result<()>;
-    pub fn get_concept_history(&self, _id: &str, _limit: usize) -> Result<Vec<ConceptVersion>>;
-    pub fn schema_version(&self) -> Result<i64>;
-    pub fn apply_migrations(&self, _target_version: i64) -> Result<()>;
-    pub fn backup(&self, _path: &str) -> Result<()>;
-    pub fn restore(&self, _path: &str) -> Result<()>;
+    pub fn delete_concept(&self, id: &str) -> Result<()>;
+    pub fn save_association(&self, from: &str, to: &str, strength: f32) -> Result<()>;
+    pub fn load_associations(&self, id: &str) -> Result<Vec<(String, f32)>>;
     pub fn checkpoint(&self) -> Result<()>;
-    pub fn health_check(&self) -> Result<()>;
     pub fn size(&self) -> Result<u64>;
-}
-```
-
-
-
-## src/framework_ops.rs
-
-### impl ChaoticSemanticFramework
-
-```rust
-impl ChaoticSemanticFramework {
-    pub fn inject_concepts(&self, concepts: &[(String, HVec10240)]) -> Result<()>;
-    pub fn associate_many(&self, associations: &[(String, String, f32)]) -> Result<()>;
-    pub fn probe_batch(&self, queries: &[HVec10240], top_k: usize) -> Result<Vec<Vec<(String, f32)>>>;
-    pub fn probe_batch_cached(&self, queries: &[HVec10240], top_k: usize) -> Result<Vec<Arc<[(String, f32)]>>>;
-    pub fn export_json(&self, path: &str) -> Result<()>;
-    pub fn import_json(&self, path: &str, merge: bool) -> Result<usize>;
-    pub fn export_binary(&self, path: &str) -> Result<()>;
-    pub fn import_binary(&self, path: &str, merge: bool) -> Result<usize>;
-    pub fn backup(&self, path: &str) -> Result<()>;
-    pub fn restore(&self, path: &str) -> Result<()>;
-    pub fn concept_history(&self, id: &str, limit: usize) -> Result<Vec<crate::persistence::ConceptVersion>>;
-    pub fn update_concept_vector(&self, id: &str, vector: HVec10240) -> Result<()>;
-    pub fn update_concept_metadata(&self, id: &str, metadata: std::collections::HashMap<String, serde_json::Value>) -> Result<()>;
-    pub fn disassociate(&self, from: &str, to: &str) -> Result<()>;
-    pub fn clear_associations(&self, id: &str) -> Result<()>;
-    pub fn clear_similarity_cache(&self);
-    pub fn bundle_concepts_strict(&self, ids: &[String]) -> Result<HVec10240>;
-}
-```
-
-
-
-## src/export_payload/export_payload_tests.rs
-
-
-## src/wasm.rs
-
-### initialize_wasm
-
-```rust
-pub fn initialize_wasm()
-```
-
-
-### WasmFramework
-
-```rust
-pub struct WasmFramework {
-}
-```
-
-WASM-friendly wrapper for the framework
-
-### impl WasmFramework
-
-```rust
-impl WasmFramework {
-    pub fn new() -> Result<WasmFramework, JsValue>;
-    pub fn inject_concept(&self, id: String, vector: &[u8]) -> Result<(), JsValue>;
-    pub fn probe(&self, vector: &[u8], top_k: usize) -> Result<Array, JsValue>;
-    pub fn associate(&self, from: String, to: String, strength: f32) -> Result<(), JsValue>;
-    pub fn delete_concept(&self, id: String) -> Result<(), JsValue>;
-    pub fn update_concept(&self, id: String, vector: &[u8]) -> Result<(), JsValue>;
-    pub fn disassociate(&self, from: String, to: String) -> Result<(), JsValue>;
-    pub fn get_associations(&self, id: String) -> Result<Array, JsValue>;
-    pub fn get_concept(&self, id: String) -> Result<JsValue, JsValue>;
-    pub fn inject_concepts(&self, ids: Array, vectors: Array) -> Result<(), JsValue>;
-    pub fn associate_many(&self, associations: Array) -> Result<(), JsValue>;
-    pub fn probe_batch(&self, vectors: Array, top_k: usize) -> Result<Array, JsValue>;
-    pub fn metrics_snapshot(&self) -> Result<JsValue, JsValue>;
-    pub fn process_sequence(&self, sequence: Array) -> Result<Box<[u8]>, JsValue>;
-    pub fn export_to_bytes(&self) -> Result<Uint8Array, JsValue>;
-    pub fn import_from_bytes(&self, data: Uint8Array, merge: bool) -> Result<usize, JsValue>;
-}
-```
-
-
-### random_hypervector
-
-```rust
-pub fn random_hypervector() -> Box<[u8]>
-```
-
-Create a random hypervector (1280 bytes)
-
-### encode_text
-
-```rust
-pub fn encode_text(text: &str) -> Box<[u8]>
-```
-
-Encode text to a hypervector using HDC encoding
-
-### cosine_similarity
-
-```rust
-pub fn cosine_similarity(a: &[u8], b: &[u8]) -> Result<f32, JsValue>
-```
-
-Compute cosine similarity between two hypervectors
-
-
-## src/error.rs
-
-### MemoryError
-
-```rust
-#[derive(Error, Debug)]
-pub enum MemoryError {
-    Database { message: String, source: Option<Box<dyn Trait>> },
-    InvalidInput { field: String, reason: String },
-    InvalidDimension { expected: usize, actual: usize },
-    NotFound { entity: String, id: String },
-    UnsupportedOperation(String),
-    Reservoir { message: String, source: Option<Box<dyn Trait>> },
-    Persistence(String),
-    Io(std::io::Error),
-    Serialization(serde_json::Error),
-}
-```
-
-
-### impl MemoryError
-
-```rust
-impl MemoryError {
-    pub fn database(message: impl Trait) -> Self;
-    pub fn database_with_source(message: impl Trait, source: impl Trait) -> Self;
-    pub fn reservoir(message: impl Trait) -> Self;
-    pub fn reservoir_with_source(message: impl Trait, source: impl Trait) -> Self;
-}
-```
-
-
-### Result
-
-```rust
-pub type Result<T> = std::result::Result<T, MemoryError>
-```
-
-
-
-## src/wasm_ext.rs
-
-### impl WasmFramework
-
-```rust
-impl WasmFramework {
-    pub fn stats(&self) -> Result<JsValue, JsValue>;
-    pub fn concept_count(&self) -> Result<usize, JsValue>;
-    pub fn update_concept_metadata(&self, id: String, metadata_json: String) -> Result<(), JsValue>;
-    pub fn clear_associations(&self, id: String) -> Result<(), JsValue>;
-    pub fn neighbors(&self, id: String, min_strength: f32) -> Result<Array, JsValue>;
-    pub fn bfs(&self, start: String) -> Result<Array, JsValue>;
-    pub fn shortest_path(&self, from: String, to: String) -> Result<Array, JsValue>;
-    pub fn probe_filtered(&self, vector: &[u8], top_k: usize, filter_json: String) -> Result<Array, JsValue>;
-    pub fn traverse(&self, start: String, max_depth: u32, min_strength: f32) -> Result<Array, JsValue>;
-    pub fn on_event(&self, callback: Function);
-    pub fn inject_text(&self, id: String, text: String) -> Result<(), JsValue>;
-    pub fn probe_text(&self, query: String, top_k: usize) -> Result<Array, JsValue>;
-}
-```
-
-
-
-## src/export_payload.rs
-
-### impl From<serde_json::Value> for BinaryMetadataValue
-
-```rust
-impl From<serde_json::Value> for BinaryMetadataValue {
-}
-```
-
-
-### impl From<BinaryMetadataValue> for serde_json::Value
-
-```rust
-impl From<BinaryMetadataValue> for serde_json::Value {
-}
-```
-
-
-### impl From<crate::singularity::Concept> for BinaryConcept
-
-```rust
-impl From<crate::singularity::Concept> for BinaryConcept {
-}
-```
-
-
-### impl BinaryConcept
-
-```rust
-impl BinaryConcept {
-}
-```
-
-
-### impl From<ExportPayload> for BinaryExportPayload
-
-```rust
-impl From<ExportPayload> for BinaryExportPayload {
-}
-```
-
-
-### impl BinaryExportPayload
-
-```rust
-impl BinaryExportPayload {
-}
-```
-
-
-
-## src/persistence_versions.rs
-
-### impl Persistence
-
-```rust
-impl Persistence {
 }
 ```
 
@@ -3108,6 +1868,211 @@ pub use crate::singularity_retrieval::{CandidateSource, FilterStrategy, Retrieva
 
 
 
+## src/metadata_filter.rs
+
+### MetadataFilter
+
+```rust
+#[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize)]
+pub enum MetadataFilter {
+    Eq(String, Value),
+    In(String, Vec<Value>),
+    Exists(String),
+    And(Vec<MetadataFilter>),
+    Or(Vec<MetadataFilter>),
+    Not(Box<MetadataFilter>),
+}
+```
+
+A predicate for filtering concepts by metadata during similarity search.
+
+### impl MetadataFilter
+
+```rust
+impl MetadataFilter {
+    pub fn eq(key: impl Trait, value: impl Trait) -> Self;
+    pub fn in_(key: impl Trait, values: Vec<Value>) -> Self;
+    pub fn exists(key: impl Trait) -> Self;
+    pub fn and(filters: Vec<MetadataFilter>) -> Self;
+    pub fn or(filters: Vec<MetadataFilter>) -> Self;
+    pub fn matches(&self, metadata: &HashMap<String, Value>) -> bool;
+}
+```
+
+
+### impl ops::Not for MetadataFilter
+
+```rust
+impl ops::Not for MetadataFilter {
+}
+```
+
+
+
+## src/wasm_ext.rs
+
+### impl WasmFramework
+
+```rust
+impl WasmFramework {
+    pub fn stats(&self) -> Result<JsValue, JsValue>;
+    pub fn concept_count(&self) -> Result<usize, JsValue>;
+    pub fn update_concept_metadata(&self, id: String, metadata_json: String) -> Result<(), JsValue>;
+    pub fn clear_associations(&self, id: String) -> Result<(), JsValue>;
+    pub fn neighbors(&self, id: String, min_strength: f32) -> Result<Array, JsValue>;
+    pub fn bfs(&self, start: String) -> Result<Array, JsValue>;
+    pub fn shortest_path(&self, from: String, to: String) -> Result<Array, JsValue>;
+    pub fn probe_filtered(&self, vector: &[u8], top_k: usize, filter_json: String) -> Result<Array, JsValue>;
+    pub fn traverse(&self, start: String, max_depth: u32, min_strength: f32) -> Result<Array, JsValue>;
+    pub fn on_event(&self, callback: Function);
+    pub fn inject_text(&self, id: String, text: String) -> Result<(), JsValue>;
+    pub fn probe_text(&self, query: String, top_k: usize) -> Result<Array, JsValue>;
+}
+```
+
+
+
+## src/singularity.rs
+
+### crate::singularity_cache::CacheMetricsSnapshot
+
+```rust
+pub use crate::singularity_cache::CacheMetricsSnapshot;
+```
+
+
+### crate::singularity_retrieval::{CandidateSource, RetrievalConfig, RetrievalStats}
+
+```rust
+pub use crate::singularity_retrieval::{CandidateSource, RetrievalConfig, RetrievalStats};
+```
+
+
+### DEFAULT_MAX_CACHED_TOP_K
+
+```rust
+pub const DEFAULT_MAX_CACHED_TOP_K: usize
+```
+
+
+### Concept
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Concept {
+    pub id: String,
+    pub vector: HVec10240,
+    pub metadata: HashMap<String, serde_json::Value>,
+    pub created_at: u64,
+    pub modified_at: u64,
+    pub expires_at: Option<u64>,
+    pub canonical_concept_ids: Vec<String>,
+}
+```
+
+A concept in semantic memory.
+
+Use [`ConceptBuilder`] to construct instances with proper defaults.
+Direct struct construction is supported but the `expires_at` field should
+default to `None` for backward compatibility.
+
+### SingularityConfig
+
+```rust
+#[derive(Debug, Clone)]
+pub struct SingularityConfig {
+    pub max_concepts: Option<usize>,
+    pub max_associations_per_concept: Option<usize>,
+    pub concept_cache_size: usize,
+    pub max_cached_top_k: usize,
+}
+```
+
+Runtime configuration for [`Singularity`].
+
+### impl Default for SingularityConfig
+
+```rust
+impl Default for SingularityConfig {
+}
+```
+
+
+### Singularity
+
+```rust
+#[derive(Debug)]
+pub struct Singularity {
+}
+```
+
+Episode-free singularity engine
+
+### impl Singularity
+
+```rust
+impl Singularity {
+    pub fn new() -> Self;
+    pub fn with_config(config: SingularityConfig) -> Self;
+    pub fn inject(&mut self, concept: Concept) -> Result<()>;
+    pub fn get(&self, id: &str) -> Option<&Concept>;
+    pub fn delete(&mut self, id: &str) -> Result<()>;
+    pub fn clear(&mut self);
+    pub fn update(&mut self, id: &str, new_vector: HVec10240) -> Result<()>;
+    pub fn find_similar(&self, query: &HVec10240, top_k: usize) -> Vec<(String, f32)>;
+    pub fn find_similar_arc(&self, query: &HVec10240, top_k: usize) -> Arc<[(String, f32)]>;
+    pub fn find_similar_cached(&self, query: &HVec10240, top_k: usize) -> Arc<[(String, f32)]>;
+    pub fn associate(&mut self, from: &str, to: &str, strength: f32) -> Result<()>;
+    pub fn get_associations(&self, id: &str) -> Vec<(String, f32)>;
+    pub fn bundle_concepts(&self, ids: &[String]) -> Result<HVec10240>;
+    pub fn concept_ids(&self) -> Vec<String>;
+    pub fn all_concepts(&self) -> Vec<Concept>;
+    pub fn all_associations(&self) -> Vec<(String, String, f32)>;
+    pub fn len(&self) -> usize;
+    pub fn is_empty(&self) -> bool;
+    pub fn cache_metrics_snapshot(&self) -> CacheMetricsSnapshot;
+}
+```
+
+
+### impl Default for Singularity
+
+```rust
+impl Default for Singularity {
+}
+```
+
+
+### crate::concept_builder::ConceptBuilder
+
+```rust
+pub use crate::concept_builder::ConceptBuilder;
+```
+
+
+
+## src/singularity_ttl.rs
+
+### impl Default for Concept
+
+```rust
+impl Default for Concept {
+}
+```
+
+
+### impl Singularity
+
+```rust
+impl Singularity {
+    pub fn purge_expired(&mut self) -> usize;
+    pub fn is_expired(&self, id: &str) -> bool;
+    pub fn active_concept_ids(&self) -> Vec<String>;
+}
+```
+
+
+
 ## src/bridge_retrieval.rs
 
 ### BridgeRetrieval
@@ -3136,274 +2101,177 @@ impl BridgeRetrieval {
 
 
 
-## src/semantic_bridge.rs
+## src/persistence_wasm.rs
 
-### CanonicalConcept
+### Persistence
 
 ```rust
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CanonicalConcept {
-    pub id: String,
-    pub version: u32,
-    pub labels: Vec<String>,
-    pub related: Vec<String>,
+pub struct Persistence;
+```
+
+Persistence stub for wasm32 builds.
+
+### ConceptVersion
+
+```rust
+#[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize)]
+pub struct ConceptVersion {
+    pub concept_id: String,
+    pub version: i64,
+    pub vector: HVec10240,
+    pub metadata: serde_json::Value,
+    pub modified_at: u64,
 }
 ```
 
-A canonical concept with symbolic identity relationships.
-
-Canonical concepts represent semantic equivalence classes (e.g., "agent memory"
-≈ "cross-session context" ≈ "ai memory") without modifying stored vectors.
-
-### impl CanonicalConcept
-
-```rust
-impl CanonicalConcept {
-    pub fn new(id: impl Trait) -> Self;
-    pub fn with_label(self, label: impl Trait) -> Self;
-    pub fn with_related(self, related_id: impl Trait) -> Self;
-}
-```
-
-
-### BridgeConfig
-
-```rust
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BridgeConfig {
-    pub max_expansion_depth: u8,
-    pub max_packet_facts: usize,
-    pub token_budget: usize,
-    pub deterministic_weight: f32,
-    pub concept_weight: f32,
-    pub semantic_weight: f32,
-}
-```
-
-Configuration for the bridge retrieval pipeline.
-
-### impl Default for BridgeConfig
-
-```rust
-impl Default for BridgeConfig {
-}
-```
-
-
-### ScoreBreakdown
-
-```rust
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ScoreBreakdown {
-    pub deterministic: f32,
-    pub concept: f32,
-    pub semantic: f32,
-    pub final_score: f32,
-    pub evidence: Vec<String>,
-}
-```
-
-Breakdown of scores for a bridge retrieval hit.
-
-### impl ScoreBreakdown
-
-```rust
-impl ScoreBreakdown {
-    pub fn deterministic_only(score: f32) -> Self;
-}
-```
-
-
-### BridgeHit
-
-```rust
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BridgeHit {
-    pub id: String,
-    pub text_preview: Option<String>,
-    pub scores: ScoreBreakdown,
-}
-```
-
-A single hit from bridge retrieval.
-
-### MemoryPacket
-
-```rust
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MemoryPacket {
-    pub query_intent: String,
-    pub facts: Vec<String>,
-    pub sources: Vec<String>,
-    pub confidence: f32,
-}
-```
-
-Compressed memory packet for LLM context injection.
-
-### impl MemoryPacket
-
-```rust
-impl MemoryPacket {
-    pub fn estimated_tokens(&self) -> usize;
-    pub fn to_json(&self) -> serde_json::Result<String>;
-    pub fn to_json_pretty(&self) -> serde_json::Result<String>;
-}
-```
-
-
-### SemanticReranker
-
-```rust
-pub trait SemanticReranker: Send + Sync {
-    fn version(&self) -> &str;
-    fn rerank(&self, query: &str, hits: &mut [BridgeHit]);
-}
-```
-
-Trait for optional semantic reranking.
-
-Implementations can wrap local models, remote APIs, or rule-based heuristics.
-The reranker never mutates deterministic scores—only adjusts ordering.
-
-### ConceptGraph
-
-```rust
-#[derive(Debug, Clone, Default)]
-pub struct ConceptGraph {
-}
-```
-
-In-memory canonical concept graph for symbolic semantic expansion.
-
-### impl ConceptGraph
-
-```rust
-impl ConceptGraph {
-    pub fn new() -> Self;
-    pub fn add_concept(&mut self, concept: CanonicalConcept);
-    pub fn remove_concept(&mut self, id: &str) -> Option<CanonicalConcept>;
-    pub fn get_concept(&self, id: &str) -> Option<&CanonicalConcept>;
-    pub fn match_tokens(&self, tokens: &[String]) -> Vec<String>;
-    pub fn expand(&self, concept_ids: &[String], max_depth: u8) -> Vec<String>;
-    pub fn load_from_json(reader: impl Trait) -> crate::Result<Self>;
-    pub fn save_to_json(&self, writer: impl Trait) -> crate::Result<()>;
-    pub fn concept_count(&self) -> usize;
-    pub fn label_count(&self) -> usize;
-    pub fn all_concepts(&self) -> impl Trait;
-}
-```
-
-
-
-## src/framework_events.rs
-
-### MemoryEvent
-
-```rust
-#[derive(Debug, Clone)]
-pub enum MemoryEvent {
-    ConceptInjected { id: String, timestamp: u64 },
-    ConceptUpdated { id: String, timestamp: u64 },
-    ConceptDeleted { id: String, timestamp: u64 },
-    Associated { from: String, to: String, strength: f32 },
-    Disassociated { from: String, to: String },
-}
-```
-
-
-### impl ChaoticSemanticFramework
-
-```rust
-impl ChaoticSemanticFramework {
-    pub fn subscribe(&self) -> broadcast::Receiver<MemoryEvent>;
-    pub fn update_concept_vector(&self, id: &str, vector: HVec10240) -> Result<()>;
-    pub fn update_concept_metadata(&self, id: &str, metadata: HashMap<String, serde_json::Value>) -> Result<()>;
-    pub fn disassociate(&self, from: &str, to: &str) -> Result<()>;
-}
-```
-
-
-
-## src/bridge_persistence.rs
 
 ### impl Persistence
 
 ```rust
 impl Persistence {
-    pub fn save_canonical_concept(&self, concept: &CanonicalConcept) -> Result<()>;
-    pub fn delete_canonical_concept(&self, id: &str) -> Result<()>;
-    pub fn load_canonical_concept(&self, id: &str) -> Result<Option<CanonicalConcept>>;
-    pub fn load_all_canonical_concepts(&self) -> Result<Vec<CanonicalConcept>>;
-    pub fn save_concept_graph(&self, graph: &ConceptGraph) -> Result<()>;
-    pub fn load_concept_graph(&self) -> Result<ConceptGraph>;
+    pub fn new_local(_path: &str) -> Result<Self>;
+    pub fn new_local_with_retention(_path: &str, _retention: usize) -> Result<Self>;
+    pub fn new_turso(_url: &str, _token: &str) -> Result<Self>;
+    pub fn new_turso_with_pool(_url: &str, _token: &str, _pool_size: usize) -> Result<Self>;
+    pub fn new_turso_with_pool_and_retention(_url: &str, _token: &str, _pool_size: usize, _retention: usize) -> Result<Self>;
+    pub fn save_concept(&self, _concept: &Concept) -> Result<()>;
+    pub fn save_concepts(&self, _concepts: &[Concept]) -> Result<()>;
+    pub fn load_concept(&self, _id: &str) -> Result<Option<Concept>>;
+    pub fn load_all_concepts(&self) -> Result<Vec<Concept>>;
+    pub fn delete_concept(&self, _id: &str) -> Result<()>;
+    pub fn save_association(&self, _from: &str, _to: &str, _strength: f32) -> Result<()>;
+    pub fn save_associations(&self, _associations: &[(String, String, f32)]) -> Result<()>;
+    pub fn load_associations(&self, _id: &str) -> Result<Vec<(String, f32)>>;
+    pub fn clear_all(&self) -> Result<()>;
+    pub fn get_concept_history(&self, _id: &str, _limit: usize) -> Result<Vec<ConceptVersion>>;
+    pub fn schema_version(&self) -> Result<i64>;
+    pub fn apply_migrations(&self, _target_version: i64) -> Result<()>;
+    pub fn backup(&self, _path: &str) -> Result<()>;
+    pub fn restore(&self, _path: &str) -> Result<()>;
+    pub fn checkpoint(&self) -> Result<()>;
+    pub fn health_check(&self) -> Result<()>;
+    pub fn size(&self) -> Result<u64>;
 }
 ```
 
 
 
-## src/encoder.rs
+## src/error.rs
 
-### TextEncoderConfig
+### MemoryError
 
 ```rust
-#[derive(Debug, Clone)]
-pub struct TextEncoderConfig {
-    pub position_stride: usize,
-    pub ngram_size: Option<usize>,
-    pub lowercase: bool,
-    pub code_aware: bool,
+#[derive(Error, Debug)]
+pub enum MemoryError {
+    Database { message: String, source: Option<Box<dyn Trait>> },
+    InvalidInput { field: String, reason: String },
+    InvalidDimension { expected: usize, actual: usize },
+    NotFound { entity: String, id: String },
+    UnsupportedOperation(String),
+    Reservoir { message: String, source: Option<Box<dyn Trait>> },
+    Persistence(String),
+    Io(std::io::Error),
+    Serialization(serde_json::Error),
 }
 ```
 
-Configuration for the text encoder.
 
-### impl Default for TextEncoderConfig
+### impl MemoryError
 
 ```rust
-impl Default for TextEncoderConfig {
+impl MemoryError {
+    pub fn database(message: impl Trait) -> Self;
+    pub fn database_with_source(message: impl Trait, source: impl Trait) -> Self;
+    pub fn reservoir(message: impl Trait) -> Self;
+    pub fn reservoir_with_source(message: impl Trait, source: impl Trait) -> Self;
 }
 ```
 
 
-### TextEncoder
+### Result
 
 ```rust
-#[derive(Debug, Clone)]
-pub struct TextEncoder {
-}
+pub type Result<T> = std::result::Result<T, MemoryError>
 ```
 
-Deterministic text-to-hypervector encoder using HDC principles.
 
-Produces consistent `HVec10240` vectors from text input without external dependencies.
-The encoding is:
-- **Deterministic**: Same input always produces same output
-- **Similarity-preserving**: Similar texts produce similar vectors
-- **WASM-compatible**: No external dependencies
 
-### impl Default for TextEncoder
+## src/persistence_versions.rs
+
+### impl Persistence
 
 ```rust
-impl Default for TextEncoder {
+impl Persistence {
 }
 ```
 
 
-### impl TextEncoder
+
+## src/wasm.rs
+
+### initialize_wasm
 
 ```rust
-impl TextEncoder {
-    pub fn new() -> Self;
-    pub fn with_config(config: TextEncoderConfig) -> Self;
-    pub fn new_code_aware() -> Self;
-    pub fn config(&self) -> &TextEncoderConfig;
-    pub fn encode(&self, text: &str) -> HVec10240;
-    pub fn encode_with_ngrams(&self, text: &str, n: usize) -> HVec10240;
-    pub fn tokenize(text: &str, code_aware: bool, lowercase: bool) -> Vec<String>;
+pub fn initialize_wasm()
+```
+
+
+### WasmFramework
+
+```rust
+pub struct WasmFramework {
 }
 ```
 
+WASM-friendly wrapper for the framework
+
+### impl WasmFramework
+
+```rust
+impl WasmFramework {
+    pub fn new() -> Result<WasmFramework, JsValue>;
+    pub fn inject_concept(&self, id: String, vector: &[u8]) -> Result<(), JsValue>;
+    pub fn probe(&self, vector: &[u8], top_k: usize) -> Result<Array, JsValue>;
+    pub fn associate(&self, from: String, to: String, strength: f32) -> Result<(), JsValue>;
+    pub fn delete_concept(&self, id: String) -> Result<(), JsValue>;
+    pub fn update_concept(&self, id: String, vector: &[u8]) -> Result<(), JsValue>;
+    pub fn disassociate(&self, from: String, to: String) -> Result<(), JsValue>;
+    pub fn get_associations(&self, id: String) -> Result<Array, JsValue>;
+    pub fn get_concept(&self, id: String) -> Result<JsValue, JsValue>;
+    pub fn inject_concepts(&self, ids: Array, vectors: Array) -> Result<(), JsValue>;
+    pub fn associate_many(&self, associations: Array) -> Result<(), JsValue>;
+    pub fn probe_batch(&self, vectors: Array, top_k: usize) -> Result<Array, JsValue>;
+    pub fn metrics_snapshot(&self) -> Result<JsValue, JsValue>;
+    pub fn process_sequence(&self, sequence: Array) -> Result<Box<[u8]>, JsValue>;
+    pub fn export_to_bytes(&self) -> Result<Uint8Array, JsValue>;
+    pub fn import_from_bytes(&self, data: Uint8Array, merge: bool) -> Result<usize, JsValue>;
+}
+```
+
+
+### random_hypervector
+
+```rust
+pub fn random_hypervector() -> Box<[u8]>
+```
+
+Create a random hypervector (1280 bytes)
+
+### encode_text
+
+```rust
+pub fn encode_text(text: &str) -> Box<[u8]>
+```
+
+Encode text to a hypervector using HDC encoding
+
+### cosine_similarity
+
+```rust
+pub fn cosine_similarity(a: &[u8], b: &[u8]) -> Result<f32, JsValue>
+```
+
+Compute cosine similarity between two hypervectors
 
 
 ## src/singularity_ext.rs
@@ -3418,6 +2286,966 @@ impl Singularity {
     pub fn clear_similarity_cache(&self);
     pub fn update_metadata(&mut self, id: &str, metadata: HashMap<String, serde_json::Value>) -> Result<()>;
     pub fn find_similar_filtered(&self, query: &HVec10240, top_k: usize, filter: &MetadataFilter) -> Arc<[(String, f32)]>;
+}
+```
+
+
+
+## src/semantic_triples.rs
+
+### SemanticTriple
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct SemanticTriple {
+    pub subject: String,
+    pub predicate: String,
+    pub object: String,
+}
+```
+
+A semantic triple representing a discrete fact.
+
+### impl SemanticTriple
+
+```rust
+impl SemanticTriple {
+    pub fn new(subject: impl Trait, predicate: impl Trait, object: impl Trait) -> Self;
+    pub fn to_sentence(&self) -> String;
+}
+```
+
+
+### StructuredMemoryPayload
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StructuredMemoryPayload {
+    pub raw_summary: String,
+    pub triples: Vec<SemanticTriple>,
+}
+```
+
+A structured memory payload that can be stored in a `Concept`'s metadata.
+
+### impl StructuredMemoryPayload
+
+```rust
+impl StructuredMemoryPayload {
+    pub fn to_context_string(&self) -> String;
+}
+```
+
+
+
+## src/retrieval/mod.rs
+
+### bm25::{Bm25Config, Bm25Index}
+
+```rust
+pub use bm25::{Bm25Config, Bm25Index};
+```
+
+
+### hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores}
+
+```rust
+pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores};
+```
+
+
+
+## src/retrieval/hybrid.rs
+
+### compute_weights
+
+```rust
+pub fn compute_weights(token_count: usize) -> (f32, f32)
+```
+
+Compute query-length-dependent weights for hybrid retrieval.
+
+Returns (keyword_weight, semantic_weight) based on token count.
+
+| Query Tokens | Keyword | Semantic | Rationale |
+|-------------|---------|----------|-----------|
+| 1-2 | 0.9 | 0.1 | Exact match dominates |
+| 3-4 | 0.7 | 0.3 | Keyword still strong |
+| 5-8 | 0.4 | 0.6 | Semantic takes over |
+| 9+ | 0.2 | 0.8 | Full semantic mode |
+
+### normalize_scores
+
+```rust
+pub fn normalize_scores(scores: &[(String, f32)]) -> Vec<(String, f32)>
+```
+
+Normalize scores to [0, 1] range using min-max normalization.
+
+If all scores are equal, returns 0.5 for all.
+
+### merge_results
+
+```rust
+pub fn merge_results(bm25_results: &[(String, f32)], hdc_results: &[(String, f32)], weights: (f32, f32)) -> Vec<(String, f32)>
+```
+
+Merge BM25 and HDC results with given weights.
+
+Takes two result sets (from BM25 and HDC), normalizes scores,
+and combines them using weighted sum.
+
+Duplicate IDs are merged by taking the maximum combined score.
+
+### HybridMode
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum HybridMode {
+    Auto,
+    SemanticOnly,
+    KeywordOnly,
+    Custom(f32),
+}
+```
+
+Hybrid retrieval mode.
+
+### HybridConfig
+
+```rust
+#[derive(Debug, Clone)]
+pub struct HybridConfig {
+    pub mode: HybridMode,
+    pub min_score: f32,
+}
+```
+
+Configuration for hybrid retrieval.
+
+### impl Default for HybridConfig
+
+```rust
+impl Default for HybridConfig {
+}
+```
+
+
+
+## src/retrieval/bm25.rs
+
+### Bm25Config
+
+```rust
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct Bm25Config {
+    pub k1: f32,
+    pub b: f32,
+}
+```
+
+Configuration for BM25 ranking algorithm.
+
+### impl Default for Bm25Config
+
+```rust
+impl Default for Bm25Config {
+}
+```
+
+
+### Bm25Index
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct Bm25Index {
+}
+```
+
+BM25-based document index for keyword search.
+
+### impl Bm25Index
+
+```rust
+impl Bm25Index {
+    pub fn new() -> Self;
+    pub fn with_config(config: Bm25Config) -> Self;
+    pub fn add_document<T: AsRef>(&mut self, id: &str, tokens: &[T]);
+    pub fn remove_document(&mut self, id: &str);
+    pub fn search<T: AsRef>(&self, query_tokens: &[T], top_k: usize) -> Vec<(String, f32)>;
+    pub fn clear(&mut self);
+    pub fn len(&self) -> usize;
+    pub fn is_empty(&self) -> bool;
+    pub fn avg_doc_length(&self) -> f32;
+}
+```
+
+
+
+## src/persistence_migrations.rs
+
+### impl Persistence
+
+```rust
+impl Persistence {
+}
+```
+
+
+
+## src/export_payload/export_payload_tests.rs
+
+
+## src/hyperdim_simd.rs
+
+
+## src/export_payload.rs
+
+### impl From<serde_json::Value> for BinaryMetadataValue
+
+```rust
+impl From<serde_json::Value> for BinaryMetadataValue {
+}
+```
+
+
+### impl From<BinaryMetadataValue> for serde_json::Value
+
+```rust
+impl From<BinaryMetadataValue> for serde_json::Value {
+}
+```
+
+
+### impl From<crate::singularity::Concept> for BinaryConcept
+
+```rust
+impl From<crate::singularity::Concept> for BinaryConcept {
+}
+```
+
+
+### impl BinaryConcept
+
+```rust
+impl BinaryConcept {
+}
+```
+
+
+### impl From<ExportPayload> for BinaryExportPayload
+
+```rust
+impl From<ExportPayload> for BinaryExportPayload {
+}
+```
+
+
+### impl BinaryExportPayload
+
+```rust
+impl BinaryExportPayload {
+}
+```
+
+
+
+## src/framework_builder.rs
+
+### FrameworkConfig
+
+```rust
+#[derive(Clone, Debug)]
+pub struct FrameworkConfig {
+    pub reservoir_size: usize,
+    pub reservoir_input_size: usize,
+    pub chaos_strength: f32,
+    pub enable_persistence: bool,
+    pub max_concepts: Option<usize>,
+    pub max_associations_per_concept: Option<usize>,
+    pub connection_pool_size: usize,
+    pub max_probe_top_k: usize,
+    pub max_metadata_bytes: Option<usize>,
+    pub max_cached_top_k: usize,
+    pub max_batch_size: usize,
+    pub max_sequence_length: usize,
+}
+```
+
+Runtime configuration for [`ChaoticSemanticFramework`], tuned via [`FrameworkBuilder`].
+
+### impl Default for FrameworkConfig
+
+```rust
+impl Default for FrameworkConfig {
+}
+```
+
+
+### FrameworkStats
+
+```rust
+#[derive(Debug, Clone)]
+pub struct FrameworkStats {
+    pub concept_count: usize,
+    pub db_size_bytes: Option<u64>,
+}
+```
+
+Framework statistics
+
+### FrameworkBuilder
+
+```rust
+pub struct FrameworkBuilder {
+}
+```
+
+Builder for ChaoticSemanticFramework
+
+### impl FrameworkBuilder
+
+```rust
+impl FrameworkBuilder {
+    pub fn with_reservoir_size(self, size: usize) -> Self;
+    pub fn with_reservoir_input_size(self, size: usize) -> Self;
+    pub fn with_chaos_strength(self, strength: f32) -> Self;
+    pub fn with_max_concepts(self, max_concepts: usize) -> Self;
+    pub fn with_max_associations_per_concept(self, max_associations: usize) -> Self;
+    pub fn with_concept_cache_size(self, size: usize) -> Self;
+    pub fn with_connection_pool_size(self, pool_size: usize) -> Self;
+    pub fn with_max_probe_top_k(self, max_probe_top_k: usize) -> Self;
+    pub fn with_max_metadata_bytes(self, max_metadata_bytes: usize) -> Self;
+    pub fn with_max_cached_top_k(self, max_cached_top_k: usize) -> Self;
+    pub fn with_max_batch_size(self, max_batch_size: usize) -> Self;
+    pub fn with_max_sequence_length(self, max_sequence_length: usize) -> Self;
+    pub fn with_version_retention(self, retention: usize) -> Self;
+    pub fn with_local_db(self, path: impl Trait) -> Self;
+    pub fn with_turso(self, url: impl Trait, token: impl Trait) -> Self;
+    pub fn without_persistence(self) -> Self;
+    pub fn without_persistence(self) -> Self;
+    pub fn build(self) -> Result<ChaoticSemanticFramework>;
+}
+```
+
+
+
+## src/cli/git_local.rs
+
+### resolve_git_local_path
+
+```rust
+pub fn resolve_git_local_path() -> Option<PathBuf>
+```
+
+Resolve the git-local database path for the current repository.
+
+Uses `git rev-parse --git-dir` to find the .git directory and returns
+the path `.git/memory-index/csm.db` for storing the memory index.
+
+#### Returns
+
+- `Some(path)` if inside a git repository, with the path to `.git/memory-index/csm.db`
+- `None` if not inside a git repository or git is not available
+
+#### Example
+
+```
+use chaotic_semantic_memory::cli::git_local::resolve_git_local_path;
+// This test runs in git repo environments
+let path = resolve_git_local_path();
+// In a git repo, should return Some path
+assert!(path.is_some() || path.is_none()); // Always passes, documents behavior
+```
+
+### ensure_git_local_dir
+
+```rust
+pub fn ensure_git_local_dir(path: &Path) -> std::io::Result<()>
+```
+
+Ensure the git-local storage directory exists.
+
+Creates the `.git/memory-index/` directory if it doesn't exist.
+
+#### Errors
+
+Returns an error if the directory cannot be created.
+
+
+## src/cli/args.rs
+
+### CliArgs
+
+```rust
+#[derive(Parser, Debug)]
+pub struct CliArgs {
+    pub command: Commands,
+    pub verbose: u8,
+    pub database: Option<PathBuf>,
+    pub git_local: bool,
+    pub index_path: Option<PathBuf>,
+    pub output_format: OutputFormat,
+}
+```
+
+
+### OutputFormat
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum OutputFormat {
+    Json,
+    Table,
+    Quiet,
+}
+```
+
+
+### Commands
+
+```rust
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    Inject(InjectArgs),
+    Probe(ProbeArgs),
+    Query(QueryArgs),
+    Associate(AssociateArgs),
+    Export(ExportArgs),
+    Import(ImportArgs),
+    Version(VersionArgs),
+    Completions(CompletionsArgs),
+    IndexJsonl(IndexJsonlArgs),
+    IndexDir(IndexDirArgs),
+}
+```
+
+
+### InjectArgs
+
+```rust
+#[derive(Args, Debug, Clone)]
+pub struct InjectArgs {
+    pub concept_id: String,
+    pub from_file: Option<PathBuf>,
+    pub vector_source: VectorSource,
+    pub metadata: Option<String>,
+}
+```
+
+
+### VectorSource
+
+```rust
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum VectorSource {
+    Random,
+    File,
+    Stdin,
+}
+```
+
+
+### ProbeArgs
+
+```rust
+#[derive(Args, Debug, Clone)]
+pub struct ProbeArgs {
+    pub concept_id: String,
+    pub top_k: usize,
+    pub threshold: Option<f64>,
+}
+```
+
+
+### QueryArgs
+
+```rust
+#[derive(Args, Debug, Clone)]
+pub struct QueryArgs {
+    pub text: String,
+    pub top_k: usize,
+    pub min_score: f64,
+    pub code_aware: bool,
+    pub compact: bool,
+    pub semantic_only: bool,
+    pub keyword_only: bool,
+    pub keyword_weight: Option<f64>,
+}
+```
+
+Arguments for text-based similarity query.
+
+### AssociateArgs
+
+```rust
+#[derive(Args, Debug, Clone)]
+pub struct AssociateArgs {
+    pub source_id: String,
+    pub target_id: String,
+    pub strength: f64,
+}
+```
+
+
+### ExportFormat
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ExportFormat {
+    Json,
+    Binary,
+}
+```
+
+
+### ExportArgs
+
+```rust
+#[derive(Args, Debug, Clone)]
+pub struct ExportArgs {
+    pub output: PathBuf,
+    pub format: ExportFormat,
+}
+```
+
+
+### ImportFormat
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ImportFormat {
+    Json,
+    Binary,
+    Auto,
+}
+```
+
+
+### ImportArgs
+
+```rust
+#[derive(Args, Debug, Clone)]
+pub struct ImportArgs {
+    pub input: PathBuf,
+    pub format: ImportFormat,
+    pub merge: bool,
+}
+```
+
+
+### VersionArgs
+
+```rust
+#[derive(Args, Debug, Clone)]
+pub struct VersionArgs {
+    pub detailed: bool,
+}
+```
+
+
+### CompletionsArgs
+
+```rust
+#[derive(Args, Debug, Clone)]
+pub struct CompletionsArgs {
+    pub shell: clap_complete::Shell,
+    pub output: Option<PathBuf>,
+}
+```
+
+
+### IndexJsonlArgs
+
+```rust
+#[derive(Args, Debug, Clone)]
+pub struct IndexJsonlArgs {
+    pub file: PathBuf,
+    pub field: String,
+    pub id_field: Option<String>,
+    pub tag_field: Option<String>,
+    pub code_aware: bool,
+}
+```
+
+Arguments for indexing JSONL files.
+
+### IndexDirArgs
+
+```rust
+#[derive(Args, Debug, Clone)]
+pub struct IndexDirArgs {
+    pub glob: Vec<String>,
+    pub heading_level: usize,
+    pub code_aware: bool,
+}
+```
+
+Arguments for indexing Markdown directory.
+
+
+## src/cli/error.rs
+
+### CliError
+
+```rust
+#[derive(Error, Debug)]
+pub enum CliError {
+    Config(String),
+    Database(String),
+    Input(String),
+    Output(String),
+    Validation(String),
+    Persistence(String),
+    Memory(MemoryError),
+    Io(std::io::Error),
+    Other(String),
+}
+```
+
+
+### impl From<anyhow::Error> for CliError
+
+```rust
+impl From<anyhow::Error> for CliError {
+}
+```
+
+
+### Result
+
+```rust
+pub type Result<T> = std::result::Result<T, CliError>
+```
+
+
+### ExitCode
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExitCode {
+    Success,
+    ConfigError,
+    DatabaseError,
+    InputError,
+    OutputError,
+    ValidationError,
+    MemoryError,
+    IoError,
+    UnknownError,
+}
+```
+
+
+### impl From<&CliError> for ExitCode
+
+```rust
+impl From<&CliError> for ExitCode {
+}
+```
+
+
+### impl From<CliError> for ExitCode
+
+```rust
+impl From<CliError> for ExitCode {
+}
+```
+
+
+### impl CliError
+
+```rust
+impl CliError {
+    pub fn exit_code(&self) -> i32;
+}
+```
+
+
+### impl ExitCode
+
+```rust
+impl ExitCode {
+    pub fn as_i32(self) -> i32;
+}
+```
+
+
+
+## src/cli/commands/query.rs
+
+### run_query
+
+```rust
+pub fn run_query(args: QueryArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
+```
+
+
+
+## src/cli/commands/associate.rs
+
+### run_associate
+
+```rust
+pub fn run_associate(args: AssociateArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
+```
+
+
+### run_associate_batch
+
+```rust
+pub fn run_associate_batch(associations: Vec<(String, String, f64)>, db_path: Option<&Path>, format: OutputFormat, continue_on_error: bool) -> Result<()>
+```
+
+
+
+## src/cli/commands/export.rs
+
+### run_export
+
+```rust
+pub fn run_export(args: ExportArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
+```
+
+
+
+## src/cli/commands/probe.rs
+
+### run_probe
+
+```rust
+pub fn run_probe(args: ProbeArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
+```
+
+
+### run_probe_with_vector
+
+```rust
+pub fn run_probe_with_vector(query_vector: HVec10240, top_k: usize, threshold: Option<f64>, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
+```
+
+
+
+## src/cli/commands/import.rs
+
+### run_import
+
+```rust
+pub fn run_import(args: ImportArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
+```
+
+
+
+## src/cli/commands/completions.rs
+
+### run_completions
+
+```rust
+pub fn run_completions(args: CompletionsArgs) -> Result<()>
+```
+
+
+
+## src/cli/commands/inject.rs
+
+### run_inject
+
+```rust
+pub fn run_inject(args: InjectArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
+```
+
+
+
+## src/cli/commands/mod.rs
+
+### associate::run_associate
+
+```rust
+pub use associate::run_associate;
+```
+
+
+### completions::run_completions
+
+```rust
+pub use completions::run_completions;
+```
+
+
+### export::run_export
+
+```rust
+pub use export::run_export;
+```
+
+
+### import::run_import
+
+```rust
+pub use import::run_import;
+```
+
+
+### index_dir::run_index_dir
+
+```rust
+pub use index_dir::run_index_dir;
+```
+
+
+### index_jsonl::run_index_jsonl
+
+```rust
+pub use index_jsonl::run_index_jsonl;
+```
+
+
+### inject::run_inject
+
+```rust
+pub use inject::run_inject;
+```
+
+
+### probe::run_probe
+
+```rust
+pub use probe::run_probe;
+```
+
+
+### query::run_query
+
+```rust
+pub use query::run_query;
+```
+
+
+### print_success
+
+```rust
+pub fn print_success(msg: &str, format: OutputFormat)
+```
+
+
+### print_error
+
+```rust
+pub fn print_error(msg: &str)
+```
+
+
+### print_warning
+
+```rust
+pub fn print_warning(msg: &str, format: OutputFormat)
+```
+
+
+### truncate_preview
+
+```rust
+pub fn truncate_preview(s: &str, max_chars: usize) -> String
+```
+
+Truncate a string to `max_chars` characters, appending "..." if truncated.
+
+Uses `char_indices` to avoid panicking on multi-byte UTF-8 boundaries.
+
+### create_framework
+
+```rust
+pub fn create_framework(db_path: Option<&std::path::Path>) -> Result<ChaoticSemanticFramework>
+```
+
+
+
+## src/cli/commands/index_jsonl.rs
+
+### run_index_jsonl
+
+```rust
+pub fn run_index_jsonl(args: IndexJsonlArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
+```
+
+
+
+## src/cli/commands/index_dir.rs
+
+### run_index_dir
+
+```rust
+pub fn run_index_dir(args: IndexDirArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
+```
+
+
+### MarkdownChunk
+
+```rust
+#[derive(Debug, Clone)]
+pub struct MarkdownChunk {
+    pub heading: String,
+    pub level: usize,
+    pub content: String,
+}
+```
+
+A chunk of markdown content.
+
+### chunk_by_heading
+
+```rust
+pub fn chunk_by_heading(content: &str, min_level: usize) -> Vec<MarkdownChunk>
+```
+
+Chunk markdown content by heading boundaries.
+
+Only chunks at headings >= min_level (default 2 for ##).
+Heading level 1 (#) is typically the document title and skipped.
+
+
+## src/cli/mod.rs
+
+### args::*
+
+```rust
+pub use args::*;
+```
+
+
+### commands::{run_associate, run_completions, run_export, run_import, run_index_dir, run_index_jsonl, run_inject, run_probe, run_query}
+
+```rust
+pub use commands::{run_associate, run_completions, run_export, run_import, run_index_dir, run_index_jsonl, run_inject, run_probe, run_query};
+```
+
+
+### error::{CliError, ExitCode, Result}
+
+```rust
+pub use error::{CliError, ExitCode, Result};
+```
+
+
+### git_local::{ensure_git_local_dir, resolve_git_local_path}
+
+```rust
+pub use git_local::{ensure_git_local_dir, resolve_git_local_path};
+```
+
+
+
+## src/framework_bridge.rs
+
+### impl ChaoticSemanticFramework
+
+```rust
+impl ChaoticSemanticFramework {
+    pub fn probe_bridge_text(&self, query: &str, top_k: usize, bridge: &BridgeRetrieval) -> Result<Vec<BridgeHit>>;
+    pub fn probe_bridge_text_with_reranker(&self, query: &str, top_k: usize, bridge: &BridgeRetrieval, reranker: &dyn Trait) -> Result<Vec<BridgeHit>>;
+    pub fn probe_bridge_text_filtered(&self, query: &str, top_k: usize, bridge: &BridgeRetrieval, filter: &MetadataFilter) -> Result<Vec<BridgeHit>>;
+    pub fn memory_packet_text(&self, query: &str, top_k: usize, bridge: &BridgeRetrieval) -> Result<MemoryPacket>;
+    pub fn memory_packet_text_with_reranker(&self, query: &str, top_k: usize, bridge: &BridgeRetrieval, reranker: &dyn Trait) -> Result<MemoryPacket>;
 }
 ```
 
@@ -3500,3 +3328,178 @@ Priority order:
 ```rust
 pub fn run_async(args: CliArgs) -> Result<((), OutputFormat), CliError>
 ```
+
+
+
+## src/graph_traversal.rs
+
+### TraversalConfig
+
+```rust
+#[derive(Debug, Clone)]
+pub struct TraversalConfig {
+    pub max_depth: usize,
+    pub min_strength: f32,
+    pub max_results: usize,
+}
+```
+
+Configuration for graph traversal operations.
+
+### impl Default for TraversalConfig
+
+```rust
+impl Default for TraversalConfig {
+}
+```
+
+
+### impl Singularity
+
+```rust
+impl Singularity {
+    pub fn neighbors(&self, id: &str, min_strength: f32) -> Vec<(String, f32)>;
+    pub fn incoming_associations(&self, id: &str) -> Vec<(&str, f32)>;
+    pub fn bfs(&self, start: &str, config: &TraversalConfig) -> Result<Vec<(String, u32)>>;
+    pub fn shortest_path(&self, from: &str, to: &str, config: &TraversalConfig) -> Result<Option<Vec<String>>>;
+    pub fn shortest_path_hops(&self, from: &str, to: &str, config: &TraversalConfig) -> Result<Option<Vec<String>>>;
+}
+```
+
+
+
+## src/singularity_cache.rs
+
+### impl QueryCache
+
+```rust
+impl QueryCache {
+}
+```
+
+
+### CacheMetricsSnapshot
+
+```rust
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CacheMetricsSnapshot {
+    pub cache_hits_total: u64,
+    pub cache_misses_total: u64,
+    pub cache_evictions_total: u64,
+}
+```
+
+
+### impl CacheMetrics
+
+```rust
+impl CacheMetrics {
+}
+```
+
+
+
+## src/encoder.rs
+
+### TextEncoderConfig
+
+```rust
+#[derive(Debug, Clone)]
+pub struct TextEncoderConfig {
+    pub position_stride: usize,
+    pub ngram_size: Option<usize>,
+    pub lowercase: bool,
+    pub code_aware: bool,
+}
+```
+
+Configuration for the text encoder.
+
+### impl Default for TextEncoderConfig
+
+```rust
+impl Default for TextEncoderConfig {
+}
+```
+
+
+### TextEncoder
+
+```rust
+#[derive(Debug, Clone)]
+pub struct TextEncoder {
+}
+```
+
+Deterministic text-to-hypervector encoder using HDC principles.
+
+Produces consistent `HVec10240` vectors from text input without external dependencies.
+The encoding is:
+- **Deterministic**: Same input always produces same output
+- **Similarity-preserving**: Similar texts produce similar vectors
+- **WASM-compatible**: No external dependencies
+
+### impl Default for TextEncoder
+
+```rust
+impl Default for TextEncoder {
+}
+```
+
+
+### impl TextEncoder
+
+```rust
+impl TextEncoder {
+    pub fn new() -> Self;
+    pub fn with_config(config: TextEncoderConfig) -> Self;
+    pub fn new_code_aware() -> Self;
+    pub fn config(&self) -> &TextEncoderConfig;
+    pub fn encode(&self, text: &str) -> HVec10240;
+    pub fn encode_with_ngrams(&self, text: &str, n: usize) -> HVec10240;
+    pub fn tokenize(text: &str, code_aware: bool, lowercase: bool) -> Vec<String>;
+}
+```
+
+
+
+## src/bundle.rs
+
+### BundleAccumulator
+
+```rust
+#[derive(Debug, Clone)]
+pub struct BundleAccumulator {
+}
+```
+
+Incremental bundle accumulator for streaming/sliding-window memory.
+
+Maintains signed bit counts for efficient add/remove operations.
+Finalize applies majority threshold to produce a bundled hypervector.
+
+### impl Default for BundleAccumulator
+
+```rust
+impl Default for BundleAccumulator {
+}
+```
+
+
+### impl BundleAccumulator
+
+```rust
+impl BundleAccumulator {
+    pub fn new() -> Self;
+    pub fn add(&mut self, hv: &HVec10240);
+    pub fn remove(&mut self, hv: &HVec10240);
+    pub fn try_remove(&mut self, hv: &HVec10240) -> Result<()>;
+    pub fn finalize(&self) -> HVec10240;
+    pub fn len(&self) -> u32;
+    pub fn is_empty(&self) -> bool;
+    pub fn clear(&mut self);
+}
+```
+
+
+

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2,34 +2,34 @@
 
 > AI memory systems with hyperdimensional vectors and chaotic reservoirs
 
-**Version:** 0.3.4
+**Version:** 0.3.5
 **License:** MIT
 **Repository:** https://github.com/d-o-hub/chaotic_semantic_memory
 **Homepage:** https://github.com/d-o-hub/chaotic_semantic_memory
 **Keywords:** ai, memory, hypervector, reservoir, wasm
 **Dependencies:**
-- rand (0.10.1)
-- clap_complete (4.5.42)
-- colored (2.2.0)
-- base64 (0.22)
 - glob (0.3.2)
-- tracing (0.1.41)
-- serde (1.0.219) [features: derive]
-- rand_chacha (0.10.0)
-- anyhow (1.0.102)
-- clap (4.5.60) [features: derive, env, string]
-- serde_json (1.0.149)
-- tracing-subscriber (0.3.19)
 - bincode (1.3.3)
 - thiserror (2.0.11)
+- rand (0.10.1)
+- clap (4.5.60) [features: derive, env, string]
+- tracing-subscriber (0.3.19)
+- serde_json (1.0.149)
+- rand_chacha (0.10.0)
+- base64 (0.22)
+- clap_complete (4.5.42)
+- anyhow (1.0.102)
+- colored (2.2.0)
+- tracing (0.1.41)
+- serde (1.0.219) [features: derive]
 **Features:**
+- wasm: []
+- persistence: [dep:libsql]
 - default: [cli, persistence, parallel]
 - cli: [dep:clap, dep:clap_complete, dep:anyhow, dep:colored, dep:glob]
-- wasm: []
 - parallel: [dep:rayon]
-- persistence: [dep:libsql]
 
-Generated: 2026-04-28 08:44:41 UTC  
+Generated: 2026-04-28 09:01:49 UTC  
 Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 
 ## Table of Contents

--- a/llms.txt
+++ b/llms.txt
@@ -2,34 +2,34 @@
 
 > AI memory systems with hyperdimensional vectors and chaotic reservoirs
 
-**Version:** 0.3.4
+**Version:** 0.3.5
 **License:** MIT
 **Repository:** https://github.com/d-o-hub/chaotic_semantic_memory
 **Homepage:** https://github.com/d-o-hub/chaotic_semantic_memory
 **Keywords:** ai, memory, hypervector, reservoir, wasm
 **Dependencies:**
-- rand (0.10.1)
-- clap_complete (4.5.42)
-- colored (2.2.0)
-- base64 (0.22)
 - glob (0.3.2)
-- tracing (0.1.41)
-- serde (1.0.219) [features: derive]
-- rand_chacha (0.10.0)
-- anyhow (1.0.102)
-- clap (4.5.60) [features: derive, env, string]
-- serde_json (1.0.149)
-- tracing-subscriber (0.3.19)
 - bincode (1.3.3)
 - thiserror (2.0.11)
+- rand (0.10.1)
+- clap (4.5.60) [features: derive, env, string]
+- tracing-subscriber (0.3.19)
+- serde_json (1.0.149)
+- rand_chacha (0.10.0)
+- base64 (0.22)
+- clap_complete (4.5.42)
+- anyhow (1.0.102)
+- colored (2.2.0)
+- tracing (0.1.41)
+- serde (1.0.219) [features: derive]
 **Features:**
+- wasm: []
+- persistence: [dep:libsql]
 - default: [cli, persistence, parallel]
 - cli: [dep:clap, dep:clap_complete, dep:anyhow, dep:colored, dep:glob]
-- wasm: []
 - parallel: [dep:rayon]
-- persistence: [dep:libsql]
 
-Generated: 2026-04-28 08:44:41 UTC  
+Generated: 2026-04-28 09:01:49 UTC  
 Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 
 ## Core Documentation
@@ -944,7 +944,7 @@ Contributions are welcome! Please read our [Contributing Guide](CONTRIBUTING.md)
 ```toml
 [package]
 name = "chaotic_semantic_memory"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 rust-version = "1.85"
 description = "AI memory systems with hyperdimensional vectors and chaotic reservoirs"

--- a/llms.txt
+++ b/llms.txt
@@ -8,28 +8,28 @@
 **Homepage:** https://github.com/d-o-hub/chaotic_semantic_memory
 **Keywords:** ai, memory, hypervector, reservoir, wasm
 **Dependencies:**
-- serde_json (1.0.149)
-- clap (4.5.60) [features: derive, env, string]
-- tracing (0.1.41)
 - rand (0.10.1)
-- bincode (1.3.3)
-- base64 (0.22)
-- tracing-subscriber (0.3.19)
-- anyhow (1.0.102)
-- glob (0.3.2)
+- clap_complete (4.5.42)
 - colored (2.2.0)
+- base64 (0.22)
+- glob (0.3.2)
+- tracing (0.1.41)
 - serde (1.0.219) [features: derive]
 - rand_chacha (0.10.0)
-- clap_complete (4.5.42)
+- anyhow (1.0.102)
+- clap (4.5.60) [features: derive, env, string]
+- serde_json (1.0.149)
+- tracing-subscriber (0.3.19)
+- bincode (1.3.3)
 - thiserror (2.0.11)
 **Features:**
-- parallel: [dep:rayon]
-- cli: [dep:clap, dep:clap_complete, dep:anyhow, dep:colored, dep:glob]
-- persistence: [dep:libsql]
-- wasm: []
 - default: [cli, persistence, parallel]
+- cli: [dep:clap, dep:clap_complete, dep:anyhow, dep:colored, dep:glob]
+- wasm: []
+- parallel: [dep:rayon]
+- persistence: [dep:libsql]
 
-Generated: 2026-04-28 05:25:24 UTC
+Generated: 2026-04-28 08:44:41 UTC  
 Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 
 ## Core Documentation
@@ -40,16 +40,9 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 
 ## Table of Contents
 
-### src/framework_bridge.rs
+### src/reservoir_inertial.rs
 
-- impl ChaoticSemanticFramework
-
-### src/semantic_triples.rs
-
-- pub struct SemanticTriple
-- impl SemanticTriple
-- pub struct StructuredMemoryPayload
-- impl StructuredMemoryPayload
+- impl Reservoir
 
 ### src/reservoir.rs
 
@@ -60,10 +53,14 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub struct ChaoticReservoir
 - impl ChaoticReservoir
 
-### src/concept_builder.rs
+### src/framework_events.rs
 
-- pub struct ConceptBuilder
-- impl ConceptBuilder
+- pub enum MemoryEvent
+- impl ChaoticSemanticFramework
+
+### src/reservoir_sparse.rs
+
+- impl SparseWeights
 
 ### src/hyperdim.rs
 
@@ -75,56 +72,57 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - impl Deserialize for HVec10240
 - pub use crate::bundle::BundleAccumulator
 
-### src/bundle.rs
-
-- pub struct BundleAccumulator
-- impl Default for BundleAccumulator
-- impl BundleAccumulator
-
-### src/metadata_filter.rs
-
-- pub enum MetadataFilter
-- impl MetadataFilter
-- impl ops::Not for MetadataFilter
-
-### src/persistence.rs
-
-- pub struct Persistence
-- pub struct ConceptVersion
-- impl Persistence
-
-### src/reservoir_sparse.rs
-
-- impl SparseWeights
-
-### src/singularity_ttl.rs
-
-- impl Default for Concept
-- impl Singularity
-
-### src/singularity_cache.rs
-
-- impl QueryCache
-- pub struct CacheMetricsSnapshot
-- impl CacheMetrics
-
 ### src/framework_ttl.rs
 
 - impl crate::framework::ChaoticSemanticFramework
 
-### src/framework_builder.rs
+### src/concept_builder.rs
 
-- pub struct FrameworkConfig
-- impl Default for FrameworkConfig
-- pub struct FrameworkStats
-- pub struct FrameworkBuilder
-- impl FrameworkBuilder
+- pub struct ConceptBuilder
+- impl ConceptBuilder
 
-### src/graph_traversal.rs
+### src/persistence_ops.rs
 
-- pub struct TraversalConfig
-- impl Default for TraversalConfig
-- impl Singularity
+- impl Persistence
+
+### src/framework.rs
+
+- pub struct ChaoticSemanticFramework
+- pub struct FrameworkMetrics
+- pub struct FrameworkMetricsSnapshot
+- impl FrameworkMetrics
+- impl ChaoticSemanticFramework
+
+### src/hyperdim_batch.rs
+
+- pub fn batch_cosine_similarity
+
+### src/framework_validation.rs
+
+- impl ChaoticSemanticFramework
+
+### src/semantic_bridge.rs
+
+- pub struct CanonicalConcept
+- impl CanonicalConcept
+- pub struct BridgeConfig
+- impl Default for BridgeConfig
+- pub struct ScoreBreakdown
+- impl ScoreBreakdown
+- pub struct BridgeHit
+- pub struct MemoryPacket
+- impl MemoryPacket
+- pub trait SemanticReranker
+- pub struct ConceptGraph
+- impl ConceptGraph
+
+### src/framework_ops.rs
+
+- impl ChaoticSemanticFramework
+
+### src/bridge_persistence.rs
+
+- impl Persistence
 
 ### src/singularity_retrieval.rs
 
@@ -136,222 +134,10 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - impl Default for RetrievalConfig
 - impl Singularity
 
-### src/cli/commands/index_dir.rs
-
-- pub fn run_index_dir
-- pub struct MarkdownChunk
-- pub fn chunk_by_heading
-
-### src/cli/commands/associate.rs
-
-- pub fn run_associate
-- pub fn run_associate_batch
-
-### src/cli/commands/import.rs
-
-- pub fn run_import
-
-### src/cli/commands/inject.rs
-
-- pub fn run_inject
-
-### src/cli/commands/probe.rs
-
-- pub fn run_probe
-- pub fn run_probe_with_vector
-
-### src/cli/commands/index_jsonl.rs
-
-- pub fn run_index_jsonl
-
-### src/cli/commands/query.rs
-
-- pub fn run_query
-
-### src/cli/commands/export.rs
-
-- pub fn run_export
-
-### src/cli/commands/mod.rs
-
-- pub mod associate
-- pub mod completions
-- pub mod export
-- pub mod import
-- pub mod index_dir
-- pub mod index_jsonl
-- pub mod inject
-- pub mod probe
-- pub mod query
-- pub use associate::run_associate
-- pub use completions::run_completions
-- pub use export::run_export
-- pub use import::run_import
-- pub use index_dir::run_index_dir
-- pub use index_jsonl::run_index_jsonl
-- pub use inject::run_inject
-- pub use probe::run_probe
-- pub use query::run_query
-- pub fn print_success
-- pub fn print_error
-- pub fn print_warning
-- pub fn truncate_preview
-- pub fn create_framework
-
-### src/cli/commands/completions.rs
-
-- pub fn run_completions
-
-### src/cli/git_local.rs
-
-- pub fn resolve_git_local_path
-- pub fn ensure_git_local_dir
-
-### src/cli/error.rs
-
-- pub enum CliError
-- impl From for CliError
-- pub type Result
-- pub enum ExitCode
-- impl From for ExitCode
-- impl From for ExitCode
-- impl CliError
-- impl ExitCode
-
-### src/cli/args.rs
-
-- pub struct CliArgs
-- pub enum OutputFormat
-- pub enum Commands
-- pub struct InjectArgs
-- pub enum VectorSource
-- pub struct ProbeArgs
-- pub struct QueryArgs
-- pub struct AssociateArgs
-- pub enum ExportFormat
-- pub struct ExportArgs
-- pub enum ImportFormat
-- pub struct ImportArgs
-- pub struct VersionArgs
-- pub struct CompletionsArgs
-- pub struct IndexJsonlArgs
-- pub struct IndexDirArgs
-
-### src/cli/mod.rs
-
-- pub mod args
-- pub mod commands
-- pub mod error
-- pub mod git_local
-- pub use args::*
-- pub use commands::{run_associate, run_completions, run_export, run_import, run_index_dir, run_index_jsonl, run_inject, run_probe, run_query}
-- pub use error::{CliError, ExitCode, Result}
-- pub use git_local::{ensure_git_local_dir, resolve_git_local_path}
-
-### src/persistence_migrations.rs
-
-- impl Persistence
-
-### src/framework_validation.rs
-
-- impl ChaoticSemanticFramework
-
-### src/persistence_ops.rs
-
-- impl Persistence
-
-### src/reservoir_inertial.rs
-
-- impl Reservoir
-
-### src/hyperdim_batch.rs
-
-- pub fn batch_cosine_similarity
-
-### src/retrieval/hybrid.rs
-
-- pub fn compute_weights
-- pub fn normalize_scores
-- pub fn merge_results
-- pub enum HybridMode
-- pub struct HybridConfig
-- impl Default for HybridConfig
-
-### src/retrieval/mod.rs
-
-- pub mod bm25
-- pub mod hybrid
-- pub use bm25::{Bm25Config, Bm25Index}
-- pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores}
-
-### src/retrieval/bm25.rs
-
-- pub struct Bm25Config
-- impl Default for Bm25Config
-- pub struct Bm25Index
-- impl Bm25Index
-
-### src/singularity.rs
-
-- pub use crate::singularity_cache::CacheMetricsSnapshot
-- pub use crate::singularity_retrieval::{CandidateSource, RetrievalConfig, RetrievalStats}
-- pub const DEFAULT_MAX_CACHED_TOP_K
-- pub struct Concept
-- pub struct SingularityConfig
-- impl Default for SingularityConfig
-- pub struct Singularity
-- impl Singularity
-- impl Default for Singularity
-- pub use crate::concept_builder::ConceptBuilder
-
-### src/framework.rs
-
-- pub struct ChaoticSemanticFramework
-- pub struct FrameworkMetrics
-- pub struct FrameworkMetricsSnapshot
-- impl FrameworkMetrics
-- impl ChaoticSemanticFramework
-
-### src/persistence_wasm.rs
+### src/persistence.rs
 
 - pub struct Persistence
 - pub struct ConceptVersion
-- impl Persistence
-
-### src/framework_ops.rs
-
-- impl ChaoticSemanticFramework
-
-### src/wasm.rs
-
-- pub fn initialize_wasm
-- pub struct WasmFramework
-- impl WasmFramework
-- pub fn random_hypervector
-- pub fn encode_text
-- pub fn cosine_similarity
-
-### src/error.rs
-
-- pub enum MemoryError
-- impl MemoryError
-- pub type Result
-
-### src/wasm_ext.rs
-
-- impl WasmFramework
-
-### src/export_payload.rs
-
-- impl From for BinaryMetadataValue
-- impl From for serde_json::Value
-- impl From for BinaryConcept
-- impl BinaryConcept
-- impl From for BinaryExportPayload
-- impl BinaryExportPayload
-
-### src/persistence_versions.rs
-
 - impl Persistence
 
 ### src/lib.rs
@@ -403,46 +189,234 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub use prelude::crate::singularity_retrieval::{CandidateSource, FilterStrategy, RetrievalConfig, RetrievalStats}
 - pub mod wasm
 
+### src/metadata_filter.rs
+
+- pub enum MetadataFilter
+- impl MetadataFilter
+- impl ops::Not for MetadataFilter
+
+### src/wasm_ext.rs
+
+- impl WasmFramework
+
+### src/singularity.rs
+
+- pub use crate::singularity_cache::CacheMetricsSnapshot
+- pub use crate::singularity_retrieval::{CandidateSource, RetrievalConfig, RetrievalStats}
+- pub const DEFAULT_MAX_CACHED_TOP_K
+- pub struct Concept
+- pub struct SingularityConfig
+- impl Default for SingularityConfig
+- pub struct Singularity
+- impl Singularity
+- impl Default for Singularity
+- pub use crate::concept_builder::ConceptBuilder
+
+### src/singularity_ttl.rs
+
+- impl Default for Concept
+- impl Singularity
+
 ### src/bridge_retrieval.rs
 
 - pub struct BridgeRetrieval
 - impl BridgeRetrieval
 
-### src/semantic_bridge.rs
+### src/persistence_wasm.rs
 
-- pub struct CanonicalConcept
-- impl CanonicalConcept
-- pub struct BridgeConfig
-- impl Default for BridgeConfig
-- pub struct ScoreBreakdown
-- impl ScoreBreakdown
-- pub struct BridgeHit
-- pub struct MemoryPacket
-- impl MemoryPacket
-- pub trait SemanticReranker
-- pub struct ConceptGraph
-- impl ConceptGraph
+- pub struct Persistence
+- pub struct ConceptVersion
+- impl Persistence
 
-### src/framework_events.rs
+### src/error.rs
 
-- pub enum MemoryEvent
-- impl ChaoticSemanticFramework
+- pub enum MemoryError
+- impl MemoryError
+- pub type Result
 
-### src/bridge_persistence.rs
+### src/persistence_versions.rs
 
 - impl Persistence
 
-### src/encoder.rs
+### src/wasm.rs
 
-- pub struct TextEncoderConfig
-- impl Default for TextEncoderConfig
-- pub struct TextEncoder
-- impl Default for TextEncoder
-- impl TextEncoder
+- pub fn initialize_wasm
+- pub struct WasmFramework
+- impl WasmFramework
+- pub fn random_hypervector
+- pub fn encode_text
+- pub fn cosine_similarity
 
 ### src/singularity_ext.rs
 
 - impl Singularity
+
+### src/semantic_triples.rs
+
+- pub struct SemanticTriple
+- impl SemanticTriple
+- pub struct StructuredMemoryPayload
+- impl StructuredMemoryPayload
+
+### src/retrieval/mod.rs
+
+- pub mod bm25
+- pub mod hybrid
+- pub use bm25::{Bm25Config, Bm25Index}
+- pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores}
+
+### src/retrieval/hybrid.rs
+
+- pub fn compute_weights
+- pub fn normalize_scores
+- pub fn merge_results
+- pub enum HybridMode
+- pub struct HybridConfig
+- impl Default for HybridConfig
+
+### src/retrieval/bm25.rs
+
+- pub struct Bm25Config
+- impl Default for Bm25Config
+- pub struct Bm25Index
+- impl Bm25Index
+
+### src/persistence_migrations.rs
+
+- impl Persistence
+
+### src/export_payload.rs
+
+- impl From for BinaryMetadataValue
+- impl From for serde_json::Value
+- impl From for BinaryConcept
+- impl BinaryConcept
+- impl From for BinaryExportPayload
+- impl BinaryExportPayload
+
+### src/framework_builder.rs
+
+- pub struct FrameworkConfig
+- impl Default for FrameworkConfig
+- pub struct FrameworkStats
+- pub struct FrameworkBuilder
+- impl FrameworkBuilder
+
+### src/cli/git_local.rs
+
+- pub fn resolve_git_local_path
+- pub fn ensure_git_local_dir
+
+### src/cli/args.rs
+
+- pub struct CliArgs
+- pub enum OutputFormat
+- pub enum Commands
+- pub struct InjectArgs
+- pub enum VectorSource
+- pub struct ProbeArgs
+- pub struct QueryArgs
+- pub struct AssociateArgs
+- pub enum ExportFormat
+- pub struct ExportArgs
+- pub enum ImportFormat
+- pub struct ImportArgs
+- pub struct VersionArgs
+- pub struct CompletionsArgs
+- pub struct IndexJsonlArgs
+- pub struct IndexDirArgs
+
+### src/cli/error.rs
+
+- pub enum CliError
+- impl From for CliError
+- pub type Result
+- pub enum ExitCode
+- impl From for ExitCode
+- impl From for ExitCode
+- impl CliError
+- impl ExitCode
+
+### src/cli/commands/query.rs
+
+- pub fn run_query
+
+### src/cli/commands/associate.rs
+
+- pub fn run_associate
+- pub fn run_associate_batch
+
+### src/cli/commands/export.rs
+
+- pub fn run_export
+
+### src/cli/commands/probe.rs
+
+- pub fn run_probe
+- pub fn run_probe_with_vector
+
+### src/cli/commands/import.rs
+
+- pub fn run_import
+
+### src/cli/commands/completions.rs
+
+- pub fn run_completions
+
+### src/cli/commands/inject.rs
+
+- pub fn run_inject
+
+### src/cli/commands/mod.rs
+
+- pub mod associate
+- pub mod completions
+- pub mod export
+- pub mod import
+- pub mod index_dir
+- pub mod index_jsonl
+- pub mod inject
+- pub mod probe
+- pub mod query
+- pub use associate::run_associate
+- pub use completions::run_completions
+- pub use export::run_export
+- pub use import::run_import
+- pub use index_dir::run_index_dir
+- pub use index_jsonl::run_index_jsonl
+- pub use inject::run_inject
+- pub use probe::run_probe
+- pub use query::run_query
+- pub fn print_success
+- pub fn print_error
+- pub fn print_warning
+- pub fn truncate_preview
+- pub fn create_framework
+
+### src/cli/commands/index_jsonl.rs
+
+- pub fn run_index_jsonl
+
+### src/cli/commands/index_dir.rs
+
+- pub fn run_index_dir
+- pub struct MarkdownChunk
+- pub fn chunk_by_heading
+
+### src/cli/mod.rs
+
+- pub mod args
+- pub mod commands
+- pub mod error
+- pub mod git_local
+- pub use args::*
+- pub use commands::{run_associate, run_completions, run_export, run_import, run_index_dir, run_index_jsonl, run_inject, run_probe, run_query}
+- pub use error::{CliError, ExitCode, Result}
+- pub use git_local::{ensure_git_local_dir, resolve_git_local_path}
+
+### src/framework_bridge.rs
+
+- impl ChaoticSemanticFramework
 
 ### src/bin/csm.rs
 
@@ -456,6 +430,32 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub fn native::handle_completions
 - pub fn native::resolve_database_path
 - pub fn native::run_async
+
+### src/graph_traversal.rs
+
+- pub struct TraversalConfig
+- impl Default for TraversalConfig
+- impl Singularity
+
+### src/singularity_cache.rs
+
+- impl QueryCache
+- pub struct CacheMetricsSnapshot
+- impl CacheMetrics
+
+### src/encoder.rs
+
+- pub struct TextEncoderConfig
+- impl Default for TextEncoderConfig
+- pub struct TextEncoder
+- impl Default for TextEncoder
+- impl TextEncoder
+
+### src/bundle.rs
+
+- pub struct BundleAccumulator
+- impl Default for BundleAccumulator
+- impl BundleAccumulator
 
 ---
 
@@ -1074,3 +1074,4 @@ wasm = []
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-O", "--enable-bulk-memory", "--enable-sign-ext"]
 ```
+

--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -2994,8 +2994,8 @@ actions:
     effects:
       inertial_reservoir_tested: true
     cost: 3
-    status: queued
-    file: tests/reservoir_tests.rs
+    status: complete
+    file: tests/reservoir_inertial_tests.rs
     description: |
       Test the inertial reservoir dynamics.
 
@@ -3021,7 +3021,7 @@ actions:
     effects:
       inertial_reservoir_benchmarked: true
     cost: 3
-    status: queued
+    status: complete
     file: benches/benchmark.rs
     description: |
       Benchmark inertial vs standard reservoir dynamics.
@@ -3134,8 +3134,8 @@ actions:
     effects:
       selectivity_aware_retrieval_tested: true
     cost: 3
-    status: queued
-    file: tests/retrieval_tests.rs
+    status: complete
+    file: tests/retrieval_selectivity_tests.rs
     description: |
       Test selectivity-aware filtered retrieval.
 

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -14,10 +14,17 @@ world_state:
   result_contract_clarified: true
   architecture_docs_two_tier: true
   architecture_docs_canonical_source: "context.yaml"
-  action_last_completed: goap_implement_2026_04_25
-  orchestrator_last_run: goap_analysis_2026_04_25
-  orchestrator_last_run_at_utc: 2026-04-25T22:00:00Z
-  ci_all_checks_passed: true
+  action_last_completed: ci_fix_release_wait_and_pages_heredoc_2026_04_28
+  orchestrator_last_run: goap_analysis_2026_04_28
+  orchestrator_last_run_at_utc: 2026-04-28T07:00:00Z
+  ci_all_checks_passed: false                  # Release + Pages + Pre-Release Gate failing
+  ci_release_workflow_blocked: true            # wait-for-ci times out (missing actions: read)
+  ci_release_workflow_fix_applied: true        # 2026-04-28: actions: read + null guards
+  ci_pages_workflow_fix_applied: true          # 2026-04-28: heredoc terminator de-indented
+  ci_pre_release_gate_failing: true            # version triad + security audit + planning
+  changelog_v033_yanked_recorded: true         # 2026-04-28: backfilled CHANGELOG
+  changelog_unreleased_section: true           # 2026-04-28: added Unreleased
+  goap_actions_md_synced: true                 # 2026-04-28: 3 queued -> complete
 
   # GitHub Actions Security Audit (2026-04-21)
   codeql_missing_permissions_fixed: true

--- a/plans/handoffs/W5_C_to_D_wasm_size_report.md
+++ b/plans/handoffs/W5_C_to_D_wasm_size_report.md
@@ -6,7 +6,7 @@
 ## Measurement
 - Command: `cargo build --target wasm32-unknown-unknown --release --features wasm`
 - Artifact: `target/wasm32-unknown-unknown/release/chaotic_semantic_memory.wasm`
-- Size: `878338` bytes (`857.75` KiB)
+- Size: `881337` bytes (`860.68` KiB)
 - Threshold: `1048576` bytes (configurable via `CSM_WASM_SIZE_MAX_BYTES`)
 
 ## Result

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d-o-hub/chaotic_semantic_memory",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "AI memory systems with hyperdimensional vectors and chaotic reservoirs - WASM bindings",
   "main": "chaotic_semantic_memory.js",
   "types": "chaotic_semantic_memory.d.ts",


### PR DESCRIPTION
## Summary

GOAP-orchestrated fixes for two recurring CI failures on `main` plus housekeeping.

### CI fixes

| Workflow | Symptom | Root cause | Fix |
|----------|---------|------------|-----|
| **Release** | Every push fails after 10 min on `wait-for-ci` step | `gh run list` requires `actions: read`, which the workflow never granted; `2>/dev/null` masked the error and the `||` fallback re-classified everything as `queued` | Add `actions: read`, surface errors, add explicit empty/null guards |
| **GitHub Pages** | Every `book/**` push fails with `syntax error: unexpected end of file` | Heredoc `<<'HTML'` had its terminator indented (broke bash) **and** that indentation also corrupted the YAML `run: \|` block scalar | Replace heredoc with quoted `printf '%s\n' …` array (no heredoc, no terminator-indent issue, valid YAML) |

### Housekeeping

- `CHANGELOG.md`: added `## [Unreleased]` section (covers PRs #126, #127 and these CI fixes) and back-filled `## [0.3.3] [YANKED]` entry per the yank intent in commit `1335079`.
- `plans/ACTIONS.md`: 3 stale `status: queued` → `complete` (inertial-reservoir tests/benches and selectivity-aware retrieval tests are all shipped). Filenames corrected to actual test files.
- `plans/GOAP_STATE.md`: recorded `action_last_completed`, CI fix flags, changelog flags, sync flag.

### Validation

- `python3 -m yaml` parses both modified workflows ✅
- `printf '%s\n'` placeholder rendering verified locally ✅
- Pre-commit clippy gate ✅
- No Rust source touched

### Follow-ups (deferred, not in this PR)

- Wave 20 disposition (status `queued` since 2026-04-12)
- Pre-Release Gate sub-checks (Version Triad / Security Audit / Planning State)
- v0.3.5 release once Release workflow is verified green on `main`