### PR TITLE
Federation-Ready API Enhancements (ADR-055)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-05-01
+
+### Added
+- **Federation-ready API enhancements**: Added `Hash` derive to `HVec10240`, `WIRE_VERSION` constants to `HVec10240`, `BundleAccumulator`, and `ConceptGraph`.
+- **Serde for Bundle/Graph**: Added `Serialize`/`Deserialize` to `BundleAccumulator` and `ConceptGraph` (gated by `serde` feature).
+- **Signing Helper**: Added `HVec10240::canonical_bytes()` helper (gated by `signing` feature) for cross-agent trust verification.
+
 ## [0.3.5] - 2026-04-28
 
 ### Fixed
@@ -397,8 +404,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated CI workflow with security permissions and concurrency controls
 - Trusted Publishing eliminates need for long-lived API tokens
 
+[0.4.0]: https://github.com/d-o-hub/chaotic_semantic_memory/compare/v0.3.5...v0.4.0
 [0.3.5]: https://github.com/d-o-hub/chaotic_semantic_memory/compare/v0.3.4...v0.3.5
-[unreleased]: https://github.com/d-o-hub/chaotic_semantic_memory/compare/v0.3.5...HEAD
+[unreleased]: https://github.com/d-o-hub/chaotic_semantic_memory/compare/v0.4.0...HEAD
 [0.3.4]: https://github.com/d-o-hub/chaotic_semantic_memory/compare/v0.3.2...v0.3.4
 [0.3.2]: https://github.com/d-o-hub/chaotic_semantic_memory/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/d-o-hub/chaotic_semantic_memory/releases/tag/v0.3.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "chaotic_semantic_memory"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chaotic_semantic_memory"
-version = "0.3.5"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.85"
 description = "AI memory systems with hyperdimensional vectors and chaotic reservoirs"
@@ -240,6 +240,10 @@ prometheus = ["dep:prometheus", "dep:hyper", "dep:hyper-util", "dep:http-body-ut
 
 # Reranking pipeline (ADR-0071)
 rerank-cross = ["dep:candle-core", "dep:candle-onnx"]
+
+# Federation-ready API enhancements (ADR-055 downstream)
+signing = []
+serde = []
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-O", "--enable-bulk-memory", "--enable-sign-ext"]

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -9,8 +9,8 @@ use crate::hyperdim::HVec10240;
 /// Finalize applies majority threshold to produce a bundled hypervector.
 #[derive(Debug, Clone)]
 pub struct BundleAccumulator {
-    counts: Box<[i32; HVec10240::DIMENSION]>,
-    n: u32,
+    pub(crate) counts: Box<[i32; HVec10240::DIMENSION]>,
+    pub(crate) n: u32,
 }
 
 impl Default for BundleAccumulator {
@@ -23,6 +23,9 @@ impl Default for BundleAccumulator {
 }
 
 impl BundleAccumulator {
+    /// Wire-format version. Bump when `serde` layout changes.
+    pub const WIRE_VERSION: u32 = 1;
+
     /// Create a new empty accumulator.
     pub fn new() -> Self {
         Self {

--- a/src/bundle_serde.rs
+++ b/src/bundle_serde.rs
@@ -1,0 +1,82 @@
+//! Serde Serialize/Deserialize implementations for BundleAccumulator.
+
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+
+use crate::bundle::BundleAccumulator;
+use crate::hyperdim::HVec10240;
+
+impl Serialize for BundleAccumulator {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("BundleAccumulator", 2)?;
+        // Serialize as a slice since large arrays aren't natively supported by Serde
+        state.serialize_field("counts", &self.counts.as_slice())?;
+        state.serialize_field("n", &self.n)?;
+        state.end()
+    }
+}
+
+struct BundleVisitor;
+
+impl<'de> Visitor<'de> for BundleVisitor {
+    type Value = BundleAccumulator;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("struct BundleAccumulator")
+    }
+
+    fn visit_map<V>(self, mut map: V) -> std::result::Result<Self::Value, V::Error>
+    where
+        V: de::MapAccess<'de>,
+    {
+        let mut counts: Option<Vec<i32>> = None;
+        let mut n: Option<u32> = None;
+
+        while let Some(key) = map.next_key::<String>()? {
+            match key.as_str() {
+                "counts" => {
+                    counts = Some(map.next_value()?);
+                }
+                "n" => {
+                    n = Some(map.next_value()?);
+                }
+                _ => {
+                    let _: serde::de::IgnoredAny = map.next_value()?;
+                }
+            }
+        }
+
+        let counts_vec = counts.ok_or_else(|| de::Error::missing_field("counts"))?;
+        if counts_vec.len() != HVec10240::DIMENSION {
+            return Err(de::Error::custom(format!(
+                "expected {} counts, got {}",
+                HVec10240::DIMENSION,
+                counts_vec.len()
+            )));
+        }
+
+        let mut counts_array = Box::new([0i32; HVec10240::DIMENSION]);
+        counts_array.copy_from_slice(&counts_vec);
+
+        let n = n.ok_or_else(|| de::Error::missing_field("n"))?;
+
+        Ok(BundleAccumulator {
+            counts: counts_array,
+            n,
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for BundleAccumulator {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_struct("BundleAccumulator", &["counts", "n"], BundleVisitor)
+    }
+}

--- a/src/hyperdim.rs
+++ b/src/hyperdim.rs
@@ -27,13 +27,16 @@ use crate::hyperdim_simd::bind_simd_x86;
 use crate::hyperdim_simd::hamming_distance_optimized;
 
 /// 10240-bit hypervector (80 x 128-bit words)
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[must_use]
 pub struct HVec10240 {
     pub(crate) data: [u128; 80],
 }
 
 impl HVec10240 {
+    /// Wire-format version. Bump when `to_bytes` layout changes.
+    pub const WIRE_VERSION: u32 = 1;
+
     pub const DIMENSION: usize = 10240;
     pub const WORDS: usize = 80;
 
@@ -311,6 +314,15 @@ impl HVec10240 {
         for word in &self.data {
             bytes.extend_from_slice(&word.to_le_bytes());
         }
+        bytes
+    }
+
+    /// Stable signing input. Format: WIRE_VERSION (LE u32) || to_bytes().
+    #[cfg(feature = "signing")]
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(4 + 1280);
+        bytes.extend_from_slice(&Self::WIRE_VERSION.to_le_bytes());
+        bytes.extend_from_slice(&self.to_bytes());
         bytes
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,8 @@ pub use singularity_retrieval::{CandidateSource, FilterStrategy, RetrievalConfig
 mod bridge_persistence;
 pub mod bridge_retrieval;
 pub mod bundle;
+#[cfg(feature = "serde")]
+mod bundle_serde;
 #[cfg(all(not(target_arch = "wasm32"), feature = "cli"))]
 pub mod cli;
 pub mod concept_builder;

--- a/src/semantic_bridge.rs
+++ b/src/semantic_bridge.rs
@@ -171,6 +171,7 @@ pub trait SemanticReranker: Send + Sync {
 
 /// In-memory canonical concept graph for symbolic semantic expansion.
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConceptGraph {
     /// Concepts indexed by ID.
     concepts: std::collections::HashMap<String, CanonicalConcept>,
@@ -179,6 +180,9 @@ pub struct ConceptGraph {
 }
 
 impl ConceptGraph {
+    /// Wire-format version. Bump when `serde` layout changes.
+    pub const WIRE_VERSION: u32 = 1;
+
     /// Create an empty concept graph.
     pub fn new() -> Self {
         Self::default()

--- a/tests/federation_enhancements.rs
+++ b/tests/federation_enhancements.rs
@@ -1,0 +1,62 @@
+#[cfg(test)]
+mod federation_tests {
+    use chaotic_semantic_memory::prelude::*;
+
+    #[test]
+    fn test_hvec_hash_available() {
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        let v1 = HVec10240::random();
+        let v2 = HVec10240::random();
+        set.insert(v1);
+        set.insert(v2);
+        assert!(set.contains(&v1));
+        assert!(set.contains(&v2));
+    }
+
+    #[test]
+    fn test_wire_versions() {
+        assert_eq!(HVec10240::WIRE_VERSION, 1);
+        assert_eq!(BundleAccumulator::WIRE_VERSION, 1);
+        assert_eq!(ConceptGraph::WIRE_VERSION, 1);
+    }
+
+    #[test]
+    #[cfg(feature = "signing")]
+    fn test_hvec_canonical_bytes() {
+        let v = HVec10240::random();
+        let canon = v.canonical_bytes();
+        assert_eq!(canon.len(), 4 + 1280);
+        assert_eq!(&canon[0..4], &HVec10240::WIRE_VERSION.to_le_bytes());
+        assert_eq!(&canon[4..], &v.to_bytes()[..]);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_bundle_accumulator_serde_roundtrip() {
+        let mut acc = BundleAccumulator::new();
+        let v1 = HVec10240::random();
+        acc.add(&v1);
+
+        let json = serde_json::to_string(&acc).unwrap();
+        let decoded: BundleAccumulator = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(acc.len(), decoded.len());
+        assert_eq!(acc.finalize(), decoded.finalize());
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_concept_graph_serde_roundtrip() {
+        let mut graph = ConceptGraph::new();
+        graph.add_concept(
+            chaotic_semantic_memory::semantic_bridge::CanonicalConcept::new("c1").with_label("l1"),
+        );
+
+        let json = serde_json::to_string(&graph).unwrap();
+        let decoded: ConceptGraph = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(graph.concept_count(), decoded.concept_count());
+        assert!(decoded.get_concept("c1").is_some());
+    }
+}


### PR DESCRIPTION
This PR implements federation-ready API enhancements requested for ADR-055 compatibility.

Key changes:
1. **Hash for HVec10240**: Enables dedup sets in gossip layers.
2. **WIRE_VERSION Constants**: Standard versioning for serializable types.
3. **Serde Support**: Opt-in serialization for `BundleAccumulator` and `ConceptGraph`. `BundleAccumulator` uses a manual implementation in `src/bundle_serde.rs` to handle the large internal array.
4. **Signing Helper**: `HVec10240::canonical_bytes()` provides a stable signing input.
5. **Version Bump**: Bumped crate version to 0.4.0 as these are significant (though additive) API additions.

Tests:
- New integration test file `tests/federation_enhancements.rs` covers all new functionality.
- Verified with `scripts/validate.sh`.

Fixes #156

---
*PR created automatically by Jules for task [15301316830086431883](https://jules.google.com/task/15301316830086431883) started by @d-o-hub*