### PR TITLE
feat(release): cut v0.3.6 and fix MCP CLI modularity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
     - name: Run DuckDB tests
-      run: cargo test -p chaotic_semantic_memory_duckdb --locked -- --quiet
+      run: cargo test -p chaotic_semantic_memory_duckdb --locked -- --test-threads=1 --quiet
 
   build-cli:
     name: Build CLI (${{ matrix.platform }}-${{ matrix.arch }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6] - 2026-05-20
+
+### Added
+- **MCP Server**: Implemented Model Context Protocol (MCP) server support with stdio transport, providing 12 tool and 3 resource handlers for LLM integration (ADR-0067).
+- **DuckDB Companion Crate**: Added workspace member crate `chaotic_semantic_memory_duckdb` providing parquet export, analytical queries, and a `csm-analytics` tool (ADR-0079 to ADR-0082).
+- **CLI**: Reached 100% feature-parity with the framework API across all 22 commands, locked with a new `cli_parity` smoke test suite (ADR-0066).
+- **Events**: Pluggable memory event subscriptions in the framework using the CloudEvents specification.
+
+### Changed
+- **Hyperdim**: Refactored Bit-Sliced Hypervector Bundling with target-specific SIMD optimization blocks (AVX2/NEON) and a clean fallback path.
+
+### Fixed
+- **CLI / MCP**: Fixed stdout tracing corruption issues, refactored MCP subcommands to a modular structure under `src/cli/mcp.rs`, and resolved a compilation warning.
+
 ## [0.3.5] - 2026-04-28
 
 ### Fixed
@@ -398,7 +412,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Trusted Publishing eliminates need for long-lived API tokens
 
 [0.3.5]: https://github.com/d-o-hub/chaotic_semantic_memory/compare/v0.3.4...v0.3.5
-[unreleased]: https://github.com/d-o-hub/chaotic_semantic_memory/compare/v0.3.5...HEAD
+[0.3.6]: https://github.com/d-o-hub/chaotic_semantic_memory/compare/v0.3.5...HEAD
 [0.3.4]: https://github.com/d-o-hub/chaotic_semantic_memory/compare/v0.3.2...v0.3.4
 [0.3.2]: https://github.com/d-o-hub/chaotic_semantic_memory/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/d-o-hub/chaotic_semantic_memory/releases/tag/v0.3.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "chaotic_semantic_memory"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3334,9 +3334,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -3365,9 +3365,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -3442,9 +3442,9 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pastey"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "peeking_take_while"
@@ -4149,7 +4149,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
- "tower-http 0.6.10",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4218,7 +4218,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "futures 0.3.32",
- "pastey 0.2.2",
+ "pastey 0.2.3",
  "pin-project-lite",
  "rmcp-macros",
  "schemars",
@@ -4823,9 +4823,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -5207,9 +5207,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ base64 = "0.22.1"
 
 [package]
 name = "chaotic_semantic_memory"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 rust-version = "1.85"
 description = "AI memory systems with hyperdimensional vectors and chaotic reservoirs"

--- a/cli-npm/package.json
+++ b/cli-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d-o-hub/csm",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "CLI for chaotic semantic memory - AI memory systems with hyperdimensional vectors",
   "bin": {
     "csm": "./index.js"

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -85,8 +85,6 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub struct CliArgs
 - pub enum OutputFormat
 - pub enum Commands
-- pub enum McpCommands
-- pub struct McpServeArgs
 - pub struct InjectArgs
 - pub enum VectorSource
 - pub struct ProbeArgs
@@ -272,16 +270,23 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub fn resolve_git_local_path
 - pub fn ensure_git_local_dir
 
+### src/cli/mcp.rs
+
+- pub enum McpCommands
+- pub struct McpServeArgs
+
 ### src/cli/mod.rs
 
 - pub mod args
 - pub mod commands
 - pub mod error
 - pub mod git_local
+- pub mod mcp
 - pub use args::*
 - pub use commands::{run_associate, run_associations, run_completions, run_delete, run_disassociate, run_export, run_get, run_import, run_index_dir, run_index_jsonl, run_inject, run_metrics, run_path, run_probe, run_probe_filtered, run_probe_graph, run_query, run_stats, run_traverse, run_update, run_watch}
 - pub use error::{CliError, ExitCode, Result}
 - pub use git_local::{ensure_git_local_dir, resolve_git_local_path}
+- pub use mcp::*
 
 ### src/concept_builder.rs
 
@@ -1516,7 +1521,7 @@ pub enum Commands {
     Watch(WatchArgs),
     ProbeGraph(ProbeGraphArgs),
     #[cfg(feature = "mcp")]
-    Mcp(McpCommands),
+    Mcp(crate::cli::mcp::McpCommands),
 }
 ```
 
@@ -1655,27 +1660,6 @@ pub struct InjectArgs {
     pub use_embeddings: bool,
     pub provider: Option<String>,
     pub metadata: Option<String>,
-}
-```
-
-### McpCommands
-
-```rust
-#[derive(Subcommand, Debug, Clone)]
-#[cfg(feature = "mcp")]
-pub enum McpCommands {
-    Serve(McpServeArgs),
-}
-```
-
-### McpServeArgs
-
-```rust
-#[derive(Args, Debug, Clone)]
-#[cfg(feature = "mcp")]
-pub struct McpServeArgs {
-    pub transport: crate::mcp::Transport,
-    pub bind: Option<String>,
 }
 ```
 
@@ -2386,6 +2370,29 @@ let path = resolve_git_local_path();
 assert!(path.is_some() || path.is_none()); // Always passes, documents behavior
 ```
 
+## src/cli/mcp.rs
+
+### McpCommands
+
+```rust
+#[derive(Subcommand, Debug, Clone)]
+#[cfg(feature = "mcp")]
+pub enum McpCommands {
+    Serve(McpServeArgs),
+}
+```
+
+### McpServeArgs
+
+```rust
+#[derive(Args, Debug, Clone)]
+#[cfg(feature = "mcp")]
+pub struct McpServeArgs {
+    pub transport: crate::mcp::Transport,
+    pub bind: Option<String>,
+}
+```
+
 ## src/cli/mod.rs
 
 ### args::*
@@ -2410,6 +2417,12 @@ pub use error::{CliError, ExitCode, Result};
 
 ```rust
 pub use git_local::{ensure_git_local_dir, resolve_git_local_path};
+```
+
+### mcp::*
+
+```rust
+pub use mcp::*;
 ```
 
 ## src/concept_builder.rs
@@ -3867,7 +3880,6 @@ Configuration for MCP server.
 #[derive(Debug, Clone, Copy, Default, clap :: ValueEnum)]
 pub enum Transport {
     Stdio,
-    Sse,
 }
 ```
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2,7 +2,7 @@
 
 > AI memory systems with hyperdimensional vectors and chaotic reservoirs
 
-**Version:** 0.3.5
+**Version:** 0.3.6
 **License:** MIT
 **Repository:** https://github.com/d-o-hub/chaotic_semantic_memory
 **Homepage:** https://github.com/d-o-hub/chaotic_semantic_memory

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > AI memory systems with hyperdimensional vectors and chaotic reservoirs
 
-**Version:** 0.3.5
+**Version:** 0.3.6
 **License:** MIT
 **Repository:** https://github.com/d-o-hub/chaotic_semantic_memory
 **Homepage:** https://github.com/d-o-hub/chaotic_semantic_memory
@@ -1336,7 +1336,7 @@ base64 = "0.22.1"
 
 [package]
 name = "chaotic_semantic_memory"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 rust-version = "1.85"
 description = "AI memory systems with hyperdimensional vectors and chaotic reservoirs"

--- a/llms.txt
+++ b/llms.txt
@@ -85,8 +85,6 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub struct CliArgs
 - pub enum OutputFormat
 - pub enum Commands
-- pub enum McpCommands
-- pub struct McpServeArgs
 - pub struct InjectArgs
 - pub enum VectorSource
 - pub struct ProbeArgs
@@ -272,16 +270,23 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub fn resolve_git_local_path
 - pub fn ensure_git_local_dir
 
+### src/cli/mcp.rs
+
+- pub enum McpCommands
+- pub struct McpServeArgs
+
 ### src/cli/mod.rs
 
 - pub mod args
 - pub mod commands
 - pub mod error
 - pub mod git_local
+- pub mod mcp
 - pub use args::*
 - pub use commands::{run_associate, run_associations, run_completions, run_delete, run_disassociate, run_export, run_get, run_import, run_index_dir, run_index_jsonl, run_inject, run_metrics, run_path, run_probe, run_probe_filtered, run_probe_graph, run_query, run_stats, run_traverse, run_update, run_watch}
 - pub use error::{CliError, ExitCode, Result}
 - pub use git_local::{ensure_git_local_dir, resolve_git_local_path}
+- pub use mcp::*
 
 ### src/concept_builder.rs
 

--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -3296,7 +3296,7 @@ actions:
     effects:
       mcp_server_implemented: true
     cost: 16
-    status: completed
+    status: complete
     file: src/mcp/handler.rs, src/mcp/server.rs, src/bin/csm.rs
     description: |
       Implemented consolidated rmcp 1.7 handler in src/mcp/handler.rs.
@@ -3749,7 +3749,7 @@ actions:
     effects:
       v036_released: true
     cost: 4
-    status: queued
+    status: complete
     file: Cargo.toml, VERSION, CHANGELOG.md, wasm/package.json
     description: |
       Cut v0.3.6 to ship the merged-but-unreleased work since v0.3.5:

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -914,7 +914,7 @@ world_state:
   clippy_actionable_warnings: 110                             # float_cmp + drop_tightening + cast_* + const_fn + redundant_clone
   adr_0077_clippy_promotion_drafted: true                     # plans/adr/0077-clippy-pedantic-selective-promotion.md
   clippy_pedantic_promotion_complete: false                   # 5 themed PRs queued
-  action_last_completed: implement_mcp_server_2026_05_19
+  action_last_completed: release_v0_3_6
 
   # ═══════════════════════════════════════════════════════
   # Rebase + DeepSource Fix (June 2026)
@@ -961,8 +961,8 @@ world_state:
   # ═══════════════════════════════════════════════════════
   # Release readiness (2026-05-18 snapshot)
   # ═══════════════════════════════════════════════════════
-  unreleased_changes_present: true              # DuckDB + hyperdim SIMD + framework events
-  unreleased_changelog_section: false           # CHANGELOG.md still ends at [0.3.5]
+  unreleased_changes_present: false             # All shipped in v0.3.6
+  unreleased_changelog_section: true            # CHANGELOG.md updated to v0.3.6
   next_release_planned: "v0.3.6"
   next_release_blockers: 0                      # CI green on main (790fac9)
 

--- a/plans/handoffs/W5_C_to_D_wasm_size_report.md
+++ b/plans/handoffs/W5_C_to_D_wasm_size_report.md
@@ -6,7 +6,7 @@
 ## Measurement
 - Command: `cargo build --target wasm32-unknown-unknown --release --features wasm`
 - Artifact: `target/wasm32-unknown-unknown/release/chaotic_semantic_memory.wasm`
-- Size: `964346` bytes (`941.74` KiB)
+- Size: `955020` bytes (`932.64` KiB)
 - Threshold: `1048576` bytes (configurable via `CSM_WASM_SIZE_MAX_BYTES`)
 
 ## Result

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -83,25 +83,7 @@ pub enum Commands {
     /// MCP server commands.
     #[cfg(feature = "mcp")]
     #[command(subcommand)]
-    Mcp(McpCommands),
-}
-
-#[cfg(feature = "mcp")]
-#[derive(Subcommand, Debug, Clone)]
-pub enum McpCommands {
-    /// Start MCP server.
-    Serve(McpServeArgs),
-}
-#[cfg(feature = "mcp")]
-#[derive(Args, Debug, Clone)]
-pub struct McpServeArgs {
-    /// Transport to use: stdio or sse.
-    #[arg(long, value_enum, default_value = "stdio")]
-    pub transport: crate::mcp::Transport,
-
-    /// Bind address for SSE transport (e.g. 127.0.0.1:8765).
-    #[arg(long)]
-    pub bind: Option<String>,
+    Mcp(crate::cli::mcp::McpCommands),
 }
 
 #[derive(Args, Debug, Clone)]

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -1,0 +1,21 @@
+//! MCP CLI command definitions (ADR-0067)
+use clap::{Args, Subcommand};
+
+#[cfg(feature = "mcp")]
+#[derive(Subcommand, Debug, Clone)]
+pub enum McpCommands {
+    /// Start MCP server.
+    Serve(McpServeArgs),
+}
+
+#[cfg(feature = "mcp")]
+#[derive(Args, Debug, Clone)]
+pub struct McpServeArgs {
+    /// Transport to use: stdio. (SSE is currently unsupported).
+    #[arg(long, value_enum, default_value = "stdio")]
+    pub transport: crate::mcp::Transport,
+
+    /// Bind address for SSE transport (e.g. 127.0.0.1:8765).
+    #[arg(long)]
+    pub bind: Option<String>,
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,6 +2,8 @@ pub mod args;
 pub mod commands;
 pub mod error;
 pub mod git_local;
+#[cfg(feature = "mcp")]
+pub mod mcp;
 
 pub use args::*;
 pub use commands::{
@@ -12,3 +14,5 @@ pub use commands::{
 };
 pub use error::{CliError, ExitCode, Result};
 pub use git_local::{ensure_git_local_dir, resolve_git_local_path};
+#[cfg(feature = "mcp")]
+pub use mcp::*;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -13,8 +13,6 @@ pub enum Transport {
     /// Standard input/output (default for desktop apps)
     #[default]
     Stdio,
-    /// Server-Sent Events for hosted deployments
-    Sse,
 }
 
 /// Configuration for MCP server.
@@ -56,11 +54,6 @@ pub async fn serve(config: McpConfig) -> Result<()> {
                 .waiting()
                 .await
                 .map_err(|e| anyhow::anyhow!("Server join error: {e}"))?;
-        }
-        Transport::Sse => {
-            return Err(anyhow::anyhow!(
-                "SSE transport not yet fully implemented in this version"
-            ));
         }
     }
 

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d-o-hub/chaotic_semantic_memory",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "AI memory systems with hyperdimensional vectors and chaotic reservoirs - WASM bindings",
   "main": "chaotic_semantic_memory.js",
   "types": "chaotic_semantic_memory.d.ts",


### PR DESCRIPTION
Bumps version to v0.3.6. Includes full MCP server implementation, DuckDB companion crate integration, SIMD bundling refactor, and framework events scaffolding. Also resolves the MCP server compilation warning and extracts the CLI MCP commands to a modular structure under `src/cli/mcp.rs` to satisfy the strict <500 LOC gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP server available with stdio transport and tool/resource handlers
  * DuckDB companion added (parquet export, analytics tooling)
  * Pluggable memory event subscriptions via CloudEvents
  * CLI reached feature parity with new smoke tests

* **Bug Fixes**
  * Resolved CLI/MCP stdout tracing corruption and MCP subcommand issues

* **Performance**
  * Reduced WASM binary size (~933 KiB)
  * Improved hypervector bundling with SIMD-aware optimizations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d-o-hub/chaotic_semantic_memory/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->