### PR TITLE
perf(singularity): optimize similarity search with fused integer scoring

### DIFF
--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "chaotic_semantic_memory"
-version = "0.3.2"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8,35 +8,42 @@
 **Homepage:** https://github.com/d-o-hub/chaotic_semantic_memory
 **Keywords:** ai, memory, hypervector, reservoir, wasm
 **Dependencies:**
-- rand_chacha (0.10.0)
-- clap (4.5.60) [features: derive, env, string]
-- tracing (0.1.41)
-- tracing-subscriber (0.3.19)
-- serde_json (1.0.149)
-- thiserror (2.0.11)
-- clap_complete (4.5.42)
-- anyhow (1.0.102)
-- bincode (1.3.3)
-- rand (0.10.1)
-- colored (2.2.0)
-- base64 (0.22)
-- glob (0.3.2)
 - serde (1.0.219) [features: derive]
+- glob (0.3.2)
+- tracing-subscriber (0.3.19)
+- base64 (0.22)
+- tracing (0.1.41)
+- clap_complete (4.5.42)
+- serde_json (1.0.149)
+- bincode (1.3.3)
+- thiserror (2.0.11)
+- rand (0.10.1)
+- clap (4.5.60) [features: derive, env, string]
+- anyhow (1.0.102)
+- rand_chacha (0.10.0)
+- colored (2.2.0)
 **Features:**
 - cli: [dep:clap, dep:clap_complete, dep:anyhow, dep:colored, dep:glob]
+- parallel: [dep:rayon]
+- default: [cli, persistence, parallel]
 - persistence: [dep:libsql]
 - wasm: []
-- default: [cli, persistence, parallel]
-- parallel: [dep:rayon]
 
-Generated: 2026-04-29 07:45:10 UTC  
+Generated: 2026-04-29 05:39:56 UTC
 Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 
 ## Table of Contents
 
-### src/reservoir_inertial.rs
+### src/framework_bridge.rs
 
-- impl Reservoir
+- impl ChaoticSemanticFramework
+
+### src/semantic_triples.rs
+
+- pub struct SemanticTriple
+- impl SemanticTriple
+- pub struct StructuredMemoryPayload
+- impl StructuredMemoryPayload
 
 ### src/reservoir.rs
 
@@ -47,14 +54,10 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub struct ChaoticReservoir
 - impl ChaoticReservoir
 
-### src/framework_events.rs
+### src/concept_builder.rs
 
-- pub enum MemoryEvent
-- impl ChaoticSemanticFramework
-
-### src/reservoir_sparse.rs
-
-- impl SparseWeights
+- pub struct ConceptBuilder
+- impl ConceptBuilder
 
 ### src/hyperdim.rs
 
@@ -66,57 +69,56 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - impl Deserialize for HVec10240
 - pub use crate::bundle::BundleAccumulator
 
+### src/bundle.rs
+
+- pub struct BundleAccumulator
+- impl Default for BundleAccumulator
+- impl BundleAccumulator
+
+### src/metadata_filter.rs
+
+- pub enum MetadataFilter
+- impl MetadataFilter
+- impl ops::Not for MetadataFilter
+
+### src/persistence.rs
+
+- pub struct Persistence
+- pub struct ConceptVersion
+- impl Persistence
+
+### src/reservoir_sparse.rs
+
+- impl SparseWeights
+
+### src/singularity_ttl.rs
+
+- impl Default for Concept
+- impl Singularity
+
+### src/singularity_cache.rs
+
+- impl QueryCache
+- pub struct CacheMetricsSnapshot
+- impl CacheMetrics
+
 ### src/framework_ttl.rs
 
 - impl crate::framework::ChaoticSemanticFramework
 
-### src/concept_builder.rs
+### src/framework_builder.rs
 
-- pub struct ConceptBuilder
-- impl ConceptBuilder
+- pub struct FrameworkConfig
+- impl Default for FrameworkConfig
+- pub struct FrameworkStats
+- pub struct FrameworkBuilder
+- impl FrameworkBuilder
 
-### src/persistence_ops.rs
+### src/graph_traversal.rs
 
-- impl Persistence
-
-### src/framework.rs
-
-- pub struct ChaoticSemanticFramework
-- pub struct FrameworkMetrics
-- pub struct FrameworkMetricsSnapshot
-- impl FrameworkMetrics
-- impl ChaoticSemanticFramework
-
-### src/hyperdim_batch.rs
-
-- pub fn batch_cosine_similarity
-
-### src/framework_validation.rs
-
-- impl ChaoticSemanticFramework
-
-### src/semantic_bridge.rs
-
-- pub struct CanonicalConcept
-- impl CanonicalConcept
-- pub struct BridgeConfig
-- impl Default for BridgeConfig
-- pub struct ScoreBreakdown
-- impl ScoreBreakdown
-- pub struct BridgeHit
-- pub struct MemoryPacket
-- impl MemoryPacket
-- pub trait SemanticReranker
-- pub struct ConceptGraph
-- impl ConceptGraph
-
-### src/framework_ops.rs
-
-- impl ChaoticSemanticFramework
-
-### src/bridge_persistence.rs
-
-- impl Persistence
+- pub struct TraversalConfig
+- impl Default for TraversalConfig
+- impl Singularity
 
 ### src/singularity_retrieval.rs
 
@@ -128,10 +130,222 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - impl Default for RetrievalConfig
 - impl Singularity
 
-### src/persistence.rs
+### src/cli/commands/index_dir.rs
+
+- pub fn run_index_dir
+- pub struct MarkdownChunk
+- pub fn chunk_by_heading
+
+### src/cli/commands/associate.rs
+
+- pub fn run_associate
+- pub fn run_associate_batch
+
+### src/cli/commands/import.rs
+
+- pub fn run_import
+
+### src/cli/commands/inject.rs
+
+- pub fn run_inject
+
+### src/cli/commands/probe.rs
+
+- pub fn run_probe
+- pub fn run_probe_with_vector
+
+### src/cli/commands/index_jsonl.rs
+
+- pub fn run_index_jsonl
+
+### src/cli/commands/query.rs
+
+- pub fn run_query
+
+### src/cli/commands/export.rs
+
+- pub fn run_export
+
+### src/cli/commands/mod.rs
+
+- pub mod associate
+- pub mod completions
+- pub mod export
+- pub mod import
+- pub mod index_dir
+- pub mod index_jsonl
+- pub mod inject
+- pub mod probe
+- pub mod query
+- pub use associate::run_associate
+- pub use completions::run_completions
+- pub use export::run_export
+- pub use import::run_import
+- pub use index_dir::run_index_dir
+- pub use index_jsonl::run_index_jsonl
+- pub use inject::run_inject
+- pub use probe::run_probe
+- pub use query::run_query
+- pub fn print_success
+- pub fn print_error
+- pub fn print_warning
+- pub fn truncate_preview
+- pub fn create_framework
+
+### src/cli/commands/completions.rs
+
+- pub fn run_completions
+
+### src/cli/git_local.rs
+
+- pub fn resolve_git_local_path
+- pub fn ensure_git_local_dir
+
+### src/cli/error.rs
+
+- pub enum CliError
+- impl From for CliError
+- pub type Result
+- pub enum ExitCode
+- impl From for ExitCode
+- impl From for ExitCode
+- impl CliError
+- impl ExitCode
+
+### src/cli/args.rs
+
+- pub struct CliArgs
+- pub enum OutputFormat
+- pub enum Commands
+- pub struct InjectArgs
+- pub enum VectorSource
+- pub struct ProbeArgs
+- pub struct QueryArgs
+- pub struct AssociateArgs
+- pub enum ExportFormat
+- pub struct ExportArgs
+- pub enum ImportFormat
+- pub struct ImportArgs
+- pub struct VersionArgs
+- pub struct CompletionsArgs
+- pub struct IndexJsonlArgs
+- pub struct IndexDirArgs
+
+### src/cli/mod.rs
+
+- pub mod args
+- pub mod commands
+- pub mod error
+- pub mod git_local
+- pub use args::*
+- pub use commands::{run_associate, run_completions, run_export, run_import, run_index_dir, run_index_jsonl, run_inject, run_probe, run_query}
+- pub use error::{CliError, ExitCode, Result}
+- pub use git_local::{ensure_git_local_dir, resolve_git_local_path}
+
+### src/persistence_migrations.rs
+
+- impl Persistence
+
+### src/framework_validation.rs
+
+- impl ChaoticSemanticFramework
+
+### src/persistence_ops.rs
+
+- impl Persistence
+
+### src/reservoir_inertial.rs
+
+- impl Reservoir
+
+### src/hyperdim_batch.rs
+
+- pub fn batch_cosine_similarity
+
+### src/retrieval/hybrid.rs
+
+- pub fn compute_weights
+- pub fn normalize_scores
+- pub fn merge_results
+- pub enum HybridMode
+- pub struct HybridConfig
+- impl Default for HybridConfig
+
+### src/retrieval/mod.rs
+
+- pub mod bm25
+- pub mod hybrid
+- pub use bm25::{Bm25Config, Bm25Index}
+- pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores}
+
+### src/retrieval/bm25.rs
+
+- pub struct Bm25Config
+- impl Default for Bm25Config
+- pub struct Bm25Index
+- impl Bm25Index
+
+### src/singularity.rs
+
+- pub use crate::singularity_cache::CacheMetricsSnapshot
+- pub use crate::singularity_retrieval::{CandidateSource, RetrievalConfig, RetrievalStats}
+- pub const DEFAULT_MAX_CACHED_TOP_K
+- pub struct Concept
+- pub struct SingularityConfig
+- impl Default for SingularityConfig
+- pub struct Singularity
+- impl Singularity
+- impl Default for Singularity
+- pub use crate::concept_builder::ConceptBuilder
+
+### src/framework.rs
+
+- pub struct ChaoticSemanticFramework
+- pub struct FrameworkMetrics
+- pub struct FrameworkMetricsSnapshot
+- impl FrameworkMetrics
+- impl ChaoticSemanticFramework
+
+### src/persistence_wasm.rs
 
 - pub struct Persistence
 - pub struct ConceptVersion
+- impl Persistence
+
+### src/framework_ops.rs
+
+- impl ChaoticSemanticFramework
+
+### src/wasm.rs
+
+- pub fn initialize_wasm
+- pub struct WasmFramework
+- impl WasmFramework
+- pub fn random_hypervector
+- pub fn encode_text
+- pub fn cosine_similarity
+
+### src/error.rs
+
+- pub enum MemoryError
+- impl MemoryError
+- pub type Result
+
+### src/wasm_ext.rs
+
+- impl WasmFramework
+
+### src/export_payload.rs
+
+- impl From for BinaryMetadataValue
+- impl From for serde_json::Value
+- impl From for BinaryConcept
+- impl BinaryConcept
+- impl From for BinaryExportPayload
+- impl BinaryExportPayload
+
+### src/persistence_versions.rs
+
 - impl Persistence
 
 ### src/lib.rs
@@ -183,234 +397,46 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub use prelude::crate::singularity_retrieval::{CandidateSource, FilterStrategy, RetrievalConfig, RetrievalStats}
 - pub mod wasm
 
-### src/metadata_filter.rs
-
-- pub enum MetadataFilter
-- impl MetadataFilter
-- impl ops::Not for MetadataFilter
-
-### src/wasm_ext.rs
-
-- impl WasmFramework
-
-### src/singularity.rs
-
-- pub use crate::singularity_cache::CacheMetricsSnapshot
-- pub use crate::singularity_retrieval::{CandidateSource, RetrievalConfig, RetrievalStats}
-- pub const DEFAULT_MAX_CACHED_TOP_K
-- pub struct Concept
-- pub struct SingularityConfig
-- impl Default for SingularityConfig
-- pub struct Singularity
-- impl Singularity
-- impl Default for Singularity
-- pub use crate::concept_builder::ConceptBuilder
-
-### src/singularity_ttl.rs
-
-- impl Default for Concept
-- impl Singularity
-
 ### src/bridge_retrieval.rs
 
 - pub struct BridgeRetrieval
 - impl BridgeRetrieval
 
-### src/persistence_wasm.rs
+### src/semantic_bridge.rs
 
-- pub struct Persistence
-- pub struct ConceptVersion
+- pub struct CanonicalConcept
+- impl CanonicalConcept
+- pub struct BridgeConfig
+- impl Default for BridgeConfig
+- pub struct ScoreBreakdown
+- impl ScoreBreakdown
+- pub struct BridgeHit
+- pub struct MemoryPacket
+- impl MemoryPacket
+- pub trait SemanticReranker
+- pub struct ConceptGraph
+- impl ConceptGraph
+
+### src/framework_events.rs
+
+- pub enum MemoryEvent
+- impl ChaoticSemanticFramework
+
+### src/bridge_persistence.rs
+
 - impl Persistence
 
-### src/error.rs
+### src/encoder.rs
 
-- pub enum MemoryError
-- impl MemoryError
-- pub type Result
-
-### src/persistence_versions.rs
-
-- impl Persistence
-
-### src/wasm.rs
-
-- pub fn initialize_wasm
-- pub struct WasmFramework
-- impl WasmFramework
-- pub fn random_hypervector
-- pub fn encode_text
-- pub fn cosine_similarity
+- pub struct TextEncoderConfig
+- impl Default for TextEncoderConfig
+- pub struct TextEncoder
+- impl Default for TextEncoder
+- impl TextEncoder
 
 ### src/singularity_ext.rs
 
 - impl Singularity
-
-### src/semantic_triples.rs
-
-- pub struct SemanticTriple
-- impl SemanticTriple
-- pub struct StructuredMemoryPayload
-- impl StructuredMemoryPayload
-
-### src/retrieval/mod.rs
-
-- pub mod bm25
-- pub mod hybrid
-- pub use bm25::{Bm25Config, Bm25Index}
-- pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores}
-
-### src/retrieval/hybrid.rs
-
-- pub fn compute_weights
-- pub fn normalize_scores
-- pub fn merge_results
-- pub enum HybridMode
-- pub struct HybridConfig
-- impl Default for HybridConfig
-
-### src/retrieval/bm25.rs
-
-- pub struct Bm25Config
-- impl Default for Bm25Config
-- pub struct Bm25Index
-- impl Bm25Index
-
-### src/persistence_migrations.rs
-
-- impl Persistence
-
-### src/export_payload.rs
-
-- impl From for BinaryMetadataValue
-- impl From for serde_json::Value
-- impl From for BinaryConcept
-- impl BinaryConcept
-- impl From for BinaryExportPayload
-- impl BinaryExportPayload
-
-### src/framework_builder.rs
-
-- pub struct FrameworkConfig
-- impl Default for FrameworkConfig
-- pub struct FrameworkStats
-- pub struct FrameworkBuilder
-- impl FrameworkBuilder
-
-### src/cli/git_local.rs
-
-- pub fn resolve_git_local_path
-- pub fn ensure_git_local_dir
-
-### src/cli/args.rs
-
-- pub struct CliArgs
-- pub enum OutputFormat
-- pub enum Commands
-- pub struct InjectArgs
-- pub enum VectorSource
-- pub struct ProbeArgs
-- pub struct QueryArgs
-- pub struct AssociateArgs
-- pub enum ExportFormat
-- pub struct ExportArgs
-- pub enum ImportFormat
-- pub struct ImportArgs
-- pub struct VersionArgs
-- pub struct CompletionsArgs
-- pub struct IndexJsonlArgs
-- pub struct IndexDirArgs
-
-### src/cli/error.rs
-
-- pub enum CliError
-- impl From for CliError
-- pub type Result
-- pub enum ExitCode
-- impl From for ExitCode
-- impl From for ExitCode
-- impl CliError
-- impl ExitCode
-
-### src/cli/commands/query.rs
-
-- pub fn run_query
-
-### src/cli/commands/associate.rs
-
-- pub fn run_associate
-- pub fn run_associate_batch
-
-### src/cli/commands/export.rs
-
-- pub fn run_export
-
-### src/cli/commands/probe.rs
-
-- pub fn run_probe
-- pub fn run_probe_with_vector
-
-### src/cli/commands/import.rs
-
-- pub fn run_import
-
-### src/cli/commands/completions.rs
-
-- pub fn run_completions
-
-### src/cli/commands/inject.rs
-
-- pub fn run_inject
-
-### src/cli/commands/mod.rs
-
-- pub mod associate
-- pub mod completions
-- pub mod export
-- pub mod import
-- pub mod index_dir
-- pub mod index_jsonl
-- pub mod inject
-- pub mod probe
-- pub mod query
-- pub use associate::run_associate
-- pub use completions::run_completions
-- pub use export::run_export
-- pub use import::run_import
-- pub use index_dir::run_index_dir
-- pub use index_jsonl::run_index_jsonl
-- pub use inject::run_inject
-- pub use probe::run_probe
-- pub use query::run_query
-- pub fn print_success
-- pub fn print_error
-- pub fn print_warning
-- pub fn truncate_preview
-- pub fn create_framework
-
-### src/cli/commands/index_jsonl.rs
-
-- pub fn run_index_jsonl
-
-### src/cli/commands/index_dir.rs
-
-- pub fn run_index_dir
-- pub struct MarkdownChunk
-- pub fn chunk_by_heading
-
-### src/cli/mod.rs
-
-- pub mod args
-- pub mod commands
-- pub mod error
-- pub mod git_local
-- pub use args::*
-- pub use commands::{run_associate, run_completions, run_export, run_import, run_index_dir, run_index_jsonl, run_inject, run_probe, run_query}
-- pub use error::{CliError, ExitCode, Result}
-- pub use git_local::{ensure_git_local_dir, resolve_git_local_path}
-
-### src/framework_bridge.rs
-
-- impl ChaoticSemanticFramework
 
 ### src/bin/csm.rs
 
@@ -424,32 +450,6 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub fn native::handle_completions
 - pub fn native::resolve_database_path
 - pub fn native::run_async
-
-### src/graph_traversal.rs
-
-- pub struct TraversalConfig
-- impl Default for TraversalConfig
-- impl Singularity
-
-### src/singularity_cache.rs
-
-- impl QueryCache
-- pub struct CacheMetricsSnapshot
-- impl CacheMetrics
-
-### src/encoder.rs
-
-- pub struct TextEncoderConfig
-- impl Default for TextEncoderConfig
-- pub struct TextEncoder
-- impl Default for TextEncoder
-- impl TextEncoder
-
-### src/bundle.rs
-
-- pub struct BundleAccumulator
-- impl Default for BundleAccumulator
-- impl BundleAccumulator
 
 ---
 
@@ -935,14 +935,64 @@ Contributions are welcome! Please read our [Contributing Guide](CONTRIBUTING.md)
 
 ---
 
-## src/reservoir_inertial.rs
+## src/framework_bridge.rs
 
-### impl Reservoir
+### impl ChaoticSemanticFramework
 
 ```rust
-impl Reservoir {
-    pub fn with_beta(self, beta: f32) -> Result<Self>;
-    pub fn beta(&self) -> f32;
+impl ChaoticSemanticFramework {
+    pub fn probe_bridge_text(&self, query: &str, top_k: usize, bridge: &BridgeRetrieval) -> Result<Vec<BridgeHit>>;
+    pub fn probe_bridge_text_with_reranker(&self, query: &str, top_k: usize, bridge: &BridgeRetrieval, reranker: &dyn Trait) -> Result<Vec<BridgeHit>>;
+    pub fn probe_bridge_text_filtered(&self, query: &str, top_k: usize, bridge: &BridgeRetrieval, filter: &MetadataFilter) -> Result<Vec<BridgeHit>>;
+    pub fn memory_packet_text(&self, query: &str, top_k: usize, bridge: &BridgeRetrieval) -> Result<MemoryPacket>;
+    pub fn memory_packet_text_with_reranker(&self, query: &str, top_k: usize, bridge: &BridgeRetrieval, reranker: &dyn Trait) -> Result<MemoryPacket>;
+}
+```
+
+
+
+## src/semantic_triples.rs
+
+### SemanticTriple
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct SemanticTriple {
+    pub subject: String,
+    pub predicate: String,
+    pub object: String,
+}
+```
+
+A semantic triple representing a discrete fact.
+
+### impl SemanticTriple
+
+```rust
+impl SemanticTriple {
+    pub fn new(subject: impl Trait, predicate: impl Trait, object: impl Trait) -> Self;
+    pub fn to_sentence(&self) -> String;
+}
+```
+
+
+### StructuredMemoryPayload
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StructuredMemoryPayload {
+    pub raw_summary: String,
+    pub triples: Vec<SemanticTriple>,
+}
+```
+
+A structured memory payload that can be stored in a `Concept`'s metadata.
+
+### impl StructuredMemoryPayload
+
+```rust
+impl StructuredMemoryPayload {
+    pub fn to_context_string(&self) -> String;
 }
 ```
 
@@ -1027,41 +1077,41 @@ impl ChaoticReservoir {
 
 
 
-## src/framework_events.rs
+## src/concept_builder.rs
 
-### MemoryEvent
+### ConceptBuilder
 
 ```rust
-#[derive(Debug, Clone)]
-pub enum MemoryEvent {
-    ConceptInjected { id: String, timestamp: u64 },
-    ConceptUpdated { id: String, timestamp: u64 },
-    ConceptDeleted { id: String, timestamp: u64 },
-    Associated { from: String, to: String, strength: f32 },
-    Disassociated { from: String, to: String },
+#[derive(Debug)]
+pub struct ConceptBuilder {
 }
 ```
 
+Builder for constructing [`Concept`] instances with a fluent API.
 
-### impl ChaoticSemanticFramework
+#### Example
 
-```rust
-impl ChaoticSemanticFramework {
-    pub fn subscribe(&self) -> broadcast::Receiver<MemoryEvent>;
-    pub fn update_concept_vector(&self, id: &str, vector: HVec10240) -> Result<()>;
-    pub fn update_concept_metadata(&self, id: &str, metadata: HashMap<String, serde_json::Value>) -> Result<()>;
-    pub fn disassociate(&self, from: &str, to: &str) -> Result<()>;
-}
+```
+use chaotic_semantic_memory::singularity::ConceptBuilder;
+use chaotic_semantic_memory::HVec10240;
+
+let concept = ConceptBuilder::new("example")
+.with_vector(HVec10240::random())
+.with_metadata("source", "test")
+.build()
+.unwrap();
 ```
 
-
-
-## src/reservoir_sparse.rs
-
-### impl SparseWeights
+### impl ConceptBuilder
 
 ```rust
-impl SparseWeights {
+impl ConceptBuilder {
+    pub fn new(id: impl Trait) -> Self;
+    pub fn with_canonical_concepts(self, ids: Vec<String>) -> Self;
+    pub fn with_ttl(self, ttl_seconds: u64) -> Self;
+    pub fn with_vector(self, vector: HVec10240) -> Self;
+    pub fn with_metadata(self, key: impl Trait, value: impl Trait) -> Self;
+    pub fn build(self) -> Result<Concept>;
 }
 ```
 
@@ -1139,6 +1189,199 @@ pub use crate::bundle::BundleAccumulator;
 
 
 
+## src/bundle.rs
+
+### BundleAccumulator
+
+```rust
+#[derive(Debug, Clone)]
+pub struct BundleAccumulator {
+}
+```
+
+Incremental bundle accumulator for streaming/sliding-window memory.
+
+Maintains signed bit counts for efficient add/remove operations.
+Finalize applies majority threshold to produce a bundled hypervector.
+
+### impl Default for BundleAccumulator
+
+```rust
+impl Default for BundleAccumulator {
+}
+```
+
+
+### impl BundleAccumulator
+
+```rust
+impl BundleAccumulator {
+    pub fn new() -> Self;
+    pub fn add(&mut self, hv: &HVec10240);
+    pub fn remove(&mut self, hv: &HVec10240);
+    pub fn try_remove(&mut self, hv: &HVec10240) -> Result<()>;
+    pub fn finalize(&self) -> HVec10240;
+    pub fn len(&self) -> u32;
+    pub fn is_empty(&self) -> bool;
+    pub fn clear(&mut self);
+}
+```
+
+
+
+## src/metadata_filter.rs
+
+### MetadataFilter
+
+```rust
+#[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize)]
+pub enum MetadataFilter {
+    Eq(String, Value),
+    In(String, Vec<Value>),
+    Exists(String),
+    And(Vec<MetadataFilter>),
+    Or(Vec<MetadataFilter>),
+    Not(Box<MetadataFilter>),
+}
+```
+
+A predicate for filtering concepts by metadata during similarity search.
+
+### impl MetadataFilter
+
+```rust
+impl MetadataFilter {
+    pub fn eq(key: impl Trait, value: impl Trait) -> Self;
+    pub fn in_(key: impl Trait, values: Vec<Value>) -> Self;
+    pub fn exists(key: impl Trait) -> Self;
+    pub fn and(filters: Vec<MetadataFilter>) -> Self;
+    pub fn or(filters: Vec<MetadataFilter>) -> Self;
+    pub fn matches(&self, metadata: &HashMap<String, Value>) -> bool;
+}
+```
+
+
+### impl ops::Not for MetadataFilter
+
+```rust
+impl ops::Not for MetadataFilter {
+}
+```
+
+
+
+## src/persistence.rs
+
+### Persistence
+
+```rust
+#[derive(Debug)]
+pub struct Persistence {
+}
+```
+
+
+### ConceptVersion
+
+```rust
+#[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize)]
+pub struct ConceptVersion {
+    pub concept_id: String,
+    pub version: i64,
+    pub vector: HVec10240,
+    pub metadata: serde_json::Value,
+    pub modified_at: u64,
+}
+```
+
+
+### impl Persistence
+
+```rust
+impl Persistence {
+    pub fn new_local(path: &str) -> Result<Self>;
+    pub fn new_local_with_retention(path: &str, version_retention: usize) -> Result<Self>;
+    pub fn new_turso(url: &str, token: &str) -> Result<Self>;
+    pub fn new_turso_with_pool(url: &str, token: &str, pool_size: usize) -> Result<Self>;
+    pub fn new_turso_with_pool_and_retention(url: &str, token: &str, pool_size: usize, version_retention: usize) -> Result<Self>;
+    pub fn save_concept(&self, concept: &Concept) -> Result<()>;
+    pub fn save_concepts(&self, concepts: &[Concept]) -> Result<()>;
+    pub fn load_concept(&self, id: &str) -> Result<Option<Concept>>;
+    pub fn load_all_concepts(&self) -> Result<Vec<Concept>>;
+    pub fn delete_concept(&self, id: &str) -> Result<()>;
+    pub fn save_association(&self, from: &str, to: &str, strength: f32) -> Result<()>;
+    pub fn load_associations(&self, id: &str) -> Result<Vec<(String, f32)>>;
+    pub fn checkpoint(&self) -> Result<()>;
+    pub fn size(&self) -> Result<u64>;
+}
+```
+
+
+
+## src/reservoir_sparse.rs
+
+### impl SparseWeights
+
+```rust
+impl SparseWeights {
+}
+```
+
+
+
+## src/singularity_ttl.rs
+
+### impl Default for Concept
+
+```rust
+impl Default for Concept {
+}
+```
+
+
+### impl Singularity
+
+```rust
+impl Singularity {
+    pub fn purge_expired(&mut self) -> usize;
+    pub fn is_expired(&self, id: &str) -> bool;
+    pub fn active_concept_ids(&self) -> Vec<String>;
+}
+```
+
+
+
+## src/singularity_cache.rs
+
+### impl QueryCache
+
+```rust
+impl QueryCache {
+}
+```
+
+
+### CacheMetricsSnapshot
+
+```rust
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CacheMetricsSnapshot {
+    pub cache_hits_total: u64,
+    pub cache_misses_total: u64,
+    pub cache_evictions_total: u64,
+}
+```
+
+
+### impl CacheMetrics
+
+```rust
+impl CacheMetrics {
+}
+```
+
+
+
 ## src/framework_ttl.rs
 
 ### impl crate::framework::ChaoticSemanticFramework
@@ -1156,365 +1399,121 @@ impl crate::framework::ChaoticSemanticFramework {
 
 
 
-## src/concept_builder.rs
+## src/hyperdim_simd.rs
 
-### ConceptBuilder
+
+## src/framework_builder.rs
+
+### FrameworkConfig
 
 ```rust
-#[derive(Debug)]
-pub struct ConceptBuilder {
+#[derive(Clone, Debug)]
+pub struct FrameworkConfig {
+    pub reservoir_size: usize,
+    pub reservoir_input_size: usize,
+    pub chaos_strength: f32,
+    pub enable_persistence: bool,
+    pub max_concepts: Option<usize>,
+    pub max_associations_per_concept: Option<usize>,
+    pub connection_pool_size: usize,
+    pub max_probe_top_k: usize,
+    pub max_metadata_bytes: Option<usize>,
+    pub max_cached_top_k: usize,
+    pub max_batch_size: usize,
+    pub max_sequence_length: usize,
 }
 ```
 
-Builder for constructing [`Concept`] instances with a fluent API.
+Runtime configuration for [`ChaoticSemanticFramework`], tuned via [`FrameworkBuilder`].
 
-#### Example
-
-```
-use chaotic_semantic_memory::singularity::ConceptBuilder;
-use chaotic_semantic_memory::HVec10240;
-
-let concept = ConceptBuilder::new("example")
-.with_vector(HVec10240::random())
-.with_metadata("source", "test")
-.build()
-.unwrap();
-```
-
-### impl ConceptBuilder
+### impl Default for FrameworkConfig
 
 ```rust
-impl ConceptBuilder {
-    pub fn new(id: impl Trait) -> Self;
-    pub fn with_canonical_concepts(self, ids: Vec<String>) -> Self;
-    pub fn with_ttl(self, ttl_seconds: u64) -> Self;
-    pub fn with_vector(self, vector: HVec10240) -> Self;
-    pub fn with_metadata(self, key: impl Trait, value: impl Trait) -> Self;
-    pub fn build(self) -> Result<Concept>;
+impl Default for FrameworkConfig {
 }
 ```
 
 
-
-## src/persistence_ops.rs
-
-### impl Persistence
-
-```rust
-impl Persistence {
-    pub fn save_associations(&self, associations: &[(String, String, f32)]) -> Result<()>;
-    pub fn clear_all(&self) -> Result<()>;
-    pub fn get_concept_history(&self, id: &str, limit: usize) -> Result<Vec<ConceptVersion>>;
-    pub fn schema_version(&self) -> Result<i64>;
-    pub fn apply_migrations(&self, target_version: i64) -> Result<()>;
-    pub fn backup(&self, path: &str) -> Result<()>;
-    pub fn restore(&self, path: &str) -> Result<()>;
-    pub fn health_check(&self) -> Result<()>;
-    pub fn delete_association(&self, from: &str, to: &str) -> Result<()>;
-    pub fn clear_concept_associations(&self, id: &str) -> Result<()>;
-}
-```
-
-
-
-## src/framework.rs
-
-### ChaoticSemanticFramework
-
-```rust
-pub struct ChaoticSemanticFramework {
-}
-```
-
-Main framework for chaotic semantic memory
-
-### FrameworkMetrics
-
-```rust
-#[derive(Debug, Default)]
-pub struct FrameworkMetrics {
-}
-```
-
-
-### FrameworkMetricsSnapshot
+### FrameworkStats
 
 ```rust
 #[derive(Debug, Clone)]
-pub struct FrameworkMetricsSnapshot {
-    pub concepts_injected_total: u64,
-    pub associations_created_total: u64,
-    pub probes_total: u64,
-    pub avg_probe_latency_ms: f64,
-    pub cache_hits_total: u64,
-    pub cache_misses_total: u64,
-    pub cache_evictions_total: u64,
-    pub reservoir_steps_total: u64,
-    pub avg_reservoir_step_latency_us: f64,
-    pub reservoir_nodes_active: u64,
+pub struct FrameworkStats {
+    pub concept_count: usize,
+    pub db_size_bytes: Option<u64>,
 }
 ```
 
+Framework statistics
 
-### impl FrameworkMetrics
+### FrameworkBuilder
 
 ```rust
-impl FrameworkMetrics {
+pub struct FrameworkBuilder {
 }
 ```
 
+Builder for ChaoticSemanticFramework
 
-### impl ChaoticSemanticFramework
+### impl FrameworkBuilder
 
 ```rust
-impl ChaoticSemanticFramework {
-    pub fn builder() -> FrameworkBuilder;
-    pub fn singularity(&self) -> Arc<RwLock<Singularity>>;
-    pub fn inject_concept(&self, id: impl Trait, vector: HVec10240) -> Result<()>;
-    pub fn inject_concept_with_metadata(&self, id: impl Trait, vector: HVec10240, metadata: std::collections::HashMap<String, serde_json::Value>) -> Result<()>;
-    pub fn probe(&self, query: HVec10240, top_k: usize) -> Result<Vec<(String, f32)>>;
-    pub fn probe_filtered(&self, query: &HVec10240, top_k: usize, filter: &MetadataFilter) -> Result<Vec<(String, f32)>>;
-    pub fn traverse(&self, start: &str, config: TraversalConfig) -> Result<Vec<(String, u32)>>;
-    pub fn shortest_path(&self, from: &str, to: &str) -> Result<Option<Vec<String>>>;
-    pub fn process_sequence(&self, sequence: &[Vec<f32>]) -> Result<HVec10240>;
-    pub fn associate(&self, from: &str, to: &str, strength: f32) -> Result<()>;
-    pub fn delete_concept(&self, id: &str) -> Result<()>;
-    pub fn get_associations(&self, id: &str) -> Result<Vec<(String, f32)>>;
-    pub fn get_concept(&self, id: &str) -> Result<Option<Concept>>;
-    pub fn persist(&self) -> Result<()>;
-    pub fn persistence_health_check(&self) -> Result<()>;
-    pub fn load_replace(&self) -> Result<()>;
-    pub fn load_merge(&self) -> Result<()>;
-    pub fn load(&self) -> Result<()>;
-    pub fn metrics_snapshot(&self) -> FrameworkMetricsSnapshot;
-    pub fn stats(&self) -> Result<FrameworkStats>;
+impl FrameworkBuilder {
+    pub fn with_reservoir_size(self, size: usize) -> Self;
+    pub fn with_reservoir_input_size(self, size: usize) -> Self;
+    pub fn with_chaos_strength(self, strength: f32) -> Self;
+    pub fn with_max_concepts(self, max_concepts: usize) -> Self;
+    pub fn with_max_associations_per_concept(self, max_associations: usize) -> Self;
+    pub fn with_concept_cache_size(self, size: usize) -> Self;
+    pub fn with_connection_pool_size(self, pool_size: usize) -> Self;
+    pub fn with_max_probe_top_k(self, max_probe_top_k: usize) -> Self;
+    pub fn with_max_metadata_bytes(self, max_metadata_bytes: usize) -> Self;
+    pub fn with_max_cached_top_k(self, max_cached_top_k: usize) -> Self;
+    pub fn with_max_batch_size(self, max_batch_size: usize) -> Self;
+    pub fn with_max_sequence_length(self, max_sequence_length: usize) -> Self;
+    pub fn with_version_retention(self, retention: usize) -> Self;
+    pub fn with_local_db(self, path: impl Trait) -> Self;
+    pub fn with_turso(self, url: impl Trait, token: impl Trait) -> Self;
+    pub fn without_persistence(self) -> Self;
+    pub fn without_persistence(self) -> Self;
+    pub fn build(self) -> Result<ChaoticSemanticFramework>;
 }
 ```
 
 
 
-## src/hyperdim_batch.rs
+## src/graph_traversal.rs
 
-### batch_cosine_similarity
+### TraversalConfig
 
 ```rust
-pub fn batch_cosine_similarity(query: &HVec10240, candidates: &[HVec10240]) -> Vec<f32>
+#[derive(Debug, Clone)]
+pub struct TraversalConfig {
+    pub max_depth: usize,
+    pub min_strength: f32,
+    pub max_results: usize,
+}
 ```
 
-Batch similarity computation tuned for cache locality and Rayon overhead.
+Configuration for graph traversal operations.
 
-
-## src/framework_validation.rs
-
-### impl ChaoticSemanticFramework
+### impl Default for TraversalConfig
 
 ```rust
-impl ChaoticSemanticFramework {
+impl Default for TraversalConfig {
 }
 ```
 
 
-
-## src/semantic_bridge.rs
-
-### CanonicalConcept
+### impl Singularity
 
 ```rust
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CanonicalConcept {
-    pub id: String,
-    pub version: u32,
-    pub labels: Vec<String>,
-    pub related: Vec<String>,
-}
-```
-
-A canonical concept with symbolic identity relationships.
-
-Canonical concepts represent semantic equivalence classes (e.g., "agent memory"
-≈ "cross-session context" ≈ "ai memory") without modifying stored vectors.
-
-### impl CanonicalConcept
-
-```rust
-impl CanonicalConcept {
-    pub fn new(id: impl Trait) -> Self;
-    pub fn with_label(self, label: impl Trait) -> Self;
-    pub fn with_related(self, related_id: impl Trait) -> Self;
-}
-```
-
-
-### BridgeConfig
-
-```rust
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BridgeConfig {
-    pub max_expansion_depth: u8,
-    pub max_packet_facts: usize,
-    pub token_budget: usize,
-    pub deterministic_weight: f32,
-    pub concept_weight: f32,
-    pub semantic_weight: f32,
-}
-```
-
-Configuration for the bridge retrieval pipeline.
-
-### impl Default for BridgeConfig
-
-```rust
-impl Default for BridgeConfig {
-}
-```
-
-
-### ScoreBreakdown
-
-```rust
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ScoreBreakdown {
-    pub deterministic: f32,
-    pub concept: f32,
-    pub semantic: f32,
-    pub final_score: f32,
-    pub evidence: Vec<String>,
-}
-```
-
-Breakdown of scores for a bridge retrieval hit.
-
-### impl ScoreBreakdown
-
-```rust
-impl ScoreBreakdown {
-    pub fn deterministic_only(score: f32) -> Self;
-}
-```
-
-
-### BridgeHit
-
-```rust
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BridgeHit {
-    pub id: String,
-    pub text_preview: Option<String>,
-    pub scores: ScoreBreakdown,
-}
-```
-
-A single hit from bridge retrieval.
-
-### MemoryPacket
-
-```rust
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MemoryPacket {
-    pub query_intent: String,
-    pub facts: Vec<String>,
-    pub sources: Vec<String>,
-    pub confidence: f32,
-}
-```
-
-Compressed memory packet for LLM context injection.
-
-### impl MemoryPacket
-
-```rust
-impl MemoryPacket {
-    pub fn estimated_tokens(&self) -> usize;
-    pub fn to_json(&self) -> serde_json::Result<String>;
-    pub fn to_json_pretty(&self) -> serde_json::Result<String>;
-}
-```
-
-
-### SemanticReranker
-
-```rust
-pub trait SemanticReranker: Send + Sync {
-    fn version(&self) -> &str;
-    fn rerank(&self, query: &str, hits: &mut [BridgeHit]);
-}
-```
-
-Trait for optional semantic reranking.
-
-Implementations can wrap local models, remote APIs, or rule-based heuristics.
-The reranker never mutates deterministic scores—only adjusts ordering.
-
-### ConceptGraph
-
-```rust
-#[derive(Debug, Clone, Default)]
-pub struct ConceptGraph {
-}
-```
-
-In-memory canonical concept graph for symbolic semantic expansion.
-
-### impl ConceptGraph
-
-```rust
-impl ConceptGraph {
-    pub fn new() -> Self;
-    pub fn add_concept(&mut self, concept: CanonicalConcept);
-    pub fn remove_concept(&mut self, id: &str) -> Option<CanonicalConcept>;
-    pub fn get_concept(&self, id: &str) -> Option<&CanonicalConcept>;
-    pub fn match_tokens(&self, tokens: &[String]) -> Vec<String>;
-    pub fn expand(&self, concept_ids: &[String], max_depth: u8) -> Vec<String>;
-    pub fn load_from_json(reader: impl Trait) -> crate::Result<Self>;
-    pub fn save_to_json(&self, writer: impl Trait) -> crate::Result<()>;
-    pub fn concept_count(&self) -> usize;
-    pub fn label_count(&self) -> usize;
-    pub fn all_concepts(&self) -> impl Trait;
-}
-```
-
-
-
-## src/framework_ops.rs
-
-### impl ChaoticSemanticFramework
-
-```rust
-impl ChaoticSemanticFramework {
-    pub fn inject_concepts(&self, concepts: &[(String, HVec10240)]) -> Result<()>;
-    pub fn associate_many(&self, associations: &[(String, String, f32)]) -> Result<()>;
-    pub fn probe_batch(&self, queries: &[HVec10240], top_k: usize) -> Result<Vec<Vec<(String, f32)>>>;
-    pub fn probe_batch_cached(&self, queries: &[HVec10240], top_k: usize) -> Result<Vec<Arc<[(String, f32)]>>>;
-    pub fn export_json(&self, path: &str) -> Result<()>;
-    pub fn import_json(&self, path: &str, merge: bool) -> Result<usize>;
-    pub fn export_binary(&self, path: &str) -> Result<()>;
-    pub fn import_binary(&self, path: &str, merge: bool) -> Result<usize>;
-    pub fn backup(&self, path: &str) -> Result<()>;
-    pub fn restore(&self, path: &str) -> Result<()>;
-    pub fn concept_history(&self, id: &str, limit: usize) -> Result<Vec<crate::persistence::ConceptVersion>>;
-    pub fn update_concept_vector(&self, id: &str, vector: HVec10240) -> Result<()>;
-    pub fn update_concept_metadata(&self, id: &str, metadata: std::collections::HashMap<String, serde_json::Value>) -> Result<()>;
-    pub fn disassociate(&self, from: &str, to: &str) -> Result<()>;
-    pub fn clear_associations(&self, id: &str) -> Result<()>;
-    pub fn clear_similarity_cache(&self);
-    pub fn bundle_concepts_strict(&self, ids: &[String]) -> Result<HVec10240>;
-}
-```
-
-
-
-## src/bridge_persistence.rs
-
-### impl Persistence
-
-```rust
-impl Persistence {
-    pub fn save_canonical_concept(&self, concept: &CanonicalConcept) -> Result<()>;
-    pub fn delete_canonical_concept(&self, id: &str) -> Result<()>;
-    pub fn load_canonical_concept(&self, id: &str) -> Result<Option<CanonicalConcept>>;
-    pub fn load_all_canonical_concepts(&self) -> Result<Vec<CanonicalConcept>>;
-    pub fn save_concept_graph(&self, graph: &ConceptGraph) -> Result<()>;
-    pub fn load_concept_graph(&self) -> Result<ConceptGraph>;
+impl Singularity {
+    pub fn neighbors(&self, id: &str, min_strength: f32) -> Vec<(String, f32)>;
+    pub fn incoming_associations(&self, id: &str) -> Vec<(&str, f32)>;
+    pub fn bfs(&self, start: &str, config: &TraversalConfig) -> Result<Vec<(String, u32)>>;
+    pub fn shortest_path(&self, from: &str, to: &str, config: &TraversalConfig) -> Result<Option<Vec<String>>>;
+    pub fn shortest_path_hops(&self, from: &str, to: &str, config: &TraversalConfig) -> Result<Option<Vec<String>>>;
 }
 ```
 
@@ -1612,1020 +1611,234 @@ impl Singularity {
 
 
 
-## src/persistence.rs
+## src/cli/commands/index_dir.rs
 
-### Persistence
+### run_index_dir
 
 ```rust
-#[derive(Debug)]
-pub struct Persistence {
-}
+pub fn run_index_dir(args: IndexDirArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
 ```
 
 
-### ConceptVersion
-
-```rust
-#[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize)]
-pub struct ConceptVersion {
-    pub concept_id: String,
-    pub version: i64,
-    pub vector: HVec10240,
-    pub metadata: serde_json::Value,
-    pub modified_at: u64,
-}
-```
-
-
-### impl Persistence
-
-```rust
-impl Persistence {
-    pub fn new_local(path: &str) -> Result<Self>;
-    pub fn new_local_with_retention(path: &str, version_retention: usize) -> Result<Self>;
-    pub fn new_turso(url: &str, token: &str) -> Result<Self>;
-    pub fn new_turso_with_pool(url: &str, token: &str, pool_size: usize) -> Result<Self>;
-    pub fn new_turso_with_pool_and_retention(url: &str, token: &str, pool_size: usize, version_retention: usize) -> Result<Self>;
-    pub fn save_concept(&self, concept: &Concept) -> Result<()>;
-    pub fn save_concepts(&self, concepts: &[Concept]) -> Result<()>;
-    pub fn load_concept(&self, id: &str) -> Result<Option<Concept>>;
-    pub fn load_all_concepts(&self) -> Result<Vec<Concept>>;
-    pub fn delete_concept(&self, id: &str) -> Result<()>;
-    pub fn save_association(&self, from: &str, to: &str, strength: f32) -> Result<()>;
-    pub fn load_associations(&self, id: &str) -> Result<Vec<(String, f32)>>;
-    pub fn checkpoint(&self) -> Result<()>;
-    pub fn size(&self) -> Result<u64>;
-}
-```
-
-
-
-## src/lib.rs
-
-### bridge_retrieval::BridgeRetrieval
-
-```rust
-pub use bridge_retrieval::BridgeRetrieval;
-```
-
-
-### bundle::BundleAccumulator
-
-```rust
-pub use bundle::BundleAccumulator;
-```
-
-
-### error::{MemoryError, Result}
-
-```rust
-pub use error::{MemoryError, Result};
-```
-
-
-### framework::ChaoticSemanticFramework
-
-```rust
-pub use framework::ChaoticSemanticFramework;
-```
-
-
-### framework_builder::FrameworkBuilder
-
-```rust
-pub use framework_builder::FrameworkBuilder;
-```
-
-
-### framework_events::MemoryEvent
-
-```rust
-pub use framework_events::MemoryEvent;
-```
-
-
-### hyperdim::{HVec10240, batch_cosine_similarity}
-
-```rust
-pub use hyperdim::{HVec10240, batch_cosine_similarity};
-```
-
-
-### semantic_bridge::{BridgeConfig, BridgeHit, CanonicalConcept, ConceptGraph, MemoryPacket, ScoreBreakdown}
-
-```rust
-pub use semantic_bridge::{BridgeConfig, BridgeHit, CanonicalConcept, ConceptGraph, MemoryPacket, ScoreBreakdown};
-```
-
-
-### singularity::{Concept, ConceptBuilder}
-
-```rust
-pub use singularity::{Concept, ConceptBuilder};
-```
-
-
-### singularity_retrieval::{CandidateSource, FilterStrategy, RetrievalConfig, RetrievalStats}
-
-```rust
-pub use singularity_retrieval::{CandidateSource, FilterStrategy, RetrievalConfig, RetrievalStats};
-```
-
-
-### metadata_filter::MetadataFilter
-
-```rust
-pub use metadata_filter::MetadataFilter;
-```
-
-
-### crate::persistence_wasm as persistence
-
-```rust
-pub use crate::persistence_wasm as persistence;
-```
-
-
-### Persistence
-
-```rust
-#[derive(Debug)]
-pub struct Persistence;
-```
-
-Stub persistence type when persistence feature is disabled.
-
-### ConceptVersion
-
-```rust
-#[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize)]
-pub struct ConceptVersion {
-    pub concept_id: String,
-    pub version: i64,
-    pub vector: HVec10240,
-    pub metadata: serde_json::Value,
-    pub modified_at: u64,
-}
-```
-
-Stub concept version type when persistence feature is disabled.
-
-### impl Persistence
-
-```rust
-impl Persistence {
-    pub fn save_concept(&self, _concept: &Concept) -> Result<()>;
-    pub fn save_concepts(&self, _concepts: &[Concept]) -> Result<()>;
-    pub fn load_concept(&self, _id: &str) -> Result<Option<Concept>>;
-    pub fn load_all_concepts(&self) -> Result<Vec<Concept>>;
-    pub fn delete_concept(&self, _id: &str) -> Result<()>;
-    pub fn save_association(&self, _from: &str, _to: &str, _strength: f32) -> Result<()>;
-    pub fn save_associations(&self, _associations: &[(String, String, f32)]) -> Result<()>;
-    pub fn load_associations(&self, _id: &str) -> Result<Vec<(String, f32)>>;
-    pub fn delete_association(&self, _from: &str, _to: &str) -> Result<()>;
-    pub fn clear_concept_associations(&self, _id: &str) -> Result<()>;
-    pub fn clear_all(&self) -> Result<()>;
-    pub fn checkpoint(&self) -> Result<()>;
-    pub fn health_check(&self) -> Result<()>;
-    pub fn size(&self) -> Result<u64>;
-    pub fn backup(&self, _path: &str) -> Result<()>;
-    pub fn restore(&self, _path: &str) -> Result<()>;
-    pub fn get_concept_history(&self, _id: &str, _limit: usize) -> Result<Vec<ConceptVersion>>;
-    pub fn schema_version(&self) -> Result<i64>;
-    pub fn apply_migrations(&self, _target_version: i64) -> Result<()>;
-}
-```
-
-
-### crate::bridge_retrieval::BridgeRetrieval
-
-```rust
-pub use crate::bridge_retrieval::BridgeRetrieval;
-```
-
-
-### crate::bundle::BundleAccumulator
-
-```rust
-pub use crate::bundle::BundleAccumulator;
-```
-
-
-### crate::error::{MemoryError, Result}
-
-```rust
-pub use crate::error::{MemoryError, Result};
-```
-
-
-### crate::framework::ChaoticSemanticFramework
-
-```rust
-pub use crate::framework::ChaoticSemanticFramework;
-```
-
-
-### crate::framework_builder::FrameworkBuilder
-
-```rust
-pub use crate::framework_builder::FrameworkBuilder;
-```
-
-
-### crate::framework_events::MemoryEvent
-
-```rust
-pub use crate::framework_events::MemoryEvent;
-```
-
-
-### crate::hyperdim::HVec10240
-
-```rust
-pub use crate::hyperdim::HVec10240;
-```
-
-
-### crate::semantic_bridge::{BridgeHit, ConceptGraph, MemoryPacket}
-
-```rust
-pub use crate::semantic_bridge::{BridgeHit, ConceptGraph, MemoryPacket};
-```
-
-
-### crate::singularity::{Concept, ConceptBuilder}
-
-```rust
-pub use crate::singularity::{Concept, ConceptBuilder};
-```
-
-
-### crate::singularity_retrieval::{CandidateSource, FilterStrategy, RetrievalConfig, RetrievalStats}
-
-```rust
-pub use crate::singularity_retrieval::{CandidateSource, FilterStrategy, RetrievalConfig, RetrievalStats};
-```
-
-
-
-## src/metadata_filter.rs
-
-### MetadataFilter
-
-```rust
-#[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize)]
-pub enum MetadataFilter {
-    Eq(String, Value),
-    In(String, Vec<Value>),
-    Exists(String),
-    And(Vec<MetadataFilter>),
-    Or(Vec<MetadataFilter>),
-    Not(Box<MetadataFilter>),
-}
-```
-
-A predicate for filtering concepts by metadata during similarity search.
-
-### impl MetadataFilter
-
-```rust
-impl MetadataFilter {
-    pub fn eq(key: impl Trait, value: impl Trait) -> Self;
-    pub fn in_(key: impl Trait, values: Vec<Value>) -> Self;
-    pub fn exists(key: impl Trait) -> Self;
-    pub fn and(filters: Vec<MetadataFilter>) -> Self;
-    pub fn or(filters: Vec<MetadataFilter>) -> Self;
-    pub fn matches(&self, metadata: &HashMap<String, Value>) -> bool;
-}
-```
-
-
-### impl ops::Not for MetadataFilter
-
-```rust
-impl ops::Not for MetadataFilter {
-}
-```
-
-
-
-## src/wasm_ext.rs
-
-### impl WasmFramework
-
-```rust
-impl WasmFramework {
-    pub fn stats(&self) -> Result<JsValue, JsValue>;
-    pub fn concept_count(&self) -> Result<usize, JsValue>;
-    pub fn update_concept_metadata(&self, id: String, metadata_json: String) -> Result<(), JsValue>;
-    pub fn clear_associations(&self, id: String) -> Result<(), JsValue>;
-    pub fn neighbors(&self, id: String, min_strength: f32) -> Result<Array, JsValue>;
-    pub fn bfs(&self, start: String) -> Result<Array, JsValue>;
-    pub fn shortest_path(&self, from: String, to: String) -> Result<Array, JsValue>;
-    pub fn probe_filtered(&self, vector: &[u8], top_k: usize, filter_json: String) -> Result<Array, JsValue>;
-    pub fn traverse(&self, start: String, max_depth: u32, min_strength: f32) -> Result<Array, JsValue>;
-    pub fn on_event(&self, callback: Function);
-    pub fn inject_text(&self, id: String, text: String) -> Result<(), JsValue>;
-    pub fn probe_text(&self, query: String, top_k: usize) -> Result<Array, JsValue>;
-}
-```
-
-
-
-## src/singularity.rs
-
-### crate::singularity_cache::CacheMetricsSnapshot
-
-```rust
-pub use crate::singularity_cache::CacheMetricsSnapshot;
-```
-
-
-### crate::singularity_retrieval::{CandidateSource, RetrievalConfig, RetrievalStats}
-
-```rust
-pub use crate::singularity_retrieval::{CandidateSource, RetrievalConfig, RetrievalStats};
-```
-
-
-### DEFAULT_MAX_CACHED_TOP_K
-
-```rust
-pub const DEFAULT_MAX_CACHED_TOP_K: usize
-```
-
-
-### Concept
-
-```rust
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Concept {
-    pub id: String,
-    pub vector: HVec10240,
-    pub metadata: HashMap<String, serde_json::Value>,
-    pub created_at: u64,
-    pub modified_at: u64,
-    pub expires_at: Option<u64>,
-    pub canonical_concept_ids: Vec<String>,
-}
-```
-
-A concept in semantic memory.
-
-Use [`ConceptBuilder`] to construct instances with proper defaults.
-Direct struct construction is supported but the `expires_at` field should
-default to `None` for backward compatibility.
-
-### SingularityConfig
+### MarkdownChunk
 
 ```rust
 #[derive(Debug, Clone)]
-pub struct SingularityConfig {
-    pub max_concepts: Option<usize>,
-    pub max_associations_per_concept: Option<usize>,
-    pub concept_cache_size: usize,
-    pub max_cached_top_k: usize,
+pub struct MarkdownChunk {
+    pub heading: String,
+    pub level: usize,
+    pub content: String,
 }
 ```
 
-Runtime configuration for [`Singularity`].
+A chunk of markdown content.
 
-### impl Default for SingularityConfig
+### chunk_by_heading
 
 ```rust
-impl Default for SingularityConfig {
-}
+pub fn chunk_by_heading(content: &str, min_level: usize) -> Vec<MarkdownChunk>
+```
+
+Chunk markdown content by heading boundaries.
+
+Only chunks at headings >= min_level (default 2 for ##).
+Heading level 1 (#) is typically the document title and skipped.
+
+
+## src/cli/commands/associate.rs
+
+### run_associate
+
+```rust
+pub fn run_associate(args: AssociateArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
 ```
 
 
-### Singularity
+### run_associate_batch
 
 ```rust
-#[derive(Debug)]
-pub struct Singularity {
-}
-```
-
-Episode-free singularity engine
-
-### impl Singularity
-
-```rust
-impl Singularity {
-    pub fn new() -> Self;
-    pub fn with_config(config: SingularityConfig) -> Self;
-    pub fn inject(&mut self, concept: Concept) -> Result<()>;
-    pub fn get(&self, id: &str) -> Option<&Concept>;
-    pub fn delete(&mut self, id: &str) -> Result<()>;
-    pub fn clear(&mut self);
-    pub fn update(&mut self, id: &str, new_vector: HVec10240) -> Result<()>;
-    pub fn find_similar(&self, query: &HVec10240, top_k: usize) -> Vec<(String, f32)>;
-    pub fn find_similar_arc(&self, query: &HVec10240, top_k: usize) -> Arc<[(String, f32)]>;
-    pub fn find_similar_cached(&self, query: &HVec10240, top_k: usize) -> Arc<[(String, f32)]>;
-    pub fn associate(&mut self, from: &str, to: &str, strength: f32) -> Result<()>;
-    pub fn get_associations(&self, id: &str) -> Vec<(String, f32)>;
-    pub fn bundle_concepts(&self, ids: &[String]) -> Result<HVec10240>;
-    pub fn concept_ids(&self) -> Vec<String>;
-    pub fn all_concepts(&self) -> Vec<Concept>;
-    pub fn all_associations(&self) -> Vec<(String, String, f32)>;
-    pub fn len(&self) -> usize;
-    pub fn is_empty(&self) -> bool;
-    pub fn cache_metrics_snapshot(&self) -> CacheMetricsSnapshot;
-}
-```
-
-
-### impl Default for Singularity
-
-```rust
-impl Default for Singularity {
-}
-```
-
-
-### crate::concept_builder::ConceptBuilder
-
-```rust
-pub use crate::concept_builder::ConceptBuilder;
+pub fn run_associate_batch(associations: Vec<(String, String, f64)>, db_path: Option<&Path>, format: OutputFormat, continue_on_error: bool) -> Result<()>
 ```
 
 
 
-## src/singularity_ttl.rs
+## src/cli/commands/import.rs
 
-### impl Default for Concept
-
-```rust
-impl Default for Concept {
-}
-```
-
-
-### impl Singularity
+### run_import
 
 ```rust
-impl Singularity {
-    pub fn purge_expired(&mut self) -> usize;
-    pub fn is_expired(&self, id: &str) -> bool;
-    pub fn active_concept_ids(&self) -> Vec<String>;
-}
+pub fn run_import(args: ImportArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
 ```
 
 
 
-## src/bridge_retrieval.rs
+## src/cli/commands/inject.rs
 
-### BridgeRetrieval
-
-```rust
-#[derive(Debug, Clone)]
-pub struct BridgeRetrieval {
-}
-```
-
-Bridge retrieval orchestrator combining concept expansion with HDC recall.
-
-### impl BridgeRetrieval
+### run_inject
 
 ```rust
-impl BridgeRetrieval {
-    pub fn new(encoder: TextEncoder, concept_graph: ConceptGraph, config: BridgeConfig) -> Self;
-    pub fn with_defaults(encoder: TextEncoder, concept_graph: ConceptGraph) -> Self;
-    pub fn query(&self, singularity: &Singularity, query_text: &str, top_k: usize, reranker: Option<&dyn Trait>) -> Result<Vec<BridgeHit>>;
-    pub fn memory_packet(&self, singularity: &Singularity, query_text: &str, top_k: usize, reranker: Option<&dyn Trait>) -> Result<MemoryPacket>;
-    pub fn concept_graph(&self) -> &ConceptGraph;
-    pub fn encoder(&self) -> &TextEncoder;
-    pub fn config(&self) -> &BridgeConfig;
-}
+pub fn run_inject(args: InjectArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
 ```
 
 
 
-## src/persistence_wasm.rs
+## src/cli/commands/probe.rs
 
-### Persistence
-
-```rust
-pub struct Persistence;
-```
-
-Persistence stub for wasm32 builds.
-
-### ConceptVersion
+### run_probe
 
 ```rust
-#[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize)]
-pub struct ConceptVersion {
-    pub concept_id: String,
-    pub version: i64,
-    pub vector: HVec10240,
-    pub metadata: serde_json::Value,
-    pub modified_at: u64,
-}
+pub fn run_probe(args: ProbeArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
 ```
 
 
-### impl Persistence
+### run_probe_with_vector
 
 ```rust
-impl Persistence {
-    pub fn new_local(_path: &str) -> Result<Self>;
-    pub fn new_local_with_retention(_path: &str, _retention: usize) -> Result<Self>;
-    pub fn new_turso(_url: &str, _token: &str) -> Result<Self>;
-    pub fn new_turso_with_pool(_url: &str, _token: &str, _pool_size: usize) -> Result<Self>;
-    pub fn new_turso_with_pool_and_retention(_url: &str, _token: &str, _pool_size: usize, _retention: usize) -> Result<Self>;
-    pub fn save_concept(&self, _concept: &Concept) -> Result<()>;
-    pub fn save_concepts(&self, _concepts: &[Concept]) -> Result<()>;
-    pub fn load_concept(&self, _id: &str) -> Result<Option<Concept>>;
-    pub fn load_all_concepts(&self) -> Result<Vec<Concept>>;
-    pub fn delete_concept(&self, _id: &str) -> Result<()>;
-    pub fn save_association(&self, _from: &str, _to: &str, _strength: f32) -> Result<()>;
-    pub fn save_associations(&self, _associations: &[(String, String, f32)]) -> Result<()>;
-    pub fn load_associations(&self, _id: &str) -> Result<Vec<(String, f32)>>;
-    pub fn clear_all(&self) -> Result<()>;
-    pub fn get_concept_history(&self, _id: &str, _limit: usize) -> Result<Vec<ConceptVersion>>;
-    pub fn schema_version(&self) -> Result<i64>;
-    pub fn apply_migrations(&self, _target_version: i64) -> Result<()>;
-    pub fn backup(&self, _path: &str) -> Result<()>;
-    pub fn restore(&self, _path: &str) -> Result<()>;
-    pub fn checkpoint(&self) -> Result<()>;
-    pub fn health_check(&self) -> Result<()>;
-    pub fn size(&self) -> Result<u64>;
-}
+pub fn run_probe_with_vector(query_vector: HVec10240, top_k: usize, threshold: Option<f64>, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
 ```
 
 
 
-## src/error.rs
+## src/cli/commands/index_jsonl.rs
 
-### MemoryError
-
-```rust
-#[derive(Error, Debug)]
-pub enum MemoryError {
-    Database { message: String, source: Option<Box<dyn Trait>> },
-    InvalidInput { field: String, reason: String },
-    InvalidDimension { expected: usize, actual: usize },
-    NotFound { entity: String, id: String },
-    UnsupportedOperation(String),
-    Reservoir { message: String, source: Option<Box<dyn Trait>> },
-    Persistence(String),
-    Io(std::io::Error),
-    Serialization(serde_json::Error),
-}
-```
-
-
-### impl MemoryError
+### run_index_jsonl
 
 ```rust
-impl MemoryError {
-    pub fn database(message: impl Trait) -> Self;
-    pub fn database_with_source(message: impl Trait, source: impl Trait) -> Self;
-    pub fn reservoir(message: impl Trait) -> Self;
-    pub fn reservoir_with_source(message: impl Trait, source: impl Trait) -> Self;
-}
-```
-
-
-### Result
-
-```rust
-pub type Result<T> = std::result::Result<T, MemoryError>
+pub fn run_index_jsonl(args: IndexJsonlArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
 ```
 
 
 
-## src/persistence_versions.rs
+## src/cli/commands/query.rs
 
-### impl Persistence
+### run_query
 
 ```rust
-impl Persistence {
-}
+pub fn run_query(args: QueryArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
 ```
 
 
 
-## src/wasm.rs
+## src/cli/commands/export.rs
 
-### initialize_wasm
-
-```rust
-pub fn initialize_wasm()
-```
-
-
-### WasmFramework
+### run_export
 
 ```rust
-pub struct WasmFramework {
-}
-```
-
-WASM-friendly wrapper for the framework
-
-### impl WasmFramework
-
-```rust
-impl WasmFramework {
-    pub fn new() -> Result<WasmFramework, JsValue>;
-    pub fn inject_concept(&self, id: String, vector: &[u8]) -> Result<(), JsValue>;
-    pub fn probe(&self, vector: &[u8], top_k: usize) -> Result<Array, JsValue>;
-    pub fn associate(&self, from: String, to: String, strength: f32) -> Result<(), JsValue>;
-    pub fn delete_concept(&self, id: String) -> Result<(), JsValue>;
-    pub fn update_concept(&self, id: String, vector: &[u8]) -> Result<(), JsValue>;
-    pub fn disassociate(&self, from: String, to: String) -> Result<(), JsValue>;
-    pub fn get_associations(&self, id: String) -> Result<Array, JsValue>;
-    pub fn get_concept(&self, id: String) -> Result<JsValue, JsValue>;
-    pub fn inject_concepts(&self, ids: Array, vectors: Array) -> Result<(), JsValue>;
-    pub fn associate_many(&self, associations: Array) -> Result<(), JsValue>;
-    pub fn probe_batch(&self, vectors: Array, top_k: usize) -> Result<Array, JsValue>;
-    pub fn metrics_snapshot(&self) -> Result<JsValue, JsValue>;
-    pub fn process_sequence(&self, sequence: Array) -> Result<Box<[u8]>, JsValue>;
-    pub fn export_to_bytes(&self) -> Result<Uint8Array, JsValue>;
-    pub fn import_from_bytes(&self, data: Uint8Array, merge: bool) -> Result<usize, JsValue>;
-}
-```
-
-
-### random_hypervector
-
-```rust
-pub fn random_hypervector() -> Box<[u8]>
-```
-
-Create a random hypervector (1280 bytes)
-
-### encode_text
-
-```rust
-pub fn encode_text(text: &str) -> Box<[u8]>
-```
-
-Encode text to a hypervector using HDC encoding
-
-### cosine_similarity
-
-```rust
-pub fn cosine_similarity(a: &[u8], b: &[u8]) -> Result<f32, JsValue>
-```
-
-Compute cosine similarity between two hypervectors
-
-
-## src/singularity_ext.rs
-
-### impl Singularity
-
-```rust
-impl Singularity {
-    pub fn bundle_concepts_strict(&self, ids: &[String]) -> Result<HVec10240>;
-    pub fn disassociate(&mut self, from: &str, to: &str) -> Result<()>;
-    pub fn clear_associations(&mut self, id: &str) -> Result<()>;
-    pub fn clear_similarity_cache(&self);
-    pub fn update_metadata(&mut self, id: &str, metadata: HashMap<String, serde_json::Value>) -> Result<()>;
-    pub fn find_similar_filtered(&self, query: &HVec10240, top_k: usize, filter: &MetadataFilter) -> Arc<[(String, f32)]>;
-}
+pub fn run_export(args: ExportArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
 ```
 
 
 
-## src/semantic_triples.rs
+## src/cli/commands/mod.rs
 
-### SemanticTriple
-
-```rust
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub struct SemanticTriple {
-    pub subject: String,
-    pub predicate: String,
-    pub object: String,
-}
-```
-
-A semantic triple representing a discrete fact.
-
-### impl SemanticTriple
+### associate::run_associate
 
 ```rust
-impl SemanticTriple {
-    pub fn new(subject: impl Trait, predicate: impl Trait, object: impl Trait) -> Self;
-    pub fn to_sentence(&self) -> String;
-}
+pub use associate::run_associate;
 ```
 
 
-### StructuredMemoryPayload
+### completions::run_completions
 
 ```rust
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StructuredMemoryPayload {
-    pub raw_summary: String,
-    pub triples: Vec<SemanticTriple>,
-}
-```
-
-A structured memory payload that can be stored in a `Concept`'s metadata.
-
-### impl StructuredMemoryPayload
-
-```rust
-impl StructuredMemoryPayload {
-    pub fn to_context_string(&self) -> String;
-}
+pub use completions::run_completions;
 ```
 
 
-
-## src/retrieval/mod.rs
-
-### bm25::{Bm25Config, Bm25Index}
+### export::run_export
 
 ```rust
-pub use bm25::{Bm25Config, Bm25Index};
+pub use export::run_export;
 ```
 
 
-### hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores}
+### import::run_import
 
 ```rust
-pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores};
+pub use import::run_import;
 ```
 
 
-
-## src/retrieval/hybrid.rs
-
-### compute_weights
+### index_dir::run_index_dir
 
 ```rust
-pub fn compute_weights(token_count: usize) -> (f32, f32)
+pub use index_dir::run_index_dir;
 ```
 
-Compute query-length-dependent weights for hybrid retrieval.
 
-Returns (keyword_weight, semantic_weight) based on token count.
-
-| Query Tokens | Keyword | Semantic | Rationale |
-|-------------|---------|----------|-----------|
-| 1-2 | 0.9 | 0.1 | Exact match dominates |
-| 3-4 | 0.7 | 0.3 | Keyword still strong |
-| 5-8 | 0.4 | 0.6 | Semantic takes over |
-| 9+ | 0.2 | 0.8 | Full semantic mode |
-
-### normalize_scores
+### index_jsonl::run_index_jsonl
 
 ```rust
-pub fn normalize_scores(scores: &[(String, f32)]) -> Vec<(String, f32)>
+pub use index_jsonl::run_index_jsonl;
 ```
 
-Normalize scores to [0, 1] range using min-max normalization.
 
-If all scores are equal, returns 0.5 for all.
-
-### merge_results
+### inject::run_inject
 
 ```rust
-pub fn merge_results(bm25_results: &[(String, f32)], hdc_results: &[(String, f32)], weights: (f32, f32)) -> Vec<(String, f32)>
+pub use inject::run_inject;
 ```
 
-Merge BM25 and HDC results with given weights.
 
-Takes two result sets (from BM25 and HDC), normalizes scores,
-and combines them using weighted sum.
-
-Duplicate IDs are merged by taking the maximum combined score.
-
-### HybridMode
+### probe::run_probe
 
 ```rust
-#[derive(Debug, Clone, Copy, PartialEq, Default)]
-pub enum HybridMode {
-    Auto,
-    SemanticOnly,
-    KeywordOnly,
-    Custom(f32),
-}
+pub use probe::run_probe;
 ```
 
-Hybrid retrieval mode.
 
-### HybridConfig
+### query::run_query
 
 ```rust
-#[derive(Debug, Clone)]
-pub struct HybridConfig {
-    pub mode: HybridMode,
-    pub min_score: f32,
-}
+pub use query::run_query;
 ```
 
-Configuration for hybrid retrieval.
 
-### impl Default for HybridConfig
+### print_success
 
 ```rust
-impl Default for HybridConfig {
-}
+pub fn print_success(msg: &str, format: OutputFormat)
+```
+
+
+### print_error
+
+```rust
+pub fn print_error(msg: &str)
+```
+
+
+### print_warning
+
+```rust
+pub fn print_warning(msg: &str, format: OutputFormat)
+```
+
+
+### truncate_preview
+
+```rust
+pub fn truncate_preview(s: &str, max_chars: usize) -> String
+```
+
+Truncate a string to `max_chars` characters, appending "..." if truncated.
+
+Uses `char_indices` to avoid panicking on multi-byte UTF-8 boundaries.
+
+### create_framework
+
+```rust
+pub fn create_framework(db_path: Option<&std::path::Path>) -> Result<ChaoticSemanticFramework>
 ```
 
 
 
-## src/retrieval/bm25.rs
+## src/cli/commands/completions.rs
 
-### Bm25Config
-
-```rust
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct Bm25Config {
-    pub k1: f32,
-    pub b: f32,
-}
-```
-
-Configuration for BM25 ranking algorithm.
-
-### impl Default for Bm25Config
+### run_completions
 
 ```rust
-impl Default for Bm25Config {
-}
-```
-
-
-### Bm25Index
-
-```rust
-#[derive(Debug, Clone, Default)]
-pub struct Bm25Index {
-}
-```
-
-BM25-based document index for keyword search.
-
-### impl Bm25Index
-
-```rust
-impl Bm25Index {
-    pub fn new() -> Self;
-    pub fn with_config(config: Bm25Config) -> Self;
-    pub fn add_document<T: AsRef>(&mut self, id: &str, tokens: &[T]);
-    pub fn remove_document(&mut self, id: &str);
-    pub fn search<T: AsRef>(&self, query_tokens: &[T], top_k: usize) -> Vec<(String, f32)>;
-    pub fn clear(&mut self);
-    pub fn len(&self) -> usize;
-    pub fn is_empty(&self) -> bool;
-    pub fn avg_doc_length(&self) -> f32;
-}
-```
-
-
-
-## src/persistence_migrations.rs
-
-### impl Persistence
-
-```rust
-impl Persistence {
-}
-```
-
-
-
-## src/export_payload/export_payload_tests.rs
-
-
-## src/hyperdim_simd.rs
-
-
-## src/export_payload.rs
-
-### impl From<serde_json::Value> for BinaryMetadataValue
-
-```rust
-impl From<serde_json::Value> for BinaryMetadataValue {
-}
-```
-
-
-### impl From<BinaryMetadataValue> for serde_json::Value
-
-```rust
-impl From<BinaryMetadataValue> for serde_json::Value {
-}
-```
-
-
-### impl From<crate::singularity::Concept> for BinaryConcept
-
-```rust
-impl From<crate::singularity::Concept> for BinaryConcept {
-}
-```
-
-
-### impl BinaryConcept
-
-```rust
-impl BinaryConcept {
-}
-```
-
-
-### impl From<ExportPayload> for BinaryExportPayload
-
-```rust
-impl From<ExportPayload> for BinaryExportPayload {
-}
-```
-
-
-### impl BinaryExportPayload
-
-```rust
-impl BinaryExportPayload {
-}
-```
-
-
-
-## src/framework_builder.rs
-
-### FrameworkConfig
-
-```rust
-#[derive(Clone, Debug)]
-pub struct FrameworkConfig {
-    pub reservoir_size: usize,
-    pub reservoir_input_size: usize,
-    pub chaos_strength: f32,
-    pub enable_persistence: bool,
-    pub max_concepts: Option<usize>,
-    pub max_associations_per_concept: Option<usize>,
-    pub connection_pool_size: usize,
-    pub max_probe_top_k: usize,
-    pub max_metadata_bytes: Option<usize>,
-    pub max_cached_top_k: usize,
-    pub max_batch_size: usize,
-    pub max_sequence_length: usize,
-}
-```
-
-Runtime configuration for [`ChaoticSemanticFramework`], tuned via [`FrameworkBuilder`].
-
-### impl Default for FrameworkConfig
-
-```rust
-impl Default for FrameworkConfig {
-}
-```
-
-
-### FrameworkStats
-
-```rust
-#[derive(Debug, Clone)]
-pub struct FrameworkStats {
-    pub concept_count: usize,
-    pub db_size_bytes: Option<u64>,
-}
-```
-
-Framework statistics
-
-### FrameworkBuilder
-
-```rust
-pub struct FrameworkBuilder {
-}
-```
-
-Builder for ChaoticSemanticFramework
-
-### impl FrameworkBuilder
-
-```rust
-impl FrameworkBuilder {
-    pub fn with_reservoir_size(self, size: usize) -> Self;
-    pub fn with_reservoir_input_size(self, size: usize) -> Self;
-    pub fn with_chaos_strength(self, strength: f32) -> Self;
-    pub fn with_max_concepts(self, max_concepts: usize) -> Self;
-    pub fn with_max_associations_per_concept(self, max_associations: usize) -> Self;
-    pub fn with_concept_cache_size(self, size: usize) -> Self;
-    pub fn with_connection_pool_size(self, pool_size: usize) -> Self;
-    pub fn with_max_probe_top_k(self, max_probe_top_k: usize) -> Self;
-    pub fn with_max_metadata_bytes(self, max_metadata_bytes: usize) -> Self;
-    pub fn with_max_cached_top_k(self, max_cached_top_k: usize) -> Self;
-    pub fn with_max_batch_size(self, max_batch_size: usize) -> Self;
-    pub fn with_max_sequence_length(self, max_sequence_length: usize) -> Self;
-    pub fn with_version_retention(self, retention: usize) -> Self;
-    pub fn with_local_db(self, path: impl Trait) -> Self;
-    pub fn with_turso(self, url: impl Trait, token: impl Trait) -> Self;
-    pub fn without_persistence(self) -> Self;
-    pub fn without_persistence(self) -> Self;
-    pub fn build(self) -> Result<ChaoticSemanticFramework>;
-}
+pub fn run_completions(args: CompletionsArgs) -> Result<()>
 ```
 
 
@@ -2671,6 +1884,94 @@ Creates the `.git/memory-index/` directory if it doesn't exist.
 #### Errors
 
 Returns an error if the directory cannot be created.
+
+
+## src/cli/error.rs
+
+### CliError
+
+```rust
+#[derive(Error, Debug)]
+pub enum CliError {
+    Config(String),
+    Database(String),
+    Input(String),
+    Output(String),
+    Validation(String),
+    Persistence(String),
+    Memory(MemoryError),
+    Io(std::io::Error),
+    Other(String),
+}
+```
+
+
+### impl From<anyhow::Error> for CliError
+
+```rust
+impl From<anyhow::Error> for CliError {
+}
+```
+
+
+### Result
+
+```rust
+pub type Result<T> = std::result::Result<T, CliError>
+```
+
+
+### ExitCode
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExitCode {
+    Success,
+    ConfigError,
+    DatabaseError,
+    InputError,
+    OutputError,
+    ValidationError,
+    MemoryError,
+    IoError,
+    UnknownError,
+}
+```
+
+
+### impl From<&CliError> for ExitCode
+
+```rust
+impl From<&CliError> for ExitCode {
+}
+```
+
+
+### impl From<CliError> for ExitCode
+
+```rust
+impl From<CliError> for ExitCode {
+}
+```
+
+
+### impl CliError
+
+```rust
+impl CliError {
+    pub fn exit_code(&self) -> i32;
+}
+```
+
+
+### impl ExitCode
+
+```rust
+impl ExitCode {
+    pub fn as_i32(self) -> i32;
+}
+```
+
 
 
 ## src/cli/args.rs
@@ -2884,326 +2185,6 @@ pub struct IndexDirArgs {
 Arguments for indexing Markdown directory.
 
 
-## src/cli/error.rs
-
-### CliError
-
-```rust
-#[derive(Error, Debug)]
-pub enum CliError {
-    Config(String),
-    Database(String),
-    Input(String),
-    Output(String),
-    Validation(String),
-    Persistence(String),
-    Memory(MemoryError),
-    Io(std::io::Error),
-    Other(String),
-}
-```
-
-
-### impl From<anyhow::Error> for CliError
-
-```rust
-impl From<anyhow::Error> for CliError {
-}
-```
-
-
-### Result
-
-```rust
-pub type Result<T> = std::result::Result<T, CliError>
-```
-
-
-### ExitCode
-
-```rust
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ExitCode {
-    Success,
-    ConfigError,
-    DatabaseError,
-    InputError,
-    OutputError,
-    ValidationError,
-    MemoryError,
-    IoError,
-    UnknownError,
-}
-```
-
-
-### impl From<&CliError> for ExitCode
-
-```rust
-impl From<&CliError> for ExitCode {
-}
-```
-
-
-### impl From<CliError> for ExitCode
-
-```rust
-impl From<CliError> for ExitCode {
-}
-```
-
-
-### impl CliError
-
-```rust
-impl CliError {
-    pub fn exit_code(&self) -> i32;
-}
-```
-
-
-### impl ExitCode
-
-```rust
-impl ExitCode {
-    pub fn as_i32(self) -> i32;
-}
-```
-
-
-
-## src/cli/commands/query.rs
-
-### run_query
-
-```rust
-pub fn run_query(args: QueryArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
-```
-
-
-
-## src/cli/commands/associate.rs
-
-### run_associate
-
-```rust
-pub fn run_associate(args: AssociateArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
-```
-
-
-### run_associate_batch
-
-```rust
-pub fn run_associate_batch(associations: Vec<(String, String, f64)>, db_path: Option<&Path>, format: OutputFormat, continue_on_error: bool) -> Result<()>
-```
-
-
-
-## src/cli/commands/export.rs
-
-### run_export
-
-```rust
-pub fn run_export(args: ExportArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
-```
-
-
-
-## src/cli/commands/probe.rs
-
-### run_probe
-
-```rust
-pub fn run_probe(args: ProbeArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
-```
-
-
-### run_probe_with_vector
-
-```rust
-pub fn run_probe_with_vector(query_vector: HVec10240, top_k: usize, threshold: Option<f64>, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
-```
-
-
-
-## src/cli/commands/import.rs
-
-### run_import
-
-```rust
-pub fn run_import(args: ImportArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
-```
-
-
-
-## src/cli/commands/completions.rs
-
-### run_completions
-
-```rust
-pub fn run_completions(args: CompletionsArgs) -> Result<()>
-```
-
-
-
-## src/cli/commands/inject.rs
-
-### run_inject
-
-```rust
-pub fn run_inject(args: InjectArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
-```
-
-
-
-## src/cli/commands/mod.rs
-
-### associate::run_associate
-
-```rust
-pub use associate::run_associate;
-```
-
-
-### completions::run_completions
-
-```rust
-pub use completions::run_completions;
-```
-
-
-### export::run_export
-
-```rust
-pub use export::run_export;
-```
-
-
-### import::run_import
-
-```rust
-pub use import::run_import;
-```
-
-
-### index_dir::run_index_dir
-
-```rust
-pub use index_dir::run_index_dir;
-```
-
-
-### index_jsonl::run_index_jsonl
-
-```rust
-pub use index_jsonl::run_index_jsonl;
-```
-
-
-### inject::run_inject
-
-```rust
-pub use inject::run_inject;
-```
-
-
-### probe::run_probe
-
-```rust
-pub use probe::run_probe;
-```
-
-
-### query::run_query
-
-```rust
-pub use query::run_query;
-```
-
-
-### print_success
-
-```rust
-pub fn print_success(msg: &str, format: OutputFormat)
-```
-
-
-### print_error
-
-```rust
-pub fn print_error(msg: &str)
-```
-
-
-### print_warning
-
-```rust
-pub fn print_warning(msg: &str, format: OutputFormat)
-```
-
-
-### truncate_preview
-
-```rust
-pub fn truncate_preview(s: &str, max_chars: usize) -> String
-```
-
-Truncate a string to `max_chars` characters, appending "..." if truncated.
-
-Uses `char_indices` to avoid panicking on multi-byte UTF-8 boundaries.
-
-### create_framework
-
-```rust
-pub fn create_framework(db_path: Option<&std::path::Path>) -> Result<ChaoticSemanticFramework>
-```
-
-
-
-## src/cli/commands/index_jsonl.rs
-
-### run_index_jsonl
-
-```rust
-pub fn run_index_jsonl(args: IndexJsonlArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
-```
-
-
-
-## src/cli/commands/index_dir.rs
-
-### run_index_dir
-
-```rust
-pub fn run_index_dir(args: IndexDirArgs, db_path: Option<&Path>, format: OutputFormat) -> Result<()>
-```
-
-
-### MarkdownChunk
-
-```rust
-#[derive(Debug, Clone)]
-pub struct MarkdownChunk {
-    pub heading: String,
-    pub level: usize,
-    pub content: String,
-}
-```
-
-A chunk of markdown content.
-
-### chunk_by_heading
-
-```rust
-pub fn chunk_by_heading(content: &str, min_level: usize) -> Vec<MarkdownChunk>
-```
-
-Chunk markdown content by heading boundaries.
-
-Only chunks at headings >= min_level (default 2 for ##).
-Heading level 1 (#) is typically the document title and skipped.
-
-
 ## src/cli/mod.rs
 
 ### args::*
@@ -3235,17 +2216,1208 @@ pub use git_local::{ensure_git_local_dir, resolve_git_local_path};
 
 
 
-## src/framework_bridge.rs
+## src/persistence_migrations.rs
+
+### impl Persistence
+
+```rust
+impl Persistence {
+}
+```
+
+
+
+## src/framework_validation.rs
 
 ### impl ChaoticSemanticFramework
 
 ```rust
 impl ChaoticSemanticFramework {
-    pub fn probe_bridge_text(&self, query: &str, top_k: usize, bridge: &BridgeRetrieval) -> Result<Vec<BridgeHit>>;
-    pub fn probe_bridge_text_with_reranker(&self, query: &str, top_k: usize, bridge: &BridgeRetrieval, reranker: &dyn Trait) -> Result<Vec<BridgeHit>>;
-    pub fn probe_bridge_text_filtered(&self, query: &str, top_k: usize, bridge: &BridgeRetrieval, filter: &MetadataFilter) -> Result<Vec<BridgeHit>>;
-    pub fn memory_packet_text(&self, query: &str, top_k: usize, bridge: &BridgeRetrieval) -> Result<MemoryPacket>;
-    pub fn memory_packet_text_with_reranker(&self, query: &str, top_k: usize, bridge: &BridgeRetrieval, reranker: &dyn Trait) -> Result<MemoryPacket>;
+}
+```
+
+
+
+## src/persistence_ops.rs
+
+### impl Persistence
+
+```rust
+impl Persistence {
+    pub fn save_associations(&self, associations: &[(String, String, f32)]) -> Result<()>;
+    pub fn clear_all(&self) -> Result<()>;
+    pub fn get_concept_history(&self, id: &str, limit: usize) -> Result<Vec<ConceptVersion>>;
+    pub fn schema_version(&self) -> Result<i64>;
+    pub fn apply_migrations(&self, target_version: i64) -> Result<()>;
+    pub fn backup(&self, path: &str) -> Result<()>;
+    pub fn restore(&self, path: &str) -> Result<()>;
+    pub fn health_check(&self) -> Result<()>;
+    pub fn delete_association(&self, from: &str, to: &str) -> Result<()>;
+    pub fn clear_concept_associations(&self, id: &str) -> Result<()>;
+}
+```
+
+
+
+## src/reservoir_inertial.rs
+
+### impl Reservoir
+
+```rust
+impl Reservoir {
+    pub fn with_beta(self, beta: f32) -> Result<Self>;
+    pub fn beta(&self) -> f32;
+}
+```
+
+
+
+## src/hyperdim_batch.rs
+
+### batch_cosine_similarity
+
+```rust
+pub fn batch_cosine_similarity(query: &HVec10240, candidates: &[HVec10240]) -> Vec<f32>
+```
+
+Batch similarity computation tuned for cache locality and Rayon overhead.
+
+
+## src/retrieval/hybrid.rs
+
+### compute_weights
+
+```rust
+pub fn compute_weights(token_count: usize) -> (f32, f32)
+```
+
+Compute query-length-dependent weights for hybrid retrieval.
+
+Returns (keyword_weight, semantic_weight) based on token count.
+
+| Query Tokens | Keyword | Semantic | Rationale |
+|-------------|---------|----------|-----------|
+| 1-2 | 0.9 | 0.1 | Exact match dominates |
+| 3-4 | 0.7 | 0.3 | Keyword still strong |
+| 5-8 | 0.4 | 0.6 | Semantic takes over |
+| 9+ | 0.2 | 0.8 | Full semantic mode |
+
+### normalize_scores
+
+```rust
+pub fn normalize_scores(scores: &[(String, f32)]) -> Vec<(String, f32)>
+```
+
+Normalize scores to [0, 1] range using min-max normalization.
+
+If all scores are equal, returns 0.5 for all.
+
+### merge_results
+
+```rust
+pub fn merge_results(bm25_results: &[(String, f32)], hdc_results: &[(String, f32)], weights: (f32, f32)) -> Vec<(String, f32)>
+```
+
+Merge BM25 and HDC results with given weights.
+
+Takes two result sets (from BM25 and HDC), normalizes scores,
+and combines them using weighted sum.
+
+Duplicate IDs are merged by taking the maximum combined score.
+
+### HybridMode
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum HybridMode {
+    Auto,
+    SemanticOnly,
+    KeywordOnly,
+    Custom(f32),
+}
+```
+
+Hybrid retrieval mode.
+
+### HybridConfig
+
+```rust
+#[derive(Debug, Clone)]
+pub struct HybridConfig {
+    pub mode: HybridMode,
+    pub min_score: f32,
+}
+```
+
+Configuration for hybrid retrieval.
+
+### impl Default for HybridConfig
+
+```rust
+impl Default for HybridConfig {
+}
+```
+
+
+
+## src/retrieval/mod.rs
+
+### bm25::{Bm25Config, Bm25Index}
+
+```rust
+pub use bm25::{Bm25Config, Bm25Index};
+```
+
+
+### hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores}
+
+```rust
+pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores};
+```
+
+
+
+## src/retrieval/bm25.rs
+
+### Bm25Config
+
+```rust
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct Bm25Config {
+    pub k1: f32,
+    pub b: f32,
+}
+```
+
+Configuration for BM25 ranking algorithm.
+
+### impl Default for Bm25Config
+
+```rust
+impl Default for Bm25Config {
+}
+```
+
+
+### Bm25Index
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct Bm25Index {
+}
+```
+
+BM25-based document index for keyword search.
+
+### impl Bm25Index
+
+```rust
+impl Bm25Index {
+    pub fn new() -> Self;
+    pub fn with_config(config: Bm25Config) -> Self;
+    pub fn add_document<T: AsRef>(&mut self, id: &str, tokens: &[T]);
+    pub fn remove_document(&mut self, id: &str);
+    pub fn search<T: AsRef>(&self, query_tokens: &[T], top_k: usize) -> Vec<(String, f32)>;
+    pub fn clear(&mut self);
+    pub fn len(&self) -> usize;
+    pub fn is_empty(&self) -> bool;
+    pub fn avg_doc_length(&self) -> f32;
+}
+```
+
+
+
+## src/singularity.rs
+
+### crate::singularity_cache::CacheMetricsSnapshot
+
+```rust
+pub use crate::singularity_cache::CacheMetricsSnapshot;
+```
+
+
+### crate::singularity_retrieval::{CandidateSource, RetrievalConfig, RetrievalStats}
+
+```rust
+pub use crate::singularity_retrieval::{CandidateSource, RetrievalConfig, RetrievalStats};
+```
+
+
+### DEFAULT_MAX_CACHED_TOP_K
+
+```rust
+pub const DEFAULT_MAX_CACHED_TOP_K: usize
+```
+
+
+### Concept
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Concept {
+    pub id: String,
+    pub vector: HVec10240,
+    pub metadata: HashMap<String, serde_json::Value>,
+    pub created_at: u64,
+    pub modified_at: u64,
+    pub expires_at: Option<u64>,
+    pub canonical_concept_ids: Vec<String>,
+}
+```
+
+A concept in semantic memory.
+
+Use [`ConceptBuilder`] to construct instances with proper defaults.
+Direct struct construction is supported but the `expires_at` field should
+default to `None` for backward compatibility.
+
+### SingularityConfig
+
+```rust
+#[derive(Debug, Clone)]
+pub struct SingularityConfig {
+    pub max_concepts: Option<usize>,
+    pub max_associations_per_concept: Option<usize>,
+    pub concept_cache_size: usize,
+    pub max_cached_top_k: usize,
+}
+```
+
+Runtime configuration for [`Singularity`].
+
+### impl Default for SingularityConfig
+
+```rust
+impl Default for SingularityConfig {
+}
+```
+
+
+### Singularity
+
+```rust
+#[derive(Debug)]
+pub struct Singularity {
+}
+```
+
+Episode-free singularity engine
+
+### impl Singularity
+
+```rust
+impl Singularity {
+    pub fn new() -> Self;
+    pub fn with_config(config: SingularityConfig) -> Self;
+    pub fn inject(&mut self, concept: Concept) -> Result<()>;
+    pub fn get(&self, id: &str) -> Option<&Concept>;
+    pub fn delete(&mut self, id: &str) -> Result<()>;
+    pub fn clear(&mut self);
+    pub fn update(&mut self, id: &str, new_vector: HVec10240) -> Result<()>;
+    pub fn find_similar(&self, query: &HVec10240, top_k: usize) -> Vec<(String, f32)>;
+    pub fn find_similar_arc(&self, query: &HVec10240, top_k: usize) -> Arc<[(String, f32)]>;
+    pub fn find_similar_cached(&self, query: &HVec10240, top_k: usize) -> Arc<[(String, f32)]>;
+    pub fn associate(&mut self, from: &str, to: &str, strength: f32) -> Result<()>;
+    pub fn get_associations(&self, id: &str) -> Vec<(String, f32)>;
+    pub fn bundle_concepts(&self, ids: &[String]) -> Result<HVec10240>;
+    pub fn concept_ids(&self) -> Vec<String>;
+    pub fn all_concepts(&self) -> Vec<Concept>;
+    pub fn all_associations(&self) -> Vec<(String, String, f32)>;
+    pub fn len(&self) -> usize;
+    pub fn is_empty(&self) -> bool;
+    pub fn cache_metrics_snapshot(&self) -> CacheMetricsSnapshot;
+}
+```
+
+
+### impl Default for Singularity
+
+```rust
+impl Default for Singularity {
+}
+```
+
+
+### crate::concept_builder::ConceptBuilder
+
+```rust
+pub use crate::concept_builder::ConceptBuilder;
+```
+
+
+
+## src/framework.rs
+
+### ChaoticSemanticFramework
+
+```rust
+pub struct ChaoticSemanticFramework {
+}
+```
+
+Main framework for chaotic semantic memory
+
+### FrameworkMetrics
+
+```rust
+#[derive(Debug, Default)]
+pub struct FrameworkMetrics {
+}
+```
+
+
+### FrameworkMetricsSnapshot
+
+```rust
+#[derive(Debug, Clone)]
+pub struct FrameworkMetricsSnapshot {
+    pub concepts_injected_total: u64,
+    pub associations_created_total: u64,
+    pub probes_total: u64,
+    pub avg_probe_latency_ms: f64,
+    pub cache_hits_total: u64,
+    pub cache_misses_total: u64,
+    pub cache_evictions_total: u64,
+    pub reservoir_steps_total: u64,
+    pub avg_reservoir_step_latency_us: f64,
+    pub reservoir_nodes_active: u64,
+}
+```
+
+
+### impl FrameworkMetrics
+
+```rust
+impl FrameworkMetrics {
+}
+```
+
+
+### impl ChaoticSemanticFramework
+
+```rust
+impl ChaoticSemanticFramework {
+    pub fn builder() -> FrameworkBuilder;
+    pub fn singularity(&self) -> Arc<RwLock<Singularity>>;
+    pub fn inject_concept(&self, id: impl Trait, vector: HVec10240) -> Result<()>;
+    pub fn inject_concept_with_metadata(&self, id: impl Trait, vector: HVec10240, metadata: std::collections::HashMap<String, serde_json::Value>) -> Result<()>;
+    pub fn probe(&self, query: HVec10240, top_k: usize) -> Result<Vec<(String, f32)>>;
+    pub fn probe_filtered(&self, query: &HVec10240, top_k: usize, filter: &MetadataFilter) -> Result<Vec<(String, f32)>>;
+    pub fn traverse(&self, start: &str, config: TraversalConfig) -> Result<Vec<(String, u32)>>;
+    pub fn shortest_path(&self, from: &str, to: &str) -> Result<Option<Vec<String>>>;
+    pub fn process_sequence(&self, sequence: &[Vec<f32>]) -> Result<HVec10240>;
+    pub fn associate(&self, from: &str, to: &str, strength: f32) -> Result<()>;
+    pub fn delete_concept(&self, id: &str) -> Result<()>;
+    pub fn get_associations(&self, id: &str) -> Result<Vec<(String, f32)>>;
+    pub fn get_concept(&self, id: &str) -> Result<Option<Concept>>;
+    pub fn persist(&self) -> Result<()>;
+    pub fn persistence_health_check(&self) -> Result<()>;
+    pub fn load_replace(&self) -> Result<()>;
+    pub fn load_merge(&self) -> Result<()>;
+    pub fn load(&self) -> Result<()>;
+    pub fn metrics_snapshot(&self) -> FrameworkMetricsSnapshot;
+    pub fn stats(&self) -> Result<FrameworkStats>;
+}
+```
+
+
+
+## src/persistence_wasm.rs
+
+### Persistence
+
+```rust
+pub struct Persistence;
+```
+
+Persistence stub for wasm32 builds.
+
+### ConceptVersion
+
+```rust
+#[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize)]
+pub struct ConceptVersion {
+    pub concept_id: String,
+    pub version: i64,
+    pub vector: HVec10240,
+    pub metadata: serde_json::Value,
+    pub modified_at: u64,
+}
+```
+
+
+### impl Persistence
+
+```rust
+impl Persistence {
+    pub fn new_local(_path: &str) -> Result<Self>;
+    pub fn new_local_with_retention(_path: &str, _retention: usize) -> Result<Self>;
+    pub fn new_turso(_url: &str, _token: &str) -> Result<Self>;
+    pub fn new_turso_with_pool(_url: &str, _token: &str, _pool_size: usize) -> Result<Self>;
+    pub fn new_turso_with_pool_and_retention(_url: &str, _token: &str, _pool_size: usize, _retention: usize) -> Result<Self>;
+    pub fn save_concept(&self, _concept: &Concept) -> Result<()>;
+    pub fn save_concepts(&self, _concepts: &[Concept]) -> Result<()>;
+    pub fn load_concept(&self, _id: &str) -> Result<Option<Concept>>;
+    pub fn load_all_concepts(&self) -> Result<Vec<Concept>>;
+    pub fn delete_concept(&self, _id: &str) -> Result<()>;
+    pub fn save_association(&self, _from: &str, _to: &str, _strength: f32) -> Result<()>;
+    pub fn save_associations(&self, _associations: &[(String, String, f32)]) -> Result<()>;
+    pub fn load_associations(&self, _id: &str) -> Result<Vec<(String, f32)>>;
+    pub fn clear_all(&self) -> Result<()>;
+    pub fn get_concept_history(&self, _id: &str, _limit: usize) -> Result<Vec<ConceptVersion>>;
+    pub fn schema_version(&self) -> Result<i64>;
+    pub fn apply_migrations(&self, _target_version: i64) -> Result<()>;
+    pub fn backup(&self, _path: &str) -> Result<()>;
+    pub fn restore(&self, _path: &str) -> Result<()>;
+    pub fn checkpoint(&self) -> Result<()>;
+    pub fn health_check(&self) -> Result<()>;
+    pub fn size(&self) -> Result<u64>;
+}
+```
+
+
+
+## src/framework_ops.rs
+
+### impl ChaoticSemanticFramework
+
+```rust
+impl ChaoticSemanticFramework {
+    pub fn inject_concepts(&self, concepts: &[(String, HVec10240)]) -> Result<()>;
+    pub fn associate_many(&self, associations: &[(String, String, f32)]) -> Result<()>;
+    pub fn probe_batch(&self, queries: &[HVec10240], top_k: usize) -> Result<Vec<Vec<(String, f32)>>>;
+    pub fn probe_batch_cached(&self, queries: &[HVec10240], top_k: usize) -> Result<Vec<Arc<[(String, f32)]>>>;
+    pub fn export_json(&self, path: &str) -> Result<()>;
+    pub fn import_json(&self, path: &str, merge: bool) -> Result<usize>;
+    pub fn export_binary(&self, path: &str) -> Result<()>;
+    pub fn import_binary(&self, path: &str, merge: bool) -> Result<usize>;
+    pub fn backup(&self, path: &str) -> Result<()>;
+    pub fn restore(&self, path: &str) -> Result<()>;
+    pub fn concept_history(&self, id: &str, limit: usize) -> Result<Vec<crate::persistence::ConceptVersion>>;
+    pub fn update_concept_vector(&self, id: &str, vector: HVec10240) -> Result<()>;
+    pub fn update_concept_metadata(&self, id: &str, metadata: std::collections::HashMap<String, serde_json::Value>) -> Result<()>;
+    pub fn disassociate(&self, from: &str, to: &str) -> Result<()>;
+    pub fn clear_associations(&self, id: &str) -> Result<()>;
+    pub fn clear_similarity_cache(&self);
+    pub fn bundle_concepts_strict(&self, ids: &[String]) -> Result<HVec10240>;
+}
+```
+
+
+
+## src/export_payload/export_payload_tests.rs
+
+
+## src/wasm.rs
+
+### initialize_wasm
+
+```rust
+pub fn initialize_wasm()
+```
+
+
+### WasmFramework
+
+```rust
+pub struct WasmFramework {
+}
+```
+
+WASM-friendly wrapper for the framework
+
+### impl WasmFramework
+
+```rust
+impl WasmFramework {
+    pub fn new() -> Result<WasmFramework, JsValue>;
+    pub fn inject_concept(&self, id: String, vector: &[u8]) -> Result<(), JsValue>;
+    pub fn probe(&self, vector: &[u8], top_k: usize) -> Result<Array, JsValue>;
+    pub fn associate(&self, from: String, to: String, strength: f32) -> Result<(), JsValue>;
+    pub fn delete_concept(&self, id: String) -> Result<(), JsValue>;
+    pub fn update_concept(&self, id: String, vector: &[u8]) -> Result<(), JsValue>;
+    pub fn disassociate(&self, from: String, to: String) -> Result<(), JsValue>;
+    pub fn get_associations(&self, id: String) -> Result<Array, JsValue>;
+    pub fn get_concept(&self, id: String) -> Result<JsValue, JsValue>;
+    pub fn inject_concepts(&self, ids: Array, vectors: Array) -> Result<(), JsValue>;
+    pub fn associate_many(&self, associations: Array) -> Result<(), JsValue>;
+    pub fn probe_batch(&self, vectors: Array, top_k: usize) -> Result<Array, JsValue>;
+    pub fn metrics_snapshot(&self) -> Result<JsValue, JsValue>;
+    pub fn process_sequence(&self, sequence: Array) -> Result<Box<[u8]>, JsValue>;
+    pub fn export_to_bytes(&self) -> Result<Uint8Array, JsValue>;
+    pub fn import_from_bytes(&self, data: Uint8Array, merge: bool) -> Result<usize, JsValue>;
+}
+```
+
+
+### random_hypervector
+
+```rust
+pub fn random_hypervector() -> Box<[u8]>
+```
+
+Create a random hypervector (1280 bytes)
+
+### encode_text
+
+```rust
+pub fn encode_text(text: &str) -> Box<[u8]>
+```
+
+Encode text to a hypervector using HDC encoding
+
+### cosine_similarity
+
+```rust
+pub fn cosine_similarity(a: &[u8], b: &[u8]) -> Result<f32, JsValue>
+```
+
+Compute cosine similarity between two hypervectors
+
+
+## src/error.rs
+
+### MemoryError
+
+```rust
+#[derive(Error, Debug)]
+pub enum MemoryError {
+    Database { message: String, source: Option<Box<dyn Trait>> },
+    InvalidInput { field: String, reason: String },
+    InvalidDimension { expected: usize, actual: usize },
+    NotFound { entity: String, id: String },
+    UnsupportedOperation(String),
+    Reservoir { message: String, source: Option<Box<dyn Trait>> },
+    Persistence(String),
+    Io(std::io::Error),
+    Serialization(serde_json::Error),
+}
+```
+
+
+### impl MemoryError
+
+```rust
+impl MemoryError {
+    pub fn database(message: impl Trait) -> Self;
+    pub fn database_with_source(message: impl Trait, source: impl Trait) -> Self;
+    pub fn reservoir(message: impl Trait) -> Self;
+    pub fn reservoir_with_source(message: impl Trait, source: impl Trait) -> Self;
+}
+```
+
+
+### Result
+
+```rust
+pub type Result<T> = std::result::Result<T, MemoryError>
+```
+
+
+
+## src/wasm_ext.rs
+
+### impl WasmFramework
+
+```rust
+impl WasmFramework {
+    pub fn stats(&self) -> Result<JsValue, JsValue>;
+    pub fn concept_count(&self) -> Result<usize, JsValue>;
+    pub fn update_concept_metadata(&self, id: String, metadata_json: String) -> Result<(), JsValue>;
+    pub fn clear_associations(&self, id: String) -> Result<(), JsValue>;
+    pub fn neighbors(&self, id: String, min_strength: f32) -> Result<Array, JsValue>;
+    pub fn bfs(&self, start: String) -> Result<Array, JsValue>;
+    pub fn shortest_path(&self, from: String, to: String) -> Result<Array, JsValue>;
+    pub fn probe_filtered(&self, vector: &[u8], top_k: usize, filter_json: String) -> Result<Array, JsValue>;
+    pub fn traverse(&self, start: String, max_depth: u32, min_strength: f32) -> Result<Array, JsValue>;
+    pub fn on_event(&self, callback: Function);
+    pub fn inject_text(&self, id: String, text: String) -> Result<(), JsValue>;
+    pub fn probe_text(&self, query: String, top_k: usize) -> Result<Array, JsValue>;
+}
+```
+
+
+
+## src/export_payload.rs
+
+### impl From<serde_json::Value> for BinaryMetadataValue
+
+```rust
+impl From<serde_json::Value> for BinaryMetadataValue {
+}
+```
+
+
+### impl From<BinaryMetadataValue> for serde_json::Value
+
+```rust
+impl From<BinaryMetadataValue> for serde_json::Value {
+}
+```
+
+
+### impl From<crate::singularity::Concept> for BinaryConcept
+
+```rust
+impl From<crate::singularity::Concept> for BinaryConcept {
+}
+```
+
+
+### impl BinaryConcept
+
+```rust
+impl BinaryConcept {
+}
+```
+
+
+### impl From<ExportPayload> for BinaryExportPayload
+
+```rust
+impl From<ExportPayload> for BinaryExportPayload {
+}
+```
+
+
+### impl BinaryExportPayload
+
+```rust
+impl BinaryExportPayload {
+}
+```
+
+
+
+## src/persistence_versions.rs
+
+### impl Persistence
+
+```rust
+impl Persistence {
+}
+```
+
+
+
+## src/lib.rs
+
+### bridge_retrieval::BridgeRetrieval
+
+```rust
+pub use bridge_retrieval::BridgeRetrieval;
+```
+
+
+### bundle::BundleAccumulator
+
+```rust
+pub use bundle::BundleAccumulator;
+```
+
+
+### error::{MemoryError, Result}
+
+```rust
+pub use error::{MemoryError, Result};
+```
+
+
+### framework::ChaoticSemanticFramework
+
+```rust
+pub use framework::ChaoticSemanticFramework;
+```
+
+
+### framework_builder::FrameworkBuilder
+
+```rust
+pub use framework_builder::FrameworkBuilder;
+```
+
+
+### framework_events::MemoryEvent
+
+```rust
+pub use framework_events::MemoryEvent;
+```
+
+
+### hyperdim::{HVec10240, batch_cosine_similarity}
+
+```rust
+pub use hyperdim::{HVec10240, batch_cosine_similarity};
+```
+
+
+### semantic_bridge::{BridgeConfig, BridgeHit, CanonicalConcept, ConceptGraph, MemoryPacket, ScoreBreakdown}
+
+```rust
+pub use semantic_bridge::{BridgeConfig, BridgeHit, CanonicalConcept, ConceptGraph, MemoryPacket, ScoreBreakdown};
+```
+
+
+### singularity::{Concept, ConceptBuilder}
+
+```rust
+pub use singularity::{Concept, ConceptBuilder};
+```
+
+
+### singularity_retrieval::{CandidateSource, FilterStrategy, RetrievalConfig, RetrievalStats}
+
+```rust
+pub use singularity_retrieval::{CandidateSource, FilterStrategy, RetrievalConfig, RetrievalStats};
+```
+
+
+### metadata_filter::MetadataFilter
+
+```rust
+pub use metadata_filter::MetadataFilter;
+```
+
+
+### crate::persistence_wasm as persistence
+
+```rust
+pub use crate::persistence_wasm as persistence;
+```
+
+
+### Persistence
+
+```rust
+#[derive(Debug)]
+pub struct Persistence;
+```
+
+Stub persistence type when persistence feature is disabled.
+
+### ConceptVersion
+
+```rust
+#[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize)]
+pub struct ConceptVersion {
+    pub concept_id: String,
+    pub version: i64,
+    pub vector: HVec10240,
+    pub metadata: serde_json::Value,
+    pub modified_at: u64,
+}
+```
+
+Stub concept version type when persistence feature is disabled.
+
+### impl Persistence
+
+```rust
+impl Persistence {
+    pub fn save_concept(&self, _concept: &Concept) -> Result<()>;
+    pub fn save_concepts(&self, _concepts: &[Concept]) -> Result<()>;
+    pub fn load_concept(&self, _id: &str) -> Result<Option<Concept>>;
+    pub fn load_all_concepts(&self) -> Result<Vec<Concept>>;
+    pub fn delete_concept(&self, _id: &str) -> Result<()>;
+    pub fn save_association(&self, _from: &str, _to: &str, _strength: f32) -> Result<()>;
+    pub fn save_associations(&self, _associations: &[(String, String, f32)]) -> Result<()>;
+    pub fn load_associations(&self, _id: &str) -> Result<Vec<(String, f32)>>;
+    pub fn delete_association(&self, _from: &str, _to: &str) -> Result<()>;
+    pub fn clear_concept_associations(&self, _id: &str) -> Result<()>;
+    pub fn clear_all(&self) -> Result<()>;
+    pub fn checkpoint(&self) -> Result<()>;
+    pub fn health_check(&self) -> Result<()>;
+    pub fn size(&self) -> Result<u64>;
+    pub fn backup(&self, _path: &str) -> Result<()>;
+    pub fn restore(&self, _path: &str) -> Result<()>;
+    pub fn get_concept_history(&self, _id: &str, _limit: usize) -> Result<Vec<ConceptVersion>>;
+    pub fn schema_version(&self) -> Result<i64>;
+    pub fn apply_migrations(&self, _target_version: i64) -> Result<()>;
+}
+```
+
+
+### crate::bridge_retrieval::BridgeRetrieval
+
+```rust
+pub use crate::bridge_retrieval::BridgeRetrieval;
+```
+
+
+### crate::bundle::BundleAccumulator
+
+```rust
+pub use crate::bundle::BundleAccumulator;
+```
+
+
+### crate::error::{MemoryError, Result}
+
+```rust
+pub use crate::error::{MemoryError, Result};
+```
+
+
+### crate::framework::ChaoticSemanticFramework
+
+```rust
+pub use crate::framework::ChaoticSemanticFramework;
+```
+
+
+### crate::framework_builder::FrameworkBuilder
+
+```rust
+pub use crate::framework_builder::FrameworkBuilder;
+```
+
+
+### crate::framework_events::MemoryEvent
+
+```rust
+pub use crate::framework_events::MemoryEvent;
+```
+
+
+### crate::hyperdim::HVec10240
+
+```rust
+pub use crate::hyperdim::HVec10240;
+```
+
+
+### crate::semantic_bridge::{BridgeHit, ConceptGraph, MemoryPacket}
+
+```rust
+pub use crate::semantic_bridge::{BridgeHit, ConceptGraph, MemoryPacket};
+```
+
+
+### crate::singularity::{Concept, ConceptBuilder}
+
+```rust
+pub use crate::singularity::{Concept, ConceptBuilder};
+```
+
+
+### crate::singularity_retrieval::{CandidateSource, FilterStrategy, RetrievalConfig, RetrievalStats}
+
+```rust
+pub use crate::singularity_retrieval::{CandidateSource, FilterStrategy, RetrievalConfig, RetrievalStats};
+```
+
+
+
+## src/bridge_retrieval.rs
+
+### BridgeRetrieval
+
+```rust
+#[derive(Debug, Clone)]
+pub struct BridgeRetrieval {
+}
+```
+
+Bridge retrieval orchestrator combining concept expansion with HDC recall.
+
+### impl BridgeRetrieval
+
+```rust
+impl BridgeRetrieval {
+    pub fn new(encoder: TextEncoder, concept_graph: ConceptGraph, config: BridgeConfig) -> Self;
+    pub fn with_defaults(encoder: TextEncoder, concept_graph: ConceptGraph) -> Self;
+    pub fn query(&self, singularity: &Singularity, query_text: &str, top_k: usize, reranker: Option<&dyn Trait>) -> Result<Vec<BridgeHit>>;
+    pub fn memory_packet(&self, singularity: &Singularity, query_text: &str, top_k: usize, reranker: Option<&dyn Trait>) -> Result<MemoryPacket>;
+    pub fn concept_graph(&self) -> &ConceptGraph;
+    pub fn encoder(&self) -> &TextEncoder;
+    pub fn config(&self) -> &BridgeConfig;
+}
+```
+
+
+
+## src/semantic_bridge.rs
+
+### CanonicalConcept
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CanonicalConcept {
+    pub id: String,
+    pub version: u32,
+    pub labels: Vec<String>,
+    pub related: Vec<String>,
+}
+```
+
+A canonical concept with symbolic identity relationships.
+
+Canonical concepts represent semantic equivalence classes (e.g., "agent memory"
+≈ "cross-session context" ≈ "ai memory") without modifying stored vectors.
+
+### impl CanonicalConcept
+
+```rust
+impl CanonicalConcept {
+    pub fn new(id: impl Trait) -> Self;
+    pub fn with_label(self, label: impl Trait) -> Self;
+    pub fn with_related(self, related_id: impl Trait) -> Self;
+}
+```
+
+
+### BridgeConfig
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeConfig {
+    pub max_expansion_depth: u8,
+    pub max_packet_facts: usize,
+    pub token_budget: usize,
+    pub deterministic_weight: f32,
+    pub concept_weight: f32,
+    pub semantic_weight: f32,
+}
+```
+
+Configuration for the bridge retrieval pipeline.
+
+### impl Default for BridgeConfig
+
+```rust
+impl Default for BridgeConfig {
+}
+```
+
+
+### ScoreBreakdown
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScoreBreakdown {
+    pub deterministic: f32,
+    pub concept: f32,
+    pub semantic: f32,
+    pub final_score: f32,
+    pub evidence: Vec<String>,
+}
+```
+
+Breakdown of scores for a bridge retrieval hit.
+
+### impl ScoreBreakdown
+
+```rust
+impl ScoreBreakdown {
+    pub fn deterministic_only(score: f32) -> Self;
+}
+```
+
+
+### BridgeHit
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeHit {
+    pub id: String,
+    pub text_preview: Option<String>,
+    pub scores: ScoreBreakdown,
+}
+```
+
+A single hit from bridge retrieval.
+
+### MemoryPacket
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryPacket {
+    pub query_intent: String,
+    pub facts: Vec<String>,
+    pub sources: Vec<String>,
+    pub confidence: f32,
+}
+```
+
+Compressed memory packet for LLM context injection.
+
+### impl MemoryPacket
+
+```rust
+impl MemoryPacket {
+    pub fn estimated_tokens(&self) -> usize;
+    pub fn to_json(&self) -> serde_json::Result<String>;
+    pub fn to_json_pretty(&self) -> serde_json::Result<String>;
+}
+```
+
+
+### SemanticReranker
+
+```rust
+pub trait SemanticReranker: Send + Sync {
+    fn version(&self) -> &str;
+    fn rerank(&self, query: &str, hits: &mut [BridgeHit]);
+}
+```
+
+Trait for optional semantic reranking.
+
+Implementations can wrap local models, remote APIs, or rule-based heuristics.
+The reranker never mutates deterministic scores—only adjusts ordering.
+
+### ConceptGraph
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct ConceptGraph {
+}
+```
+
+In-memory canonical concept graph for symbolic semantic expansion.
+
+### impl ConceptGraph
+
+```rust
+impl ConceptGraph {
+    pub fn new() -> Self;
+    pub fn add_concept(&mut self, concept: CanonicalConcept);
+    pub fn remove_concept(&mut self, id: &str) -> Option<CanonicalConcept>;
+    pub fn get_concept(&self, id: &str) -> Option<&CanonicalConcept>;
+    pub fn match_tokens(&self, tokens: &[String]) -> Vec<String>;
+    pub fn expand(&self, concept_ids: &[String], max_depth: u8) -> Vec<String>;
+    pub fn load_from_json(reader: impl Trait) -> crate::Result<Self>;
+    pub fn save_to_json(&self, writer: impl Trait) -> crate::Result<()>;
+    pub fn concept_count(&self) -> usize;
+    pub fn label_count(&self) -> usize;
+    pub fn all_concepts(&self) -> impl Trait;
+}
+```
+
+
+
+## src/framework_events.rs
+
+### MemoryEvent
+
+```rust
+#[derive(Debug, Clone)]
+pub enum MemoryEvent {
+    ConceptInjected { id: String, timestamp: u64 },
+    ConceptUpdated { id: String, timestamp: u64 },
+    ConceptDeleted { id: String, timestamp: u64 },
+    Associated { from: String, to: String, strength: f32 },
+    Disassociated { from: String, to: String },
+}
+```
+
+
+### impl ChaoticSemanticFramework
+
+```rust
+impl ChaoticSemanticFramework {
+    pub fn subscribe(&self) -> broadcast::Receiver<MemoryEvent>;
+    pub fn update_concept_vector(&self, id: &str, vector: HVec10240) -> Result<()>;
+    pub fn update_concept_metadata(&self, id: &str, metadata: HashMap<String, serde_json::Value>) -> Result<()>;
+    pub fn disassociate(&self, from: &str, to: &str) -> Result<()>;
+}
+```
+
+
+
+## src/bridge_persistence.rs
+
+### impl Persistence
+
+```rust
+impl Persistence {
+    pub fn save_canonical_concept(&self, concept: &CanonicalConcept) -> Result<()>;
+    pub fn delete_canonical_concept(&self, id: &str) -> Result<()>;
+    pub fn load_canonical_concept(&self, id: &str) -> Result<Option<CanonicalConcept>>;
+    pub fn load_all_canonical_concepts(&self) -> Result<Vec<CanonicalConcept>>;
+    pub fn save_concept_graph(&self, graph: &ConceptGraph) -> Result<()>;
+    pub fn load_concept_graph(&self) -> Result<ConceptGraph>;
+}
+```
+
+
+
+## src/encoder.rs
+
+### TextEncoderConfig
+
+```rust
+#[derive(Debug, Clone)]
+pub struct TextEncoderConfig {
+    pub position_stride: usize,
+    pub ngram_size: Option<usize>,
+    pub lowercase: bool,
+    pub code_aware: bool,
+}
+```
+
+Configuration for the text encoder.
+
+### impl Default for TextEncoderConfig
+
+```rust
+impl Default for TextEncoderConfig {
+}
+```
+
+
+### TextEncoder
+
+```rust
+#[derive(Debug, Clone)]
+pub struct TextEncoder {
+}
+```
+
+Deterministic text-to-hypervector encoder using HDC principles.
+
+Produces consistent `HVec10240` vectors from text input without external dependencies.
+The encoding is:
+- **Deterministic**: Same input always produces same output
+- **Similarity-preserving**: Similar texts produce similar vectors
+- **WASM-compatible**: No external dependencies
+
+### impl Default for TextEncoder
+
+```rust
+impl Default for TextEncoder {
+}
+```
+
+
+### impl TextEncoder
+
+```rust
+impl TextEncoder {
+    pub fn new() -> Self;
+    pub fn with_config(config: TextEncoderConfig) -> Self;
+    pub fn new_code_aware() -> Self;
+    pub fn config(&self) -> &TextEncoderConfig;
+    pub fn encode(&self, text: &str) -> HVec10240;
+    pub fn encode_with_ngrams(&self, text: &str, n: usize) -> HVec10240;
+    pub fn tokenize(text: &str, code_aware: bool, lowercase: bool) -> Vec<String>;
+}
+```
+
+
+
+## src/singularity_ext.rs
+
+### impl Singularity
+
+```rust
+impl Singularity {
+    pub fn bundle_concepts_strict(&self, ids: &[String]) -> Result<HVec10240>;
+    pub fn disassociate(&mut self, from: &str, to: &str) -> Result<()>;
+    pub fn clear_associations(&mut self, id: &str) -> Result<()>;
+    pub fn clear_similarity_cache(&self);
+    pub fn update_metadata(&mut self, id: &str, metadata: HashMap<String, serde_json::Value>) -> Result<()>;
+    pub fn find_similar_filtered(&self, query: &HVec10240, top_k: usize, filter: &MetadataFilter) -> Arc<[(String, f32)]>;
 }
 ```
 
@@ -3327,178 +3499,6 @@ Priority order:
 
 ```rust
 pub fn run_async(args: CliArgs) -> Result<((), OutputFormat), CliError>
-```
-
-
-
-## src/graph_traversal.rs
-
-### TraversalConfig
-
-```rust
-#[derive(Debug, Clone)]
-pub struct TraversalConfig {
-    pub max_depth: usize,
-    pub min_strength: f32,
-    pub max_results: usize,
-}
-```
-
-Configuration for graph traversal operations.
-
-### impl Default for TraversalConfig
-
-```rust
-impl Default for TraversalConfig {
-}
-```
-
-
-### impl Singularity
-
-```rust
-impl Singularity {
-    pub fn neighbors(&self, id: &str, min_strength: f32) -> Vec<(String, f32)>;
-    pub fn incoming_associations(&self, id: &str) -> Vec<(&str, f32)>;
-    pub fn bfs(&self, start: &str, config: &TraversalConfig) -> Result<Vec<(String, u32)>>;
-    pub fn shortest_path(&self, from: &str, to: &str, config: &TraversalConfig) -> Result<Option<Vec<String>>>;
-    pub fn shortest_path_hops(&self, from: &str, to: &str, config: &TraversalConfig) -> Result<Option<Vec<String>>>;
-}
-```
-
-
-
-## src/singularity_cache.rs
-
-### impl QueryCache
-
-```rust
-impl QueryCache {
-}
-```
-
-
-### CacheMetricsSnapshot
-
-```rust
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct CacheMetricsSnapshot {
-    pub cache_hits_total: u64,
-    pub cache_misses_total: u64,
-    pub cache_evictions_total: u64,
-}
-```
-
-
-### impl CacheMetrics
-
-```rust
-impl CacheMetrics {
-}
-```
-
-
-
-## src/encoder.rs
-
-### TextEncoderConfig
-
-```rust
-#[derive(Debug, Clone)]
-pub struct TextEncoderConfig {
-    pub position_stride: usize,
-    pub ngram_size: Option<usize>,
-    pub lowercase: bool,
-    pub code_aware: bool,
-}
-```
-
-Configuration for the text encoder.
-
-### impl Default for TextEncoderConfig
-
-```rust
-impl Default for TextEncoderConfig {
-}
-```
-
-
-### TextEncoder
-
-```rust
-#[derive(Debug, Clone)]
-pub struct TextEncoder {
-}
-```
-
-Deterministic text-to-hypervector encoder using HDC principles.
-
-Produces consistent `HVec10240` vectors from text input without external dependencies.
-The encoding is:
-- **Deterministic**: Same input always produces same output
-- **Similarity-preserving**: Similar texts produce similar vectors
-- **WASM-compatible**: No external dependencies
-
-### impl Default for TextEncoder
-
-```rust
-impl Default for TextEncoder {
-}
-```
-
-
-### impl TextEncoder
-
-```rust
-impl TextEncoder {
-    pub fn new() -> Self;
-    pub fn with_config(config: TextEncoderConfig) -> Self;
-    pub fn new_code_aware() -> Self;
-    pub fn config(&self) -> &TextEncoderConfig;
-    pub fn encode(&self, text: &str) -> HVec10240;
-    pub fn encode_with_ngrams(&self, text: &str, n: usize) -> HVec10240;
-    pub fn tokenize(text: &str, code_aware: bool, lowercase: bool) -> Vec<String>;
-}
-```
-
-
-
-## src/bundle.rs
-
-### BundleAccumulator
-
-```rust
-#[derive(Debug, Clone)]
-pub struct BundleAccumulator {
-}
-```
-
-Incremental bundle accumulator for streaming/sliding-window memory.
-
-Maintains signed bit counts for efficient add/remove operations.
-Finalize applies majority threshold to produce a bundled hypervector.
-
-### impl Default for BundleAccumulator
-
-```rust
-impl Default for BundleAccumulator {
-}
-```
-
-
-### impl BundleAccumulator
-
-```rust
-impl BundleAccumulator {
-    pub fn new() -> Self;
-    pub fn add(&mut self, hv: &HVec10240);
-    pub fn remove(&mut self, hv: &HVec10240);
-    pub fn try_remove(&mut self, hv: &HVec10240) -> Result<()>;
-    pub fn finalize(&self) -> HVec10240;
-    pub fn len(&self) -> u32;
-    pub fn is_empty(&self) -> bool;
-    pub fn clear(&mut self);
-}
 ```
 
 

--- a/llms.txt
+++ b/llms.txt
@@ -8,28 +8,28 @@
 **Homepage:** https://github.com/d-o-hub/chaotic_semantic_memory
 **Keywords:** ai, memory, hypervector, reservoir, wasm
 **Dependencies:**
-- rand_chacha (0.10.0)
-- clap (4.5.60) [features: derive, env, string]
-- tracing (0.1.41)
-- tracing-subscriber (0.3.19)
-- serde_json (1.0.149)
-- thiserror (2.0.11)
-- clap_complete (4.5.42)
-- anyhow (1.0.102)
-- bincode (1.3.3)
-- rand (0.10.1)
-- colored (2.2.0)
-- base64 (0.22)
-- glob (0.3.2)
 - serde (1.0.219) [features: derive]
+- glob (0.3.2)
+- tracing-subscriber (0.3.19)
+- base64 (0.22)
+- tracing (0.1.41)
+- clap_complete (4.5.42)
+- serde_json (1.0.149)
+- bincode (1.3.3)
+- thiserror (2.0.11)
+- rand (0.10.1)
+- clap (4.5.60) [features: derive, env, string]
+- anyhow (1.0.102)
+- rand_chacha (0.10.0)
+- colored (2.2.0)
 **Features:**
 - cli: [dep:clap, dep:clap_complete, dep:anyhow, dep:colored, dep:glob]
+- parallel: [dep:rayon]
+- default: [cli, persistence, parallel]
 - persistence: [dep:libsql]
 - wasm: []
-- default: [cli, persistence, parallel]
-- parallel: [dep:rayon]
 
-Generated: 2026-04-29 07:45:10 UTC  
+Generated: 2026-04-29 05:39:56 UTC
 Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 
 ## Core Documentation
@@ -40,9 +40,16 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 
 ## Table of Contents
 
-### src/reservoir_inertial.rs
+### src/framework_bridge.rs
 
-- impl Reservoir
+- impl ChaoticSemanticFramework
+
+### src/semantic_triples.rs
+
+- pub struct SemanticTriple
+- impl SemanticTriple
+- pub struct StructuredMemoryPayload
+- impl StructuredMemoryPayload
 
 ### src/reservoir.rs
 
@@ -53,14 +60,10 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub struct ChaoticReservoir
 - impl ChaoticReservoir
 
-### src/framework_events.rs
+### src/concept_builder.rs
 
-- pub enum MemoryEvent
-- impl ChaoticSemanticFramework
-
-### src/reservoir_sparse.rs
-
-- impl SparseWeights
+- pub struct ConceptBuilder
+- impl ConceptBuilder
 
 ### src/hyperdim.rs
 
@@ -72,57 +75,56 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - impl Deserialize for HVec10240
 - pub use crate::bundle::BundleAccumulator
 
+### src/bundle.rs
+
+- pub struct BundleAccumulator
+- impl Default for BundleAccumulator
+- impl BundleAccumulator
+
+### src/metadata_filter.rs
+
+- pub enum MetadataFilter
+- impl MetadataFilter
+- impl ops::Not for MetadataFilter
+
+### src/persistence.rs
+
+- pub struct Persistence
+- pub struct ConceptVersion
+- impl Persistence
+
+### src/reservoir_sparse.rs
+
+- impl SparseWeights
+
+### src/singularity_ttl.rs
+
+- impl Default for Concept
+- impl Singularity
+
+### src/singularity_cache.rs
+
+- impl QueryCache
+- pub struct CacheMetricsSnapshot
+- impl CacheMetrics
+
 ### src/framework_ttl.rs
 
 - impl crate::framework::ChaoticSemanticFramework
 
-### src/concept_builder.rs
+### src/framework_builder.rs
 
-- pub struct ConceptBuilder
-- impl ConceptBuilder
+- pub struct FrameworkConfig
+- impl Default for FrameworkConfig
+- pub struct FrameworkStats
+- pub struct FrameworkBuilder
+- impl FrameworkBuilder
 
-### src/persistence_ops.rs
+### src/graph_traversal.rs
 
-- impl Persistence
-
-### src/framework.rs
-
-- pub struct ChaoticSemanticFramework
-- pub struct FrameworkMetrics
-- pub struct FrameworkMetricsSnapshot
-- impl FrameworkMetrics
-- impl ChaoticSemanticFramework
-
-### src/hyperdim_batch.rs
-
-- pub fn batch_cosine_similarity
-
-### src/framework_validation.rs
-
-- impl ChaoticSemanticFramework
-
-### src/semantic_bridge.rs
-
-- pub struct CanonicalConcept
-- impl CanonicalConcept
-- pub struct BridgeConfig
-- impl Default for BridgeConfig
-- pub struct ScoreBreakdown
-- impl ScoreBreakdown
-- pub struct BridgeHit
-- pub struct MemoryPacket
-- impl MemoryPacket
-- pub trait SemanticReranker
-- pub struct ConceptGraph
-- impl ConceptGraph
-
-### src/framework_ops.rs
-
-- impl ChaoticSemanticFramework
-
-### src/bridge_persistence.rs
-
-- impl Persistence
+- pub struct TraversalConfig
+- impl Default for TraversalConfig
+- impl Singularity
 
 ### src/singularity_retrieval.rs
 
@@ -134,10 +136,222 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - impl Default for RetrievalConfig
 - impl Singularity
 
-### src/persistence.rs
+### src/cli/commands/index_dir.rs
+
+- pub fn run_index_dir
+- pub struct MarkdownChunk
+- pub fn chunk_by_heading
+
+### src/cli/commands/associate.rs
+
+- pub fn run_associate
+- pub fn run_associate_batch
+
+### src/cli/commands/import.rs
+
+- pub fn run_import
+
+### src/cli/commands/inject.rs
+
+- pub fn run_inject
+
+### src/cli/commands/probe.rs
+
+- pub fn run_probe
+- pub fn run_probe_with_vector
+
+### src/cli/commands/index_jsonl.rs
+
+- pub fn run_index_jsonl
+
+### src/cli/commands/query.rs
+
+- pub fn run_query
+
+### src/cli/commands/export.rs
+
+- pub fn run_export
+
+### src/cli/commands/mod.rs
+
+- pub mod associate
+- pub mod completions
+- pub mod export
+- pub mod import
+- pub mod index_dir
+- pub mod index_jsonl
+- pub mod inject
+- pub mod probe
+- pub mod query
+- pub use associate::run_associate
+- pub use completions::run_completions
+- pub use export::run_export
+- pub use import::run_import
+- pub use index_dir::run_index_dir
+- pub use index_jsonl::run_index_jsonl
+- pub use inject::run_inject
+- pub use probe::run_probe
+- pub use query::run_query
+- pub fn print_success
+- pub fn print_error
+- pub fn print_warning
+- pub fn truncate_preview
+- pub fn create_framework
+
+### src/cli/commands/completions.rs
+
+- pub fn run_completions
+
+### src/cli/git_local.rs
+
+- pub fn resolve_git_local_path
+- pub fn ensure_git_local_dir
+
+### src/cli/error.rs
+
+- pub enum CliError
+- impl From for CliError
+- pub type Result
+- pub enum ExitCode
+- impl From for ExitCode
+- impl From for ExitCode
+- impl CliError
+- impl ExitCode
+
+### src/cli/args.rs
+
+- pub struct CliArgs
+- pub enum OutputFormat
+- pub enum Commands
+- pub struct InjectArgs
+- pub enum VectorSource
+- pub struct ProbeArgs
+- pub struct QueryArgs
+- pub struct AssociateArgs
+- pub enum ExportFormat
+- pub struct ExportArgs
+- pub enum ImportFormat
+- pub struct ImportArgs
+- pub struct VersionArgs
+- pub struct CompletionsArgs
+- pub struct IndexJsonlArgs
+- pub struct IndexDirArgs
+
+### src/cli/mod.rs
+
+- pub mod args
+- pub mod commands
+- pub mod error
+- pub mod git_local
+- pub use args::*
+- pub use commands::{run_associate, run_completions, run_export, run_import, run_index_dir, run_index_jsonl, run_inject, run_probe, run_query}
+- pub use error::{CliError, ExitCode, Result}
+- pub use git_local::{ensure_git_local_dir, resolve_git_local_path}
+
+### src/persistence_migrations.rs
+
+- impl Persistence
+
+### src/framework_validation.rs
+
+- impl ChaoticSemanticFramework
+
+### src/persistence_ops.rs
+
+- impl Persistence
+
+### src/reservoir_inertial.rs
+
+- impl Reservoir
+
+### src/hyperdim_batch.rs
+
+- pub fn batch_cosine_similarity
+
+### src/retrieval/hybrid.rs
+
+- pub fn compute_weights
+- pub fn normalize_scores
+- pub fn merge_results
+- pub enum HybridMode
+- pub struct HybridConfig
+- impl Default for HybridConfig
+
+### src/retrieval/mod.rs
+
+- pub mod bm25
+- pub mod hybrid
+- pub use bm25::{Bm25Config, Bm25Index}
+- pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores}
+
+### src/retrieval/bm25.rs
+
+- pub struct Bm25Config
+- impl Default for Bm25Config
+- pub struct Bm25Index
+- impl Bm25Index
+
+### src/singularity.rs
+
+- pub use crate::singularity_cache::CacheMetricsSnapshot
+- pub use crate::singularity_retrieval::{CandidateSource, RetrievalConfig, RetrievalStats}
+- pub const DEFAULT_MAX_CACHED_TOP_K
+- pub struct Concept
+- pub struct SingularityConfig
+- impl Default for SingularityConfig
+- pub struct Singularity
+- impl Singularity
+- impl Default for Singularity
+- pub use crate::concept_builder::ConceptBuilder
+
+### src/framework.rs
+
+- pub struct ChaoticSemanticFramework
+- pub struct FrameworkMetrics
+- pub struct FrameworkMetricsSnapshot
+- impl FrameworkMetrics
+- impl ChaoticSemanticFramework
+
+### src/persistence_wasm.rs
 
 - pub struct Persistence
 - pub struct ConceptVersion
+- impl Persistence
+
+### src/framework_ops.rs
+
+- impl ChaoticSemanticFramework
+
+### src/wasm.rs
+
+- pub fn initialize_wasm
+- pub struct WasmFramework
+- impl WasmFramework
+- pub fn random_hypervector
+- pub fn encode_text
+- pub fn cosine_similarity
+
+### src/error.rs
+
+- pub enum MemoryError
+- impl MemoryError
+- pub type Result
+
+### src/wasm_ext.rs
+
+- impl WasmFramework
+
+### src/export_payload.rs
+
+- impl From for BinaryMetadataValue
+- impl From for serde_json::Value
+- impl From for BinaryConcept
+- impl BinaryConcept
+- impl From for BinaryExportPayload
+- impl BinaryExportPayload
+
+### src/persistence_versions.rs
+
 - impl Persistence
 
 ### src/lib.rs
@@ -189,234 +403,46 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub use prelude::crate::singularity_retrieval::{CandidateSource, FilterStrategy, RetrievalConfig, RetrievalStats}
 - pub mod wasm
 
-### src/metadata_filter.rs
-
-- pub enum MetadataFilter
-- impl MetadataFilter
-- impl ops::Not for MetadataFilter
-
-### src/wasm_ext.rs
-
-- impl WasmFramework
-
-### src/singularity.rs
-
-- pub use crate::singularity_cache::CacheMetricsSnapshot
-- pub use crate::singularity_retrieval::{CandidateSource, RetrievalConfig, RetrievalStats}
-- pub const DEFAULT_MAX_CACHED_TOP_K
-- pub struct Concept
-- pub struct SingularityConfig
-- impl Default for SingularityConfig
-- pub struct Singularity
-- impl Singularity
-- impl Default for Singularity
-- pub use crate::concept_builder::ConceptBuilder
-
-### src/singularity_ttl.rs
-
-- impl Default for Concept
-- impl Singularity
-
 ### src/bridge_retrieval.rs
 
 - pub struct BridgeRetrieval
 - impl BridgeRetrieval
 
-### src/persistence_wasm.rs
+### src/semantic_bridge.rs
 
-- pub struct Persistence
-- pub struct ConceptVersion
+- pub struct CanonicalConcept
+- impl CanonicalConcept
+- pub struct BridgeConfig
+- impl Default for BridgeConfig
+- pub struct ScoreBreakdown
+- impl ScoreBreakdown
+- pub struct BridgeHit
+- pub struct MemoryPacket
+- impl MemoryPacket
+- pub trait SemanticReranker
+- pub struct ConceptGraph
+- impl ConceptGraph
+
+### src/framework_events.rs
+
+- pub enum MemoryEvent
+- impl ChaoticSemanticFramework
+
+### src/bridge_persistence.rs
+
 - impl Persistence
 
-### src/error.rs
+### src/encoder.rs
 
-- pub enum MemoryError
-- impl MemoryError
-- pub type Result
-
-### src/persistence_versions.rs
-
-- impl Persistence
-
-### src/wasm.rs
-
-- pub fn initialize_wasm
-- pub struct WasmFramework
-- impl WasmFramework
-- pub fn random_hypervector
-- pub fn encode_text
-- pub fn cosine_similarity
+- pub struct TextEncoderConfig
+- impl Default for TextEncoderConfig
+- pub struct TextEncoder
+- impl Default for TextEncoder
+- impl TextEncoder
 
 ### src/singularity_ext.rs
 
 - impl Singularity
-
-### src/semantic_triples.rs
-
-- pub struct SemanticTriple
-- impl SemanticTriple
-- pub struct StructuredMemoryPayload
-- impl StructuredMemoryPayload
-
-### src/retrieval/mod.rs
-
-- pub mod bm25
-- pub mod hybrid
-- pub use bm25::{Bm25Config, Bm25Index}
-- pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores}
-
-### src/retrieval/hybrid.rs
-
-- pub fn compute_weights
-- pub fn normalize_scores
-- pub fn merge_results
-- pub enum HybridMode
-- pub struct HybridConfig
-- impl Default for HybridConfig
-
-### src/retrieval/bm25.rs
-
-- pub struct Bm25Config
-- impl Default for Bm25Config
-- pub struct Bm25Index
-- impl Bm25Index
-
-### src/persistence_migrations.rs
-
-- impl Persistence
-
-### src/export_payload.rs
-
-- impl From for BinaryMetadataValue
-- impl From for serde_json::Value
-- impl From for BinaryConcept
-- impl BinaryConcept
-- impl From for BinaryExportPayload
-- impl BinaryExportPayload
-
-### src/framework_builder.rs
-
-- pub struct FrameworkConfig
-- impl Default for FrameworkConfig
-- pub struct FrameworkStats
-- pub struct FrameworkBuilder
-- impl FrameworkBuilder
-
-### src/cli/git_local.rs
-
-- pub fn resolve_git_local_path
-- pub fn ensure_git_local_dir
-
-### src/cli/args.rs
-
-- pub struct CliArgs
-- pub enum OutputFormat
-- pub enum Commands
-- pub struct InjectArgs
-- pub enum VectorSource
-- pub struct ProbeArgs
-- pub struct QueryArgs
-- pub struct AssociateArgs
-- pub enum ExportFormat
-- pub struct ExportArgs
-- pub enum ImportFormat
-- pub struct ImportArgs
-- pub struct VersionArgs
-- pub struct CompletionsArgs
-- pub struct IndexJsonlArgs
-- pub struct IndexDirArgs
-
-### src/cli/error.rs
-
-- pub enum CliError
-- impl From for CliError
-- pub type Result
-- pub enum ExitCode
-- impl From for ExitCode
-- impl From for ExitCode
-- impl CliError
-- impl ExitCode
-
-### src/cli/commands/query.rs
-
-- pub fn run_query
-
-### src/cli/commands/associate.rs
-
-- pub fn run_associate
-- pub fn run_associate_batch
-
-### src/cli/commands/export.rs
-
-- pub fn run_export
-
-### src/cli/commands/probe.rs
-
-- pub fn run_probe
-- pub fn run_probe_with_vector
-
-### src/cli/commands/import.rs
-
-- pub fn run_import
-
-### src/cli/commands/completions.rs
-
-- pub fn run_completions
-
-### src/cli/commands/inject.rs
-
-- pub fn run_inject
-
-### src/cli/commands/mod.rs
-
-- pub mod associate
-- pub mod completions
-- pub mod export
-- pub mod import
-- pub mod index_dir
-- pub mod index_jsonl
-- pub mod inject
-- pub mod probe
-- pub mod query
-- pub use associate::run_associate
-- pub use completions::run_completions
-- pub use export::run_export
-- pub use import::run_import
-- pub use index_dir::run_index_dir
-- pub use index_jsonl::run_index_jsonl
-- pub use inject::run_inject
-- pub use probe::run_probe
-- pub use query::run_query
-- pub fn print_success
-- pub fn print_error
-- pub fn print_warning
-- pub fn truncate_preview
-- pub fn create_framework
-
-### src/cli/commands/index_jsonl.rs
-
-- pub fn run_index_jsonl
-
-### src/cli/commands/index_dir.rs
-
-- pub fn run_index_dir
-- pub struct MarkdownChunk
-- pub fn chunk_by_heading
-
-### src/cli/mod.rs
-
-- pub mod args
-- pub mod commands
-- pub mod error
-- pub mod git_local
-- pub use args::*
-- pub use commands::{run_associate, run_completions, run_export, run_import, run_index_dir, run_index_jsonl, run_inject, run_probe, run_query}
-- pub use error::{CliError, ExitCode, Result}
-- pub use git_local::{ensure_git_local_dir, resolve_git_local_path}
-
-### src/framework_bridge.rs
-
-- impl ChaoticSemanticFramework
 
 ### src/bin/csm.rs
 
@@ -430,32 +456,6 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub fn native::handle_completions
 - pub fn native::resolve_database_path
 - pub fn native::run_async
-
-### src/graph_traversal.rs
-
-- pub struct TraversalConfig
-- impl Default for TraversalConfig
-- impl Singularity
-
-### src/singularity_cache.rs
-
-- impl QueryCache
-- pub struct CacheMetricsSnapshot
-- impl CacheMetrics
-
-### src/encoder.rs
-
-- pub struct TextEncoderConfig
-- impl Default for TextEncoderConfig
-- pub struct TextEncoder
-- impl Default for TextEncoder
-- impl TextEncoder
-
-### src/bundle.rs
-
-- pub struct BundleAccumulator
-- impl Default for BundleAccumulator
-- impl BundleAccumulator
 
 ---
 

--- a/plans/handoffs/W5_C_to_D_wasm_size_report.md
+++ b/plans/handoffs/W5_C_to_D_wasm_size_report.md
@@ -6,7 +6,7 @@
 ## Measurement
 - Command: `cargo build --target wasm32-unknown-unknown --release --features wasm`
 - Artifact: `target/wasm32-unknown-unknown/release/chaotic_semantic_memory.wasm`
-- Size: `882118` bytes (`861.44` KiB)
+- Size: `880074` bytes (`859.45` KiB)
 - Threshold: `1048576` bytes (configurable via `CSM_WASM_SIZE_MAX_BYTES`)
 
 ## Result

--- a/src/singularity_retrieval.rs
+++ b/src/singularity_retrieval.rs
@@ -195,36 +195,44 @@ impl Singularity {
     ) -> Arc<[(String, f32)]> {
         let scoring_start = unix_now_ns();
 
+        // Algorithmic Optimization: Use integer Hamming distance for ranking to avoid floating-point
+        // overhead and use a fused allocation to improve cache locality.
         #[cfg(all(not(target_arch = "wasm32"), feature = "parallel"))]
-        let scores: Vec<f32> = self
+        let mut scores: Vec<(usize, u32)> = self
             .concept_vectors
             .par_iter()
-            .map(|v| query.cosine_similarity(v))
+            .enumerate()
+            .with_min_len(512)
+            .map(|(idx, v)| (idx, query.hamming_distance(v)))
             .collect();
 
         #[cfg(any(target_arch = "wasm32", not(feature = "parallel")))]
-        let scores: Vec<f32> = self
+        let mut scores: Vec<(usize, u32)> = self
             .concept_vectors
             .iter()
-            .map(|v| query.cosine_similarity(v))
+            .enumerate()
+            .map(|(idx, v)| (idx, query.hamming_distance(v)))
             .collect();
 
         let scoring_ns = unix_now_ns().saturating_sub(scoring_start);
         let scored_count = scores.len();
 
-        let mut indices: Vec<usize> = (0..scored_count).collect();
-
+        // Sort by Hamming distance (ascending = more similar)
         if scored_count <= top_k {
-            indices.sort_by(|&a, &b| scores[b].total_cmp(&scores[a]));
+            scores.sort_unstable_by_key(|&(_, dist)| dist);
         } else {
-            indices.select_nth_unstable_by(top_k - 1, |&a, &b| scores[b].total_cmp(&scores[a]));
-            indices.truncate(top_k);
-            indices.sort_by(|&a, &b| scores[b].total_cmp(&scores[a]));
+            scores.select_nth_unstable_by(top_k - 1, |a, b| a.1.cmp(&b.1));
+            scores.truncate(top_k);
+            scores.sort_unstable_by_key(|&(_, dist)| dist);
         }
 
-        let results: Vec<(String, f32)> = indices
+        let results: Vec<(String, f32)> = scores
             .into_iter()
-            .map(|idx| (self.concept_indices[idx].clone(), scores[idx]))
+            .map(|(idx, dist)| {
+                // Defer cosine similarity calculation until the final top_k results
+                let similarity = 1.0 - (dist as f32 / 5120.0);
+                (self.concept_indices[idx].clone(), similarity)
+            })
             .collect();
 
         let results_arc = Arc::from(results);
@@ -268,31 +276,34 @@ impl Singularity {
         let candidate_count = candidates.len();
 
         #[cfg(all(not(target_arch = "wasm32"), feature = "parallel"))]
-        let mut scores: Vec<(usize, f32)> = candidates
+        let mut scores: Vec<(usize, u32)> = candidates
             .into_par_iter()
-            .map(|idx| (idx, query.cosine_similarity(&self.concept_vectors[idx])))
+            .map(|idx| (idx, query.hamming_distance(&self.concept_vectors[idx])))
             .collect();
 
         #[cfg(any(target_arch = "wasm32", not(feature = "parallel")))]
-        let mut scores: Vec<(usize, f32)> = candidates
+        let mut scores: Vec<(usize, u32)> = candidates
             .into_iter()
-            .map(|idx| (idx, query.cosine_similarity(&self.concept_vectors[idx])))
+            .map(|idx| (idx, query.hamming_distance(&self.concept_vectors[idx])))
             .collect();
 
         let scoring_ns = unix_now_ns().saturating_sub(scoring_start);
         let scored_count = scores.len();
 
         if scores.len() <= top_k {
-            scores.sort_by(|a, b| b.1.total_cmp(&a.1));
+            scores.sort_unstable_by_key(|&(_, dist)| dist);
         } else {
-            scores.select_nth_unstable_by(top_k - 1, |a, b| b.1.total_cmp(&a.1));
+            scores.select_nth_unstable_by(top_k - 1, |a, b| a.1.cmp(&b.1));
             scores.truncate(top_k);
-            scores.sort_by(|a, b| b.1.total_cmp(&a.1));
+            scores.sort_unstable_by_key(|&(_, dist)| dist);
         }
 
         let results: Vec<(String, f32)> = scores
             .into_iter()
-            .map(|(idx, score)| (self.concept_indices[idx].clone(), score))
+            .map(|(idx, dist)| {
+                let similarity = 1.0 - (dist as f32 / 5120.0);
+                (self.concept_indices[idx].clone(), similarity)
+            })
             .collect();
 
         let results_arc = Arc::from(results);
@@ -366,31 +377,34 @@ impl Singularity {
         let candidate_count = candidates.len();
 
         #[cfg(all(not(target_arch = "wasm32"), feature = "parallel"))]
-        let mut scores: Vec<(usize, f32)> = candidates
+        let mut scores: Vec<(usize, u32)> = candidates
             .into_par_iter()
-            .map(|idx| (idx, query.cosine_similarity(&self.concept_vectors[idx])))
+            .map(|idx| (idx, query.hamming_distance(&self.concept_vectors[idx])))
             .collect();
 
         #[cfg(any(target_arch = "wasm32", not(feature = "parallel")))]
-        let mut scores: Vec<(usize, f32)> = candidates
+        let mut scores: Vec<(usize, u32)> = candidates
             .into_iter()
-            .map(|idx| (idx, query.cosine_similarity(&self.concept_vectors[idx])))
+            .map(|idx| (idx, query.hamming_distance(&self.concept_vectors[idx])))
             .collect();
 
         let scoring_ns = unix_now_ns().saturating_sub(scoring_start);
         let scored_count = scores.len();
 
         if scores.len() <= top_k {
-            scores.sort_by(|a, b| b.1.total_cmp(&a.1));
+            scores.sort_unstable_by_key(|&(_, dist)| dist);
         } else {
-            scores.select_nth_unstable_by(top_k - 1, |a, b| b.1.total_cmp(&a.1));
+            scores.select_nth_unstable_by(top_k - 1, |a, b| a.1.cmp(&b.1));
             scores.truncate(top_k);
-            scores.sort_by(|a, b| b.1.total_cmp(&a.1));
+            scores.sort_unstable_by_key(|&(_, dist)| dist);
         }
 
         let results: Vec<(String, f32)> = scores
             .into_iter()
-            .map(|(idx, score)| (self.concept_indices[idx].clone(), score))
+            .map(|(idx, dist)| {
+                let similarity = 1.0 - (dist as f32 / 5120.0);
+                (self.concept_indices[idx].clone(), similarity)
+            })
             .collect();
 
         let results_arc = Arc::from(results);


### PR DESCRIPTION
What: Replaced floating-point cosine similarity ranking with integer Hamming distance ranking in the semantic retrieval hot path. Fused index and score allocations into a single vector of pairs to improve cache locality.

Why: Calculating cosine similarity for all documents during a scan is expensive due to floating-point divisions and conversions. Ranking on integer distances is faster and avoids the overhead of f32::total_cmp.

Impact: Reduced allocation overhead and improved cache locality for large-scale similarity scans. Optimized Rayon task granularity with with_min_len(512). Verified 333 tests passing.

---
*PR created automatically by Jules for task [14101379004962807968](https://jules.google.com/task/14101379004962807968) started by @d-o-hub*