### PR TITLE
ci: replace direct push with PR creation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
-permissions: read-all
+permissions: {}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,20 +146,6 @@ jobs:
           exit 1
         fi
 
-    - name: Create pull request with regenerated llms.txt
-      uses: peter-evans/create-pull-request@v5
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: "chore: regenerate llms.txt for release [skip ci]"
-        branch: regenerate-llms-${{ steps.version.outputs.version }}-${{ github.run_id }}
-        title: "chore: regenerate llms.txt for v${{ steps.version.outputs.version }}"
-        body: |
-          This PR updates llms.txt and llms-full.txt as part of the release workflow.
-          Files updated by scripts/gen-llms-txt.sh
-        labels: automated
-        paths: llms.txt,llms-full.txt
-        base: main
-
     - name: Ensure version sync is clean
       run: |
         # Exclude llms.txt and llms-full.txt from clean check as they may be mutated
@@ -187,6 +173,21 @@ jobs:
         git push origin "$TAG"
         echo "Created tag ${TAG}"
         echo "release-needed=true" >> $GITHUB_OUTPUT
+
+    - name: Create pull request with regenerated llms.txt
+      if: steps.tag.outputs.release-needed == 'true'
+      uses: peter-evans/create-pull-request@v5
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: "chore: regenerate llms.txt for release [skip ci]"
+        branch: regenerate-llms-${{ steps.version.outputs.version }}-${{ github.run_id }}
+        title: "chore: regenerate llms.txt for v${{ steps.version.outputs.version }}"
+        body: |
+          This PR updates llms.txt and llms-full.txt as part of the release workflow.
+          Files updated by scripts/gen-llms-txt.sh
+        labels: automated
+        paths: llms.txt,llms-full.txt
+        base: main
 
     - name: Validate publish dry-run
       run: cargo publish --dry-run --allow-dirty

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,7 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
-permissions:
-  contents: write
-  id-token: write
+permissions: read-all
 
 env:
   CARGO_TERM_COLOR: always
@@ -380,6 +378,8 @@ jobs:
     if: needs.validate.outputs.release-needed == 'true'
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v6
       with:
@@ -457,6 +457,9 @@ jobs:
     needs: [validate, build-wasm]
     if: needs.validate.outputs.release-needed == 'true'
     environment: npm
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - uses: actions/checkout@v6
 
@@ -540,6 +543,9 @@ jobs:
     needs: [validate, build-cli-matrix, create-github-release]
     if: needs.validate.outputs.release-needed == 'true'
     environment: npm-cli
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - uses: actions/checkout@v6
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ concurrency:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -132,11 +133,11 @@ jobs:
         VERSION="${{ steps.version.outputs.version }}"
         bash scripts/sync-version.sh "$VERSION"
 
-    - name: Regenerate & commit llms.txt
+    - name: Regenerate llms files
       run: |
         bash scripts/gen-llms-txt.sh
 
-        # Verify API surface threshold before committing
+        # Verify API surface threshold
         LOC=$(grep -cE '^\s*(pub |fn |struct |enum |trait |impl )' llms-full.txt || true)
         echo "Public API surface: $LOC symbols"
         THRESHOLD=5000
@@ -145,10 +146,19 @@ jobs:
           exit 1
         fi
 
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        git add llms.txt llms-full.txt
-        git diff --cached --quiet || (git commit -m "chore: regenerate llms.txt for release [skip ci]" && git push)
+    - name: Create pull request with regenerated llms.txt
+      uses: peter-evans/create-pull-request@v5
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: "chore: regenerate llms.txt for release [skip ci]"
+        branch: regenerate-llms-${{ steps.version.outputs.version }}-${{ github.run_id }}
+        title: "chore: regenerate llms.txt for v${{ steps.version.outputs.version }}"
+        body: |
+          This PR updates llms.txt and llms-full.txt as part of the release workflow.
+          Files updated by scripts/gen-llms-txt.sh
+        labels: automated
+        paths: llms.txt,llms-full.txt
+        base: main
 
     - name: Ensure version sync is clean
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ concurrency:
 permissions:
   contents: write
   id-token: write
-  pull-requests: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -81,6 +80,9 @@ jobs:
     runs-on: ubuntu-24.04
     needs: wait-for-ci
     if: needs.wait-for-ci.outputs.ci-passed == 'true'
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       version: ${{ steps.version.outputs.version }}
       release-needed: ${{ steps.tag.outputs.release-needed }}


### PR DESCRIPTION
This PR fixes the release workflow which previously failed by attempting to push directly to the `main` branch. 
Because the `main` branch is protected and requires PRs, the workflow has been updated to:
1. Add `pull-requests: write` to top-level workflow permissions.
2. Replace the step that commits and pushes directly to `main` with two separate steps:
   - One to regenerate files and check LOC thresholds.
   - One to use `peter-evans/create-pull-request` to create a PR for those regenerated files (`llms.txt`, `llms-full.txt`).

---
*PR created automatically by Jules for task [16256433037792045186](https://jules.google.com/task/16256433037792045186) started by @d-o-hub*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow now regenerates generated artifact files in a dedicated step and—when a new release is required—opens a versioned pull request that only updates those artifacts.
  * Default workflow permissions were tightened and job-level permissions were explicitly scoped for safety.
  * Publishing/release steps were given specific scoped permissions to support authenticated release creation and provenance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d-o-hub/chaotic_semantic_memory/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->