### PR TITLE
Use config.database for McpResources in MCP server

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -72,8 +72,8 @@ pub async fn serve(config: McpConfig) -> Result<()> {
 }
 
 async fn serve_stdio(config: McpConfig) -> Result<()> {
-    let _tools = McpTools::new(config.database);
-    let _resources = McpResources::new(None); // TODO: use config.database when wired
+    let _tools = McpTools::new(config.database.clone());
+    let _resources = McpResources::new(config.database);
 
     // Stub: actual rmcp integration would be:
     // let server = rmcp::ServerBuilder::new()
@@ -88,8 +88,8 @@ async fn serve_stdio(config: McpConfig) -> Result<()> {
 }
 
 async fn serve_sse(config: McpConfig, bind: &str) -> Result<()> {
-    let _tools = McpTools::new(config.database);
-    let _resources = McpResources::new(None); // TODO: use config.database when wired
+    let _tools = McpTools::new(config.database.clone());
+    let _resources = McpResources::new(config.database);
 
     // Stub: actual rmcp integration would be:
     // let server = rmcp::ServerBuilder::new()


### PR DESCRIPTION
This change updates `src/mcp/server.rs` to correctly pass the database configuration from `McpConfig` to the `McpResources` handler. Previously, it was hardcoded to `None`. 

The fix applies to both `serve_stdio` and `serve_sse` functions. Since `config.database` is an `Option<std::path::PathBuf>`, I've added a `.clone()` to the first usage (for `McpTools`) so it remains available for `McpResources`.

Verification:
- Manually inspected the source code to ensure correct ownership handling.
- Successfully passed a code review which confirmed the logic is idiomatic and correct.
- Attempted `cargo check` and `cargo test`, but the environment had network-related dependency resolution failures (missing `async-trait`). Given the context and the nature of the change (fixing a TODO/stub), this is deemed ready for submission.

---
*PR created automatically by Jules for task [17996437634100359435](https://jules.google.com/task/17996437634100359435) started by @d-o-hub*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured database configuration is consistently applied to all MCP server setup paths, resolving misalignment between stdio and SSE configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->