### PR TITLE
fix(scripts): sync-version parse package version not rust-version

### DIFF
--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -53,7 +53,7 @@ validate_changelog() {
 
 # Get current version from Cargo.toml first
 # Use quotes for the filename to satisfy linting
-CURRENT_VERSION=$(grep -m1 'version = ' "Cargo.toml" | sed 's/version = "\(.*\)"/\1/')
+CURRENT_VERSION=$(grep -m1 '^version = ' "Cargo.toml" | sed 's/^version = "\(.*\)"/\1/')
 
 # If version unchanged, skip validation and exit early
 if [ "$VERSION" = "$CURRENT_VERSION" ]; then
@@ -73,7 +73,7 @@ echo "=============================================="
 
 # Files that need version updates
 declare -A VERSION_FILES
-VERSION_FILES["Cargo.toml"]="s/version = \"$CURRENT_VERSION\"/version = \"$VERSION\"/"
+VERSION_FILES["Cargo.toml"]="s/^version = \"$CURRENT_VERSION\"/version = \"$VERSION\"/"
 VERSION_FILES["README.md"]="s/version = \"$CURRENT_VERSION\"/version = \"$MAJOR_MINOR\"/g"
 VERSION_FILES["book/src/getting-started.md"]="s/version = \"$CURRENT_VERSION\"/version = \"$MAJOR_MINOR\"/g"
 VERSION_FILES["CHANGELOG.md"]="s/\[Unreleased\]/\[$VERSION\]/; s/## \[Unreleased\]/## [$VERSION] - $(date +%Y-%m-%d)/"


### PR DESCRIPTION
The `sync-version.sh` script previously parsed the `rust-version = "1.85"` value from `Cargo.toml` instead of the actual package `version = "0.3.5"` because it matched the first occurrence of `version = `. This caused the script to mistakenly think the version had bumped and proceeded to validate `CHANGELOG.md` when it shouldn't have.

Fixed by anchoring the `grep` search to the start of the line using `^version = ` and updating the replacement `sed` commands.

---
*PR created automatically by Jules for task [4373563996424158825](https://jules.google.com/task/4373563996424158825) started by @d-o-hub*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved version synchronization script reliability and linting safety in the build process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d-o-hub/chaotic_semantic_memory/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->