### PR TITLE
🔒 [security fix] Remove hardcoded token from WASM persistence tests

### DIFF
--- a/src/persistence_wasm.rs
+++ b/src/persistence_wasm.rs
@@ -168,7 +168,7 @@ mod tests {
 
     #[tokio::test]
     async fn new_turso_returns_unsupported() {
-        let result = Persistence::new_turso("https://example.com", "token").await;
+        let result = Persistence::new_turso("", "").await;
         assert!(result.is_err());
 
         let err = result.unwrap_err();


### PR DESCRIPTION
🎯 **What:** Removed a hardcoded token string and example URL from the `new_turso_returns_unsupported` test case in `src/persistence_wasm.rs`.
⚠️ **Risk:** Hardcoded credentials or tokens, even in test code, can be flagged by security scanners and represent a poor security practice that could lead to accidental credential leakage if misused or copied.
🛡️ **Solution:** Replaced `"https://example.com"` and `"token"` with empty strings `""`. Since the WASM implementation is a stub that always returns an `UnsupportedOperation` error regardless of input, using empty strings preserves the test's intent without including sensitive-looking placeholders.

---
*PR created automatically by Jules for task [14862990726087845107](https://jules.google.com/task/14862990726087845107) started by @d-o-hub*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated WASM test validation with refined test parameters to ensure consistent behavior.

---

**Note:** This update primarily addresses internal testing improvements with no user-facing impact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d-o-hub/chaotic_semantic_memory/pull/238)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->