### PR TITLE
Design Plans for CloudEvents EventEmitter (ADR-0078)

### DIFF
--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -3550,3 +3550,44 @@ actions:
     description: |
       Remove 7 redundant_clone sites. Mostly tests and small surface code.
       Verify cargo test --all-features stays green throughout.
+
+  # ─────────────────────────────────────────────────────────
+  # Wave 25: P2 — CloudEvents Event Emitter (cost: 12)
+  # ─────────────────────────────────────────────────────────
+
+  - name: write_adr_cloudevents_emitter
+    preconditions:
+      gap_analysis_2026_04_30_completed: true
+    effects:
+      cloudevents_adr_written: true
+    cost: 2
+    status: complete
+    file: plans/adr/0078-cloudevents-event-emitter.md
+    description: |
+      Write ADR for CloudEvents emitter integration. Must cover mapping
+      logic, trait-based pluggable emitters, and sink options (Log, HTTP).
+
+  - name: implement_cloudevents_emitter
+    preconditions:
+      cloudevents_adr_written: true
+    effects:
+      cloudevents_implemented: true
+    cost: 6
+    status: queued
+    file: src/framework_events_ce.rs
+    description: |
+      Implement EventEmitter trait and CloudEvents mapping logic.
+      Provide LogEmitter and HttpEmitter (opt-in) implementations.
+      Integrate into ChaoticSemanticFramework event pipeline.
+
+  - name: test_cloudevents_emitter
+    preconditions:
+      cloudevents_implemented: true
+    effects:
+      cloudevents_tested: true
+    cost: 4
+    status: queued
+    file: tests/cloudevents_integration.rs
+    description: |
+      Test CloudEvents emission across all MemoryEvent variants.
+      Verify LogEmitter output and HttpEmitter payload structure.

--- a/plans/ADR_REGISTRY.md
+++ b/plans/ADR_REGISTRY.md
@@ -80,6 +80,7 @@
 | 0075 | Quantized Binary Hypervectors | Proposed | [adr/0075-quantized-binary-hypervectors.md](adr/0075-quantized-binary-hypervectors.md) |
 | 0076 | ADR Backfill | Implemented | [adr/0076-adr-backfill.md](adr/0076-adr-backfill.md) |
 | 0077 | Clippy Pedantic Selective Promotion | Phase A+B Implemented | [adr/0077-clippy-pedantic-selective-promotion.md](adr/0077-clippy-pedantic-selective-promotion.md) |
+| 0078 | CloudEvents Event Emitter | Proposed | [adr/0078-cloudevents-event-emitter.md](adr/0078-cloudevents-event-emitter.md) |
 
 ## Status Definitions
 

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -926,3 +926,10 @@ world_state:
     loc_gate: satisfied
   rebase_commit: b771317
   pr_173_status: "OPEN, MERGEABLE, BLOCKED (old CI: benchmark-small failed, waiting for new CI run on b771317)"
+
+  # ═══════════════════════════════════════════════════════
+  # Wave 25: CloudEvents Event Emitter (P2)
+  # ═══════════════════════════════════════════════════════
+  cloudevents_adr_written: true
+  cloudevents_implemented: false
+  cloudevents_tested: false

--- a/plans/adr/0078-cloudevents-event-emitter.md
+++ b/plans/adr/0078-cloudevents-event-emitter.md
@@ -1,0 +1,96 @@
+# ADR-0078: CloudEvents Event Emitter
+
+## Status
+
+Proposed (2026-05-04)
+
+## Context and Problem Statement
+
+The `ChaoticSemanticFramework` currently emits internal `MemoryEvent` notifications via a `tokio::sync::broadcast` channel. While this is sufficient for in-process subscribers, it does not support distributed AI agent architectures where memory changes must trigger external workflows.
+
+CloudEvents is a CNCF specification for describing event data in a common way. Standardizing our memory events as CloudEvents enables:
+- **Interoperability** — Triggering serverless functions, webhooks, or event buses (NATS, Kafka).
+- **Tooling** — Using standard CloudEvents SDKs for downstream consumers.
+- **Auditability** — Structured event logs with standard metadata (id, source, type, time).
+
+## Decision Drivers
+
+- Standardize event schema across native and WASM boundaries (where applicable).
+- Minimize overhead: CloudEvent conversion should be cheap.
+- Pluggable sinks: Support multiple output targets (Stdout, HTTP, etc.).
+- Maintain LOC limits (≤ 400 lines for the new implementation file).
+
+## Considered Options
+
+1. **Native CloudEvents conversion** in `src/framework_events.rs`.
+2. **Pluggable `EventEmitter` trait** with `MemoryEvent` → `CloudEvent` mapping.
+3. **External "sidecar"** that subscribes to the broadcast channel and re-emits.
+
+## Decision Outcome
+
+Chosen: **Option 2** — Pluggable `EventEmitter` trait.
+
+This approach provides a clean separation between internal broadcast events and external standardized events. It allows the framework to remain unopinionated about the event sink while providing a first-class way to integrate with the CloudEvents ecosystem.
+
+## Implementation
+
+### New Module
+
+`src/framework_events_ce.rs`
+
+### Trait Definition
+
+```rust
+#[async_trait]
+pub trait EventEmitter: Send + Sync {
+    fn name(&self) -> &str;
+    async fn emit(&self, event: cloudevents::Event) -> Result<(), MemoryError>;
+}
+```
+
+### Event Mapping
+
+`MemoryEvent` will be mapped to `cloudevents::Event` with:
+- `source`: `chaotic-semantic-memory://<namespace>`
+- `type`: `io.d-o-hub.csm.memory.<variant>` (e.g., `concept.injected`)
+- `subject`: The concept ID.
+- `data`: JSON representation of the event payload.
+
+### Built-in Emitters
+
+1. **LogEmitter** — Emits formatted CloudEvents to the `tracing` log.
+2. **HttpEmitter** — Posts CloudEvents to a configured webhook URL (native only, requires `reqwest`).
+
+### Integration
+
+`ChaoticSemanticFramework` will optionally hold a list of emitters:
+
+```rust
+pub struct ChaoticSemanticFramework {
+    // ...
+    emitters: Vec<Box<dyn EventEmitter>>,
+}
+```
+
+When an event is emitted internally, the framework will iterate through configured emitters and trigger their `emit` methods.
+
+## Pros and Cons
+
+### Pros
+- Compliance with industry standard event formats.
+- Highly extensible sink architecture.
+- Improved observability and auditability for distributed agents.
+
+### Cons
+- Added dependency on `cloudevents-sdk`.
+- Minor latency overhead during mutation operations (async emission).
+
+## Acceptance Criteria
+
+- [ ] `EventEmitter` trait defined in `src/framework_events_ce.rs`.
+- [ ] `MemoryEvent` to `cloudevents::Event` mapping logic implemented.
+- [ ] `LogEmitter` provided as a default implementation.
+- [ ] `HttpEmitter` provided behind an opt-in feature.
+- [ ] Integration tests verify that mutating operations trigger the emitter.
+- [ ] Documentation updated to show how to configure custom emitters.
+- [ ] File size in `src/` remains under 400 lines.


### PR DESCRIPTION
This submission establishes the design and implementation plan for a CloudEvents-based event emitter system within the `chaotic_semantic_memory` framework.

Key changes:
1. **ADR-0078**: Defines a pluggable `EventEmitter` trait and a mapping logic from internal `MemoryEvent` to the CNCF CloudEvents specification. This enables interoperability with external event buses and distributed AI agent architectures.
2. **GOAP Updates**:
   - **ACTIONS.md**: Queues Wave 25 (P2) tasks for implementing the `EventEmitter` trait and providing built-in sinks (Log, HTTP).
   - **GOAP_STATE.md**: Updates the world state to reflect that the design phase (ADR writing) is complete and the implementation is queued.
3. **Registry Consistency**: Synchronizes `ADR_REGISTRY.md` to include the new architectural decision.

This design-first approach ensures alignment with the project's architectural standards and provides a clear roadmap for the upcoming implementation wave.

Fixes #195

---
*PR created automatically by Jules for task [9898990618098047139](https://jules.google.com/task/9898990618098047139) started by @d-o-hub*