### PR TITLE
perf(persistence): eliminate redundant serialization and allocations

### DIFF
--- a/src/persistence_concepts.rs
+++ b/src/persistence_concepts.rs
@@ -28,19 +28,25 @@ impl Persistence {
             params![
                 ns,
                 concept.id.as_str(),
-                vector_bytes,
-                metadata_json,
+                vector_bytes.as_slice(),
+                metadata_json.as_str(),
                 concept.created_at as i64,
                 concept.modified_at as i64,
                 expires_at,
-                canonical_concept_ids_json
+                canonical_concept_ids_json.as_str()
             ],
         )
         .await
         .map_err(|e| MemoryError::database(format!("Failed to save concept: {e}")))?;
 
-        self.record_concept_version_scoped(&conn, ns, concept)
-            .await?;
+        self.record_concept_version_scoped(
+            &conn,
+            ns,
+            concept,
+            Some(&vector_bytes),
+            Some(&metadata_json),
+        )
+        .await?;
         Ok(())
     }
 
@@ -77,12 +83,12 @@ impl Persistence {
                     params![
                         ns,
                         concept.id.as_str(),
-                        vector_bytes,
-                        metadata_json,
+                        vector_bytes.as_slice(),
+                        metadata_json.as_str(),
                         concept.created_at as i64,
                         concept.modified_at as i64,
                         expires_at,
-                        canonical_concept_ids_json
+                        canonical_concept_ids_json.as_str()
                     ],
                 )
                 .await
@@ -93,7 +99,16 @@ impl Persistence {
                 break;
             }
 
-            if let Err(e) = self.record_concept_version_scoped(&conn, ns, concept).await {
+            if let Err(e) = self
+                .record_concept_version_scoped(
+                    &conn,
+                    ns,
+                    concept,
+                    Some(&vector_bytes),
+                    Some(&metadata_json),
+                )
+                .await
+            {
                 first_error = Some(e);
                 break;
             }

--- a/src/persistence_versions.rs
+++ b/src/persistence_versions.rs
@@ -9,20 +9,25 @@ impl Persistence {
         conn: &Connection,
         concept: &Concept,
     ) -> Result<()> {
-        self.record_concept_version_scoped(conn, "_default", concept)
+        self.record_concept_version_scoped(conn, "_default", concept, None, None)
             .await
     }
 
+    /// Records a new concept version, optionally using pre-computed vector bytes and metadata JSON.
+    /// Performance Optimization: Accepting pre-computed values avoids redundant serialization and
+    /// allocations when this is called from batch operations or normal save paths.
     pub(crate) async fn record_concept_version_scoped(
         &self,
         conn: &Connection,
         ns: &str,
         concept: &Concept,
+        vector_bytes: Option<&[u8]>,
+        metadata_json: Option<&str>,
     ) -> Result<()> {
         let mut rows = conn
             .query(
                 "SELECT COALESCE(MAX(version), 0) FROM csm_versions WHERE namespace = ?1 AND concept_id = ?2",
-                params![ns.to_string(), concept.id.clone()],
+                params![ns, concept.id.as_str()],
             )
             .await
             .map_err(|e| MemoryError::database(format!("Failed to query concept version: {e}")))?;
@@ -37,18 +42,31 @@ impl Persistence {
             0
         };
         let next_version = current + 1;
-        let vector_bytes = concept.vector.to_bytes();
-        let metadata_json = serde_json::to_string(&concept.metadata)?;
+        let vector_bytes_owned: Vec<u8>;
+        let vector_ref = if let Some(v) = vector_bytes {
+            v
+        } else {
+            vector_bytes_owned = concept.vector.to_bytes();
+            &vector_bytes_owned
+        };
+
+        let metadata_owned: String;
+        let metadata_ref = if let Some(m) = metadata_json {
+            m
+        } else {
+            metadata_owned = serde_json::to_string(&concept.metadata)?;
+            &metadata_owned
+        };
 
         conn.execute(
             "INSERT INTO csm_versions (namespace, concept_id, version, vector, metadata, modified_at)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             params![
-                ns.to_string(),
-                concept.id.clone(),
+                ns,
+                concept.id.as_str(),
                 next_version,
-                vector_bytes,
-                metadata_json,
+                vector_ref,
+                metadata_ref,
                 concept.modified_at as i64
             ],
         )
@@ -61,11 +79,7 @@ impl Persistence {
              AND version <= (
                 SELECT MAX(version) - ?3 FROM csm_versions WHERE namespace = ?1 AND concept_id = ?2
              )",
-            params![
-                ns.to_string(),
-                concept.id.clone(),
-                self.version_retention as i64
-            ],
+            params![ns, concept.id.as_str(), self.version_retention as i64],
         )
         .await
         .map_err(|e| MemoryError::database(format!("Failed to prune concept versions: {e}")))?;


### PR DESCRIPTION
What: Refactored `record_concept_version_scoped` to accept optional pre-computed vector bytes and metadata JSON. Updated `save_concept` and `save_concepts` to pass these values and use borrowed references in `libsql::params!`.
Why: Previous implementation performed redundant O(N) serialization of concepts in both the main save path and the versioning path, and created unnecessary owned strings/vectors for database parameters.
Impact: Eliminates one full serialization pass per concept saved and reduces heap allocations from O(N) to O(1) for loop-invariant parameters.

---
*PR created automatically by Jules for task [13914411230019000984](https://jules.google.com/task/13914411230019000984) started by @d-o-hub*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal persistence logic for concept storage to improve memory efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d-o-hub/chaotic_semantic_memory/pull/222)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->