### PR TITLE
Bridge Association TaskType testing gap in benchmarks

### DIFF
--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -325,6 +325,7 @@ name = "chaotic_semantic_memory"
 version = "0.3.5"
 dependencies = [
  "anyhow",
+ "async-trait",
  "base64 0.22.1",
  "bincode",
  "clap",

--- a/benchmarks/src/generator.rs
+++ b/benchmarks/src/generator.rs
@@ -172,21 +172,40 @@ pub fn generate_queries(sessions: &[Session]) -> Vec<QueryCase> {
 
     // Add cross-session query types (Association and MultiSession)
     if sessions.len() >= 2 {
-        // Association: Link concepts across sessions
-        let s1 = &sessions[0];
-        let s2 = &sessions[1];
-        cases.push(QueryCase {
-            query_id: "cross-session:association".into(),
-            session_id: "cross-session".into(),
-            task_type: TaskType::Association,
-            query: "What colors have I mentioned across different conversations?".into(),
-            gold_evidence_ids: vec![
-                format!("{}:favorite_color:v1", s1.session_id),
-                format!("{}:favorite_color:v1", s2.session_id),
-            ],
-            expected_answer: None,
-            should_abstain: false,
-        });
+        // Association: Link concepts across sessions by finding common themes
+        for i in 0..sessions.len().min(10) {
+            let s1 = &sessions[i];
+            let s2 = &sessions[(i + 1) % sessions.len()];
+
+            // Generate association query based on shared color or city if possible,
+            // but for simplicity we'll just use colors from these two sessions.
+            cases.push(QueryCase {
+                query_id: format!("association-{:03}", i),
+                session_id: "cross-session".into(),
+                task_type: TaskType::Association,
+                query: "What are the favorite colors I've mentioned in my different chats?".into(),
+                gold_evidence_ids: vec![
+                    format!("{}:favorite_color:v1", s1.session_id),
+                    format!("{}:favorite_color:v1", s2.session_id),
+                ],
+                expected_answer: None,
+                should_abstain: false,
+            });
+
+            // Add a query that targets explicit associations between city and color in a session
+            cases.push(QueryCase {
+                query_id: format!("association-internal-{:03}", i),
+                session_id: s1.session_id.clone(),
+                task_type: TaskType::Association,
+                query: "Show me items related to my location and interests in this session.".into(),
+                gold_evidence_ids: vec![
+                    format!("{}:favorite_color:v1", s1.session_id),
+                    format!("{}:city:v1", s1.session_id),
+                ],
+                expected_answer: None,
+                should_abstain: false,
+            });
+        }
 
         // MultiSession: Aggregate across sessions
         cases.push(QueryCase {

--- a/benchmarks/src/memory_adapter.rs
+++ b/benchmarks/src/memory_adapter.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use chaotic_semantic_memory::prelude::*;
+use chaotic_semantic_memory::retrieval::GraphRagConfig;
 use chaotic_semantic_memory::retrieval::bm25::Bm25Index;
 use chaotic_semantic_memory::retrieval::hybrid::{compute_weights, merge_results};
 use std::collections::{HashMap, HashSet};
@@ -76,6 +77,35 @@ impl MemoryAdapter {
         // Store text for retrieval
         self.text_store.write().await.insert(id.to_string(), text.to_string());
 
+        // Create automatic associations for cross-session linking
+        // For benchmarks, we associate concepts within the same session
+        // and concepts with shared significant tokens across sessions.
+        if let Some((session_id, _)) = id.split_once(':') {
+            let text_store = self.text_store.read().await;
+            for (other_id, other_text) in text_store.iter() {
+                if other_id == id {
+                    continue;
+                }
+
+                let mut strength = 0.0;
+                if other_id.starts_with(session_id) {
+                    // Intra-session association
+                    strength = 0.8;
+                } else {
+                    // Cross-session association based on token overlap
+                    let other_tokens = tokenize_for_bm25(other_text);
+                    let overlap = Self::token_overlap_ratio(&tokens, &other_tokens);
+                    if overlap > 0.3 {
+                        strength = overlap * 0.5;
+                    }
+                }
+
+                if strength > 0.0 {
+                    self.framework.associate(id, other_id, strength).await?;
+                }
+            }
+        }
+
         if let Some(previous_id) = Self::previous_version_id(id) {
             if let Err(err) = self.framework.delete_concept(&previous_id).await {
                 debug!(target: "benchmark", %previous_id, ?err, "failed to delete prior version");
@@ -89,8 +119,34 @@ impl MemoryAdapter {
     }
 
     pub async fn query(&self, text: &str, top_k: usize) -> Result<Vec<(String, f32)>> {
+        self.query_internal(text, top_k, false).await
+    }
+
+    /// Query specifically for association tasks using GraphRAG.
+    pub async fn query_association(&self, text: &str, top_k: usize) -> Result<Vec<(String, f32)>> {
+        self.query_internal(text, top_k, true).await
+    }
+
+    async fn query_internal(&self, text: &str, top_k: usize, use_graph: bool) -> Result<Vec<(String, f32)>> {
         // Get HDC results
-        let hdc_hits = self.framework.probe_text(text, top_k * 3).await?; // Get more for filtering
+        let hdc_hits = if use_graph {
+            let config = GraphRagConfig {
+                anchor_top_k: top_k,
+                final_top_k: top_k * 2,
+                max_hops: 2,
+                similarity_weight: 0.4,
+                graph_weight: 0.6,
+                ..Default::default()
+            };
+            self.framework
+                .probe_text_with_graph(text, config)
+                .await?
+                .into_iter()
+                .map(|r| (r.id, r.score))
+                .collect()
+        } else {
+            self.framework.probe_text(text, top_k * 3).await?
+        };
 
         // Get BM25 results
         let query_tokens = tokenize_for_bm25(text);
@@ -134,8 +190,21 @@ impl MemoryAdapter {
 
     /// Query with session filtering - only returns documents from the specified session.
     pub async fn query_in_session(&self, text: &str, session_id: &str, top_k: usize) -> Result<Vec<(String, f32)>> {
+        self.query_in_session_internal(text, session_id, top_k, false).await
+    }
+
+    /// Query with session filtering specifically for association tasks.
+    pub async fn query_in_session_association(&self, text: &str, session_id: &str, top_k: usize) -> Result<Vec<(String, f32)>> {
+        self.query_in_session_internal(text, session_id, top_k, true).await
+    }
+
+    async fn query_in_session_internal(&self, text: &str, session_id: &str, top_k: usize, use_graph: bool) -> Result<Vec<(String, f32)>> {
         // Get all results
-        let all_results = self.query(text, top_k * 3).await?;
+        let all_results = if use_graph {
+            self.query_association(text, top_k * 3).await?
+        } else {
+            self.query(text, top_k * 3).await?
+        };
 
         // Filter to session-specific results
         let session_prefix = format!("{}:", session_id);

--- a/benchmarks/src/metrics.rs
+++ b/benchmarks/src/metrics.rs
@@ -49,6 +49,17 @@ pub fn aggregate(
         (0.0, 0.0)
     };
 
+    let association_cases: Vec<_> = results
+        .iter()
+        .filter(|r| matches!(r.task_type, TaskType::Association))
+        .collect();
+    let association_success_rate = if !association_cases.is_empty() {
+        association_cases.iter().filter(|r| r.recall_at_5).count() as f32
+            / association_cases.len() as f32
+    } else {
+        0.0
+    };
+
     let mut latencies: Vec<_> = results.iter().map(|r| r.latency_ms).collect();
     latencies.sort_unstable();
     // Use floor-based indexing for percentiles (industry standard)
@@ -80,6 +91,7 @@ pub fn aggregate(
         exact_match,
         abstain_precision,
         abstain_recall,
+        association_success_rate,
         ingest_ms,
         p50_latency_ms: p50,
         p50_latency_us: p50_us,

--- a/benchmarks/src/report.rs
+++ b/benchmarks/src/report.rs
@@ -47,6 +47,7 @@ pub fn write_markdown(
 - Recall@10: {:.4}\n\
 - MRR: {:.4}\n\
 - NDCG@10: {:.4}\n\
+- Association Success: {:.4}
 - Abstain precision: {:.4}\n\
 - Abstain recall: {:.4}\n\
 - Ingest ms: {}\n\
@@ -75,6 +76,7 @@ pub fn write_markdown(
         summary.recall_at_10,
         summary.mrr,
         summary.ndcg_at_10,
+        summary.association_success_rate,
         summary.abstain_precision,
         summary.abstain_recall,
         summary.ingest_ms,

--- a/benchmarks/src/runner.rs
+++ b/benchmarks/src/runner.rs
@@ -48,14 +48,21 @@ pub async fn run(cli: Cli) -> Result<()> {
         let start_query = Instant::now();
 
         // Use session-scoped retrieval for session-specific queries
-        let hits = if matches!(
-            query_case.task_type,
-            TaskType::Recall | TaskType::Update | TaskType::Temporal | TaskType::Abstain,
-        ) {
-            adapter.query_in_session(&query_case.query, &query_case.session_id, cli.top_k).await?
-        } else {
-            // For abstain and other queries, search globally
-            adapter.query(&query_case.query, cli.top_k).await?
+        let hits = match query_case.task_type {
+            TaskType::Recall | TaskType::Update | TaskType::Temporal | TaskType::Abstain => {
+                adapter.query_in_session(&query_case.query, &query_case.session_id, cli.top_k).await?
+            }
+            TaskType::Association => {
+                if query_case.session_id == "cross-session" {
+                    adapter.query_association(&query_case.query, cli.top_k).await?
+                } else {
+                    adapter.query_in_session_association(&query_case.query, &query_case.session_id, cli.top_k).await?
+                }
+            }
+            _ => {
+                // For other queries, search globally
+                adapter.query(&query_case.query, cli.top_k).await?
+            }
         };
         let elapsed = start_query.elapsed();
         let latency_ms = elapsed.as_millis();

--- a/benchmarks/src/types.rs
+++ b/benchmarks/src/types.rs
@@ -128,6 +128,9 @@ pub struct SummaryMetrics {
     pub abstain_precision: f32,
     /// Recall of abstention decisions.
     pub abstain_recall: f32,
+    /// Success rate of association tasks.
+    #[serde(default)]
+    pub association_success_rate: f32,
     /// Total ingestion time in milliseconds.
     pub ingest_ms: u128,
     /// Median (p50) query latency in milliseconds.


### PR DESCRIPTION
This PR bridges the testing gap for `TaskType::Association` in the benchmark suite.

Previously, `TaskType::Association` was defined but not generated or specifically handled in benchmarks. This change:
1.  **Enhances Case Generation**: `generator.rs` now produces a variety of association queries that link concepts across and within sessions.
2.  **Implements Graph-Aware Retrieval**: The benchmark `MemoryAdapter` now automatically establishes associations between concepts during ingestion based on session context and content overlap. It uses the framework's `probe_text_with_graph` (GraphRAG) to resolve these associations during retrieval.
3.  **Adds Scoring Metrics**: A new `association_success_rate` metric (Recall@5 for association tasks) is added to the summary report to track the effectiveness of association-based retrieval.

Verified by running the benchmark suite and ensuring that association cases are now executed and scored correctly. All system tests passed.

Fixes #160

---
*PR created automatically by Jules for task [16103141312131552272](https://jules.google.com/task/16103141312131552272) started by @d-o-hub*