### PR TITLE
fix(release): correct invalid paths parameter to add-paths in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,7 @@ jobs:
           This PR updates llms.txt and llms-full.txt as part of the release workflow.
           Files updated by scripts/gen-llms-txt.sh
         labels: automated
-        paths: llms.txt,llms-full.txt
+        add-paths: llms.txt,llms-full.txt
         base: main
 
     - name: Validate publish dry-run


### PR DESCRIPTION
This PR fixes the invalid 'paths' parameter to 'add-paths' in the peter-evans/create-pull-request@v5 action block, which caused the Release workflow validate job to fail. Validated locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration to improve release process automation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d-o-hub/chaotic_semantic_memory/pull/257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->