### PR TITLE
🔒 [security] Fix SQL injection in column_exists migrations query

### DIFF
--- a/src/persistence_migrations.rs
+++ b/src/persistence_migrations.rs
@@ -37,21 +37,20 @@ impl Persistence {
         table_name: &str,
         column_name: &str,
     ) -> Result<bool> {
-        // Validate table_name to prevent SQL injection in pragma_table_info (CWE-89)
-        if !table_name
-            .chars()
-            .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
-        {
+        // Validate table_name to prevent potential issues in pragma_table_info (CWE-89)
+        if table_name.is_empty() {
             return Err(MemoryError::InvalidInput {
                 field: "table_name".to_string(),
-                reason: "Table name contains invalid characters".to_string(),
+                reason: "Table name cannot be empty".to_string(),
             });
         }
 
-        let sql = format!("SELECT COUNT(*) FROM pragma_table_info('{table_name}') WHERE name = ?1");
+        // Use parameter binding for both the table name and the column name.
+        // pragma_table_info supports parameter binding for its argument.
+        let sql = "SELECT COUNT(*) FROM pragma_table_info(?1) WHERE name = ?2";
 
         let mut rows = conn
-            .query(&sql, params![column_name])
+            .query(sql, params![table_name, column_name])
             .await
             .map_err(|e| MemoryError::database(format!("Failed to check column existence: {e}")))?;
 


### PR DESCRIPTION
This PR fixes a security vulnerability (CWE-89: SQL Injection) in the `Persistence::column_exists` method.

🎯 **What:** The vulnerability involved string interpolation of the `table_name` parameter into a SQLite PRAGMA query.
⚠️ **Risk:** Although basic validation was present, string interpolation in SQL queries poses a risk of injection if the validation is bypassed or incomplete.
🛡️ **Solution:** The fix utilizes SQLite's ability to treat `pragma_table_info` as a table-valued function, allowing the `table_name` to be passed securely via parameter binding (`?1`). This completely eliminates the risk of SQL injection for this query.

The validation was also simplified to just check for non-empty strings, as parameter binding safely handles all characters.

---
*PR created automatically by Jules for task [5387700601235202352](https://jules.google.com/task/5387700601235202352) started by @d-o-hub*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database schema validation for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->