### PR TITLE
Decouple llms.txt diff check from LOC gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,8 +132,13 @@ jobs:
         VERSION="${{ steps.version.outputs.version }}"
         bash scripts/sync-version.sh "$VERSION"
 
-    - name: Generate llms.txt files for AI tool integration
-      run: bash scripts/gen-llms-txt.sh
+    - name: Regenerate & commit llms.txt
+      run: |
+        bash scripts/gen-llms-txt.sh
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add llms.txt llms-full.txt
+        git diff --cached --quiet || (git commit -m "chore: regenerate llms.txt for release [skip ci]" && git push)
 
     - name: Ensure version sync is clean
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,16 @@ jobs:
     - name: Regenerate & commit llms.txt
       run: |
         bash scripts/gen-llms-txt.sh
+
+        # Verify API surface threshold before committing
+        LOC=$(grep -cE '^\s*(pub |fn |struct |enum |trait |impl )' llms-full.txt || true)
+        echo "Public API surface: $LOC symbols"
+        THRESHOLD=5000
+        if [[ "$LOC" -gt "$THRESHOLD" ]]; then
+          echo "❌ API surface $LOC exceeds threshold of $THRESHOLD"
+          exit 1
+        fi
+
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git add llms.txt llms-full.txt

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -645,6 +645,10 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 
 - impl WasmFramework
 
+### src/wasm_graph_rag.rs
+
+- impl WasmFramework
+
 ## README.md
 
 ### CLI workflow test (inject → probe → export → import)
@@ -3782,12 +3786,6 @@ pub fn graph_rag_retrieve(query: &HVec10240, concepts: &[Concept], associations:
 
 Execute GraphRAG retrieval.
 
-Algorithm:
-1. Anchor: probe(query, anchor_top_k) → seed set
-2. Expand: traverse from each anchor
-3. Score: similarity_weight * cosine + graph_weight * (1/(1+hops)) * strength
-4. Dedupe + rank by score
-
 ### impl Default for GraphRagConfig
 
 ```rust
@@ -4433,3 +4431,13 @@ impl WasmFramework {
 }
 ```
 
+## src/wasm_graph_rag.rs
+
+### impl WasmFramework
+
+```rust
+impl WasmFramework {
+    pub fn probe_with_graph(&self, vector: &[u8], anchor_top_k: usize, max_hops: usize, min_assoc_strength: f32, similarity_weight: f32, graph_weight: f32, final_top_k: usize) -> Result<Array, JsValue>;
+    pub fn probe_text_with_graph(&self, text: String, anchor_top_k: usize, max_hops: usize, min_assoc_strength: f32, similarity_weight: f32, graph_weight: f32, final_top_k: usize) -> Result<Array, JsValue>;
+}
+```

--- a/llms.txt
+++ b/llms.txt
@@ -645,6 +645,10 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 
 - impl WasmFramework
 
+### src/wasm_graph_rag.rs
+
+- impl WasmFramework
+
 ## Core Documentation
 
 - [Complete API Documentation](llms-full.txt): Full public API documentation with detailed descriptions

--- a/plans/handoffs/W5_C_to_D_wasm_size_report.md
+++ b/plans/handoffs/W5_C_to_D_wasm_size_report.md
@@ -6,7 +6,7 @@
 ## Measurement
 - Command: `cargo build --target wasm32-unknown-unknown --release --features wasm`
 - Artifact: `target/wasm32-unknown-unknown/release/chaotic_semantic_memory.wasm`
-- Size: `875960` bytes (`855.43` KiB)
+- Size: `919681` bytes (`898.13` KiB)
 - Threshold: `1048576` bytes (configurable via `CSM_WASM_SIZE_MAX_BYTES`)
 
 ## Result

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -45,13 +45,11 @@ if [ -f "CHANGELOG.md" ]; then
   fi
 fi
 
-# Docs sync: regenerate llms.txt files and add to staging
+# Docs sync: regenerate llms.txt files
 echo " → Regenerating llms.txt files..."
 if [[ -f "scripts/gen-llms-txt.sh" ]]; then
     bash scripts/gen-llms-txt.sh 2>/dev/null || true
-    # Add regenerated files to staging so they're included in commit
-    git add llms.txt llms-full.txt 2>/dev/null || true
-    echo "   ✓ llms.txt files regenerated and staged"
+    echo "   ✓ llms.txt files regenerated"
 fi
 
 # Docs version sync check (will fail if other docs need updates)

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -26,10 +26,10 @@ done
 
 # CHANGELOG duplicate header guardrail (prevents release workflow failures)
 echo " → Checking CHANGELOG format..."
-if [ -f "CHANGELOG.md" ]; then
+if [[ -f "CHANGELOG.md" ]]; then
   # Check for duplicate version headers (each version should appear exactly once)
   DUPLICATES=$(grep "^## \\[" CHANGELOG.md | cut -d'[' -f2 | cut -d']' -f1 | sort | uniq -d)
-  if [ -n "$DUPLICATES" ]; then
+  if [[ -n "$DUPLICATES" ]]; then
     echo "❌ Duplicate CHANGELOG headers found: $DUPLICATES"
     echo "   Each version should have exactly one '## [VERSION] - YYYY-MM-DD' header"
     exit 1
@@ -37,7 +37,7 @@ if [ -f "CHANGELOG.md" ]; then
   
   # Check that version headers have dates
   NO_DATE=$(grep "^## \\[" CHANGELOG.md | grep -v " - [0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\}" | grep -v "\\[Unreleased\\]" || true)
-  if [ -n "$NO_DATE" ]; then
+  if [[ -n "$NO_DATE" ]]; then
     echo "❌ CHANGELOG headers missing dates:"
     echo "$NO_DATE"
     echo "   Format: ## [VERSION] - YYYY-MM-DD"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -63,11 +63,17 @@ fi
 
 echo "==> Generating/validating llms.txt and llms-full.txt"
 scripts/gen-llms-txt.sh
-if ! git diff --quiet llms.txt llms-full.txt 2>/dev/null; then
-  echo "❌ llms.txt or llms-full.txt was modified. Run scripts/gen-llms-txt.sh and commit the changes."
-  git diff llms.txt llms-full.txt
+
+LOC=$(grep -cE '^\s*(pub |fn |struct |enum |trait |impl )' llms-full.txt || true)
+echo "Public API surface: $LOC symbols"
+
+THRESHOLD=5000
+if [ "$LOC" -gt "$THRESHOLD" ]; then
+  echo "❌ API surface $LOC exceeds threshold of $THRESHOLD"
   exit 1
 fi
+
+echo "✅ API surface within threshold ($LOC / $THRESHOLD)"
 
 if command -v npm >/dev/null 2>&1; then
   echo "==> CLI npm pack smoke test"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -36,7 +36,7 @@ cargo test --all-targets
 echo "==> Source file LOC gate (< ${MAX_SRC_LOC})"
 for file in $(find src -name '*.rs'); do
   loc="$(wc -l < "${file}")"
-  if [ "${loc}" -gt "${MAX_SRC_LOC}" ]; then
+  if [[ "${loc}" -gt "${MAX_SRC_LOC}" ]]; then
     echo "LOC gate failed: ${file} has ${loc} lines"
     exit 1
   fi
@@ -56,7 +56,7 @@ else
   echo "skip: ${WASM_TARGET} target not installed"
 fi
 
-if [ -x scripts/wasm_size_gate.sh ]; then
+if [[ -x scripts/wasm_size_gate.sh ]]; then
   echo "==> scripts/wasm_size_gate.sh"
   scripts/wasm_size_gate.sh
 fi
@@ -68,7 +68,7 @@ LOC=$(grep -cE '^\s*(pub |fn |struct |enum |trait |impl )' llms-full.txt || true
 echo "Public API surface: $LOC symbols"
 
 THRESHOLD=5000
-if [ "$LOC" -gt "$THRESHOLD" ]; then
+if [[ "$LOC" -gt "$THRESHOLD" ]]; then
   echo "❌ API surface $LOC exceeds threshold of $THRESHOLD"
   exit 1
 fi


### PR DESCRIPTION
Decoupled the `llms.txt` synchronization check from the standard CI linting process. Instead of failing on stale artifacts, CI now enforces a public API surface threshold (5000 symbols) to prevent uncontrolled growth. Automation for updating and committing these artifacts has been moved to the release workflow. Pre-commit hook still regenerates them for local visibility but no longer auto-stages them.

Fixes #175

---
*PR created automatically by Jules for task [3286101680947605025](https://jules.google.com/task/3286101680947605025) started by @d-o-hub*