### PR TITLE
⚡ Eliminate redundant string allocations in persistence layer

### DIFF
--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -904,7 +904,7 @@ world_state:
   clippy_actionable_warnings: 110                             # float_cmp + drop_tightening + cast_* + const_fn + redundant_clone
   adr_0077_clippy_promotion_drafted: true                     # plans/adr/0077-clippy-pedantic-selective-promotion.md
   clippy_pedantic_promotion_complete: false                   # 5 themed PRs queued
-  action_last_completed: rebase_deepsource_fix_2026_06
+  action_last_completed: optimize_persistence_allocations_2026_06
 
   # ═══════════════════════════════════════════════════════
   # Rebase + DeepSource Fix (June 2026)

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -169,7 +169,7 @@ impl Persistence {
             "INSERT INTO csm_associations (namespace, from_id, to_id, strength)
              VALUES (?1, ?2, ?3, ?4)
              ON CONFLICT(namespace, from_id, to_id) DO UPDATE SET strength = excluded.strength",
-            params![ns.to_string(), from, to, strength],
+            params![ns, from, to, strength],
         )
         .await
         .map_err(|e| MemoryError::database(format!("Failed to save association: {e}")))?;
@@ -185,7 +185,7 @@ impl Persistence {
         let mut rows = conn
             .query(
                 "SELECT to_id, strength FROM csm_associations WHERE namespace = ?1 AND from_id = ?2",
-                params![ns.to_string(), id],
+                params![ns, id],
             )
             .await
             .map_err(|e| MemoryError::database(format!("Failed to load associations: {e}")))?;

--- a/src/persistence_concepts.rs
+++ b/src/persistence_concepts.rs
@@ -27,7 +27,7 @@ impl Persistence {
              canonical_concept_ids_json = excluded.canonical_concept_ids_json",
             params![
                 ns,
-                &concept.id,
+                concept.id.as_str(),
                 vector_bytes,
                 metadata_json,
                 concept.created_at as i64,
@@ -76,7 +76,7 @@ impl Persistence {
                      canonical_concept_ids_json = excluded.canonical_concept_ids_json",
                     params![
                         ns,
-                        &concept.id,
+                        concept.id.as_str(),
                         vector_bytes,
                         metadata_json,
                         concept.created_at as i64,

--- a/src/persistence_concepts.rs
+++ b/src/persistence_concepts.rs
@@ -26,8 +26,8 @@ impl Persistence {
              expires_at = excluded.expires_at,
              canonical_concept_ids_json = excluded.canonical_concept_ids_json",
             params![
-                ns.to_string(),
-                concept.id.clone(),
+                ns,
+                &concept.id,
                 vector_bytes,
                 metadata_json,
                 concept.created_at as i64,
@@ -75,8 +75,8 @@ impl Persistence {
                      expires_at = excluded.expires_at,
                      canonical_concept_ids_json = excluded.canonical_concept_ids_json",
                     params![
-                        ns.to_string(),
-                        concept.id.clone(),
+                        ns,
+                        &concept.id,
                         vector_bytes,
                         metadata_json,
                         concept.created_at as i64,
@@ -120,7 +120,7 @@ impl Persistence {
             .query(
                 "SELECT vector, metadata, created_at, modified_at, expires_at, canonical_concept_ids_json
                  FROM csm_concepts WHERE namespace = ?1 AND id = ?2",
-                params![ns.to_string(), id.to_string()],
+                params![ns, id],
             )
             .await
             .map_err(|e| MemoryError::database(format!("Failed to load concept: {e}")))?;
@@ -176,7 +176,7 @@ impl Persistence {
             .query(
                 "SELECT id, vector, metadata, created_at, modified_at, expires_at, canonical_concept_ids_json
                  FROM csm_concepts WHERE namespace = ?1",
-                params![ns.to_string()],
+                params![ns],
             )
             .await
             .map_err(|e| MemoryError::database(format!("Failed to load concepts: {e}")))?;
@@ -241,7 +241,7 @@ impl Persistence {
         if let Err(e) = conn
             .execute(
                 "DELETE FROM csm_versions WHERE namespace = ?1 AND concept_id = ?2",
-                params![ns.to_string(), id.to_string()],
+                params![ns, id],
             )
             .await
         {
@@ -254,7 +254,7 @@ impl Persistence {
         if let Err(e) = conn
             .execute(
                 "DELETE FROM csm_associations WHERE namespace = ?1 AND (from_id = ?2 OR to_id = ?2)",
-                params![ns.to_string(), id.to_string()],
+                params![ns, id],
             )
             .await
         {
@@ -267,7 +267,7 @@ impl Persistence {
         if let Err(e) = conn
             .execute(
                 "DELETE FROM csm_concepts WHERE namespace = ?1 AND id = ?2",
-                params![ns.to_string(), id.to_string()],
+                params![ns, id],
             )
             .await
         {

--- a/src/persistence_ops.rs
+++ b/src/persistence_ops.rs
@@ -34,7 +34,7 @@ impl Persistence {
         for (from, to, strength) in associations {
             stmt.reset();
             if let Err(e) = stmt
-                .execute(params![ns.to_string(), from.clone(), to.clone(), *strength])
+                .execute(params![ns, from, to, *strength])
                 .await
             {
                 first_error = Some(MemoryError::database(format!(
@@ -59,7 +59,6 @@ impl Persistence {
     pub async fn clear_namespace(&self, ns: &str) -> Result<()> {
         let _permit = self.acquire_remote_slot().await?;
         let conn = self.connect().await?;
-        let ns_param = ns.to_string();
         conn.execute("BEGIN", ())
             .await
             .map_err(|e| MemoryError::database(format!("Failed to begin transaction: {e}")))?;
@@ -73,7 +72,7 @@ impl Persistence {
         ];
 
         for sql in &tables {
-            if let Err(e) = conn.execute(sql, params![ns_param.clone()]).await {
+            if let Err(e) = conn.execute(sql, params![ns]).await {
                 let _ = conn.execute("ROLLBACK", ()).await;
                 return Err(MemoryError::database(format!(
                     "Failed to clear namespace data: {e}"
@@ -120,7 +119,7 @@ impl Persistence {
                  WHERE namespace = ?1 AND concept_id = ?2
                  ORDER BY version DESC
                  LIMIT ?3",
-                libsql::params![ns.to_string(), id, limit as i64],
+                libsql::params![ns, id, limit as i64],
             )
             .await
             .map_err(|e| MemoryError::database(format!("Failed to load concept history: {e}")))?;
@@ -288,7 +287,7 @@ impl Persistence {
         let conn = self.connect().await?;
         conn.execute(
             "DELETE FROM csm_associations WHERE namespace = ?1 AND from_id = ?2 AND to_id = ?3",
-            params![ns.to_string(), from, to],
+            params![ns, from, to],
         )
         .await
         .map_err(|e| MemoryError::database(format!("Failed to delete association: {e}")))?;
@@ -301,7 +300,7 @@ impl Persistence {
         let conn = self.connect().await?;
         conn.execute(
             "DELETE FROM csm_associations WHERE namespace = ?1 AND from_id = ?2",
-            params![ns.to_string(), id],
+            params![ns, id],
         )
         .await
         .map_err(|e| MemoryError::database(format!("Failed to clear concept associations: {e}")))?;

--- a/src/persistence_ops.rs
+++ b/src/persistence_ops.rs
@@ -34,7 +34,7 @@ impl Persistence {
         for (from, to, strength) in associations {
             stmt.reset();
             if let Err(e) = stmt
-                .execute(params![ns, from, to, *strength])
+                .execute(params![ns, from.as_str(), to.as_str(), *strength])
                 .await
             {
                 first_error = Some(MemoryError::database(format!(


### PR DESCRIPTION
The persistence layer was performing redundant $O(N)$ string allocations and clones, particularly inside loops for batch operations like `save_associations`. By leveraging the ability of `libsql::params!` to accept references and taking ownership of strings where appropriate, these unnecessary allocations were eliminated.

**Optimizations implemented:**
- In `src/persistence_ops.rs`: `save_associations` now passes references directly to the SQL executor. `clear_namespace`, `get_concept_history`, `delete_association`, and `clear_concept_associations` were also optimized.
- In `src/persistence_concepts.rs`: `save_concept`, `save_concepts`, `load_concept`, `load_all_concepts`, and `delete_concept` no longer perform redundant string conversions for namespace and IDs.
- In `src/persistence.rs`: `save_association` and `load_associations` were updated for consistency and efficiency.

**Performance Impact:**
Eliminates $O(N)$ allocations in batch loops, providing a cleaner and more efficient execution path for persistence tasks. While environment constraints prevented benchmarking, the architectural improvement is significant for high-throughput memory systems.

---
*PR created automatically by Jules for task [485175724233575684](https://jules.google.com/task/485175724233575684) started by @d-o-hub*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized database query parameter handling to reduce allocations and improve efficiency in persistence operations.
* **Documentation**
  * Updated plan/state file to reflect the most recently completed action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->