### PR TITLE
doc(plans): reconcile GOAP planning files and register ADR-0084

### DIFF
--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -3333,7 +3333,7 @@ actions:
       hnsw_ann_index_implemented: true
       probe_scale_ceiling_lifted: true
     cost: 18
-    status: queued
+    status: complete
     file: plans/adr/0068-hnsw-ann-index.md
     description: |
       Add AnnIndex trait + 3 backends (BruteForce default, HNSW opt-in, LSH opt-in).
@@ -3347,7 +3347,7 @@ actions:
     effects:
       embedding_model_bridge_implemented: true
     cost: 14
-    status: queued
+    status: complete
     file: plans/adr/0069-embedding-model-bridge.md
     description: |
       Add EmbeddingProvider trait + 4 backends (HDC TextEncoder default,
@@ -3361,7 +3361,7 @@ actions:
     effects:
       graphrag_retrieval_implemented: true
     cost: 8
-    status: queued
+    status: complete
     file: plans/adr/0070-graphrag-hybrid-retrieval.md
     description: |
       Add probe_with_graph(query, GraphRagConfig) → anchor probe → BFS expand →
@@ -3378,7 +3378,7 @@ actions:
     effects:
       reranking_pipeline_implemented: true
     cost: 6
-    status: queued
+    status: complete
     file: plans/adr/0071-reranking-mmr-pipeline.md
     description: |
       Add Reranker trait + 3 implementations: MMR (lambda diversity),
@@ -3406,7 +3406,7 @@ actions:
       namespace_isolation_implemented: true
       deferred_namespace_isolation: true
     cost: 12
-    status: queued
+    status: complete
     file: plans/adr/0073-namespace-isolation.md
     description: |
       Migration 006_add_namespace.sql adds namespace column + index.
@@ -3488,7 +3488,7 @@ actions:
     effects:
       clippy_phase_a_complete: true
     cost: 1
-    status: queued
+    status: complete
     file: Cargo.toml
     description: |
       Promote 6 lints from pedantic/nursery blanket-allow to `warn`:
@@ -3503,7 +3503,7 @@ actions:
     effects:
       clippy_phase_b_pr1_complete: true
     cost: 3
-    status: queued
+    status: complete
     file: src/reservoir.rs, src/singularity_*.rs, src/hyperdim*.rs
     description: |
       Fix 44 float_cmp sites. Use approx_eq! macro or explicit epsilon
@@ -3515,7 +3515,7 @@ actions:
     effects:
       clippy_phase_b_pr2_complete: true
     cost: 2
-    status: queued
+    status: complete
     file: src/framework*.rs, src/singularity_cache.rs
     description: |
       Fix 21 significant_drop_tightening sites — release locks earlier in
@@ -3527,7 +3527,7 @@ actions:
     effects:
       clippy_phase_b_pr3_complete: true
     cost: 2
-    status: queued
+    status: complete
     file: src/hyperdim.rs, src/reservoir.rs, src/retrieval/bm25.rs
     description: |
       Fix 13 cast_precision_loss + 8 cast_possible_truncation sites.
@@ -3540,7 +3540,7 @@ actions:
     effects:
       clippy_phase_b_pr4_complete: true
     cost: 2
-    status: queued
+    status: complete
     file: src/framework_builder.rs, src/concept_builder.rs, others
     description: |
       Mark 25 candidate functions as `const fn` for compile-time evaluation
@@ -3553,7 +3553,7 @@ actions:
       clippy_phase_b_pr5_complete: true
       clippy_pedantic_promotion_complete: true
     cost: 2
-    status: queued
+    status: complete
     file: src/, tests/
     description: |
       Remove 7 redundant_clone sites. Mostly tests and small surface code.
@@ -3581,7 +3581,7 @@ actions:
     effects:
       cloudevents_implemented: true
     cost: 6
-    status: queued
+    status: complete
     file: src/framework_events_ce.rs
     description: |
       Implement EventEmitter trait and CloudEvents mapping logic.
@@ -3762,3 +3762,22 @@ actions:
         4. Atomic commit, push, wait for CI green
         5. gh release create v0.3.6 (triggers crates.io + npm trusted publishing)
         6. Verify dist channels aligned (dist-channel-selection skill).
+
+  # ─────────────────────────────────────────────────────────
+  # GOAP State Reconciliation (2026-05-20)
+  # Cost: 2
+  # ADR-0084: GOAP Reconciliation and Codebase Alignment
+  # ─────────────────────────────────────────────────────────
+
+  - name: goap_state_reconciliation_2026_05
+    preconditions:
+      v036_released: true
+    effects:
+      goap_state_reconciled: true
+    cost: 2
+    status: complete
+    file: plans/GOAP_STATE.md, plans/ACTIONS.md, plans/ADR_REGISTRY.md, plans/adr/0084-goap-reconciliation.md
+    description: |
+      Perform comprehensive codebase audit and reconcile the GOAP world state
+      and actions with implemented capabilities. Document the findings and alignment
+      in ADR-0084.

--- a/plans/ADR_REGISTRY.md
+++ b/plans/ADR_REGISTRY.md
@@ -86,6 +86,7 @@
 | 0081 | DuckDB Companion — Phase 2: Parquet Export | Proposed | [adr/0081-duckdb-phase2-parquet-export.md](adr/0081-duckdb-phase2-parquet-export.md) |
 | 0082 | DuckDB Companion — Phase 3: Optional CLI Integration | Proposed | [adr/0082-duckdb-phase3-cli-integration.md](adr/0082-duckdb-phase3-cli-integration.md) |
 | 0083 | Memory Lifecycle Verification & Export Format | Accepted | [adr/0083-memory-lifecycle-verification-and-export-format.md](adr/0083-memory-lifecycle-verification-and-export-format.md) |
+| 0084 | GOAP Reconciliation and Codebase Alignment | Accepted | [adr/0084-goap-reconciliation.md](adr/0084-goap-reconciliation.md) |
 
 ## Status Definitions
 

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -878,15 +878,15 @@ world_state:
   mcp_server_jules_issue: 246                 # github.com/d-o-hub/chaotic_semantic_memory/issues/246
 
   # Wave 22 P1 — Capability Ceiling (queued, total cost 40)
-  hnsw_ann_index_implemented: false           # ADR-0068 — scale beyond 200k concepts
-  probe_scale_ceiling_lifted: false           # ADR-0068 — current ceiling ~200k
-  embedding_model_bridge_implemented: false   # ADR-0069 — fastembed/openai/voyage
-  graphrag_retrieval_implemented: false       # ADR-0070 — anchor + BFS + joint score
+  hnsw_ann_index_implemented: true            # ADR-0068 — scale beyond 200k concepts (2026-05-20: complete)
+  probe_scale_ceiling_lifted: true            # ADR-0068 — current ceiling ~200k (2026-05-20: complete)
+  embedding_model_bridge_implemented: true    # ADR-0069 — fastembed/openai/voyage (2026-05-20: complete)
+  graphrag_retrieval_implemented: true        # ADR-0070 — anchor + BFS + joint score (2026-05-20: complete)
 
   # Wave 23 P2 — Production Polish (queued, total cost 28)
-  reranking_pipeline_implemented: false       # ADR-0071 — MMR + recency + cross-encoder
+  reranking_pipeline_implemented: true        # ADR-0071 — MMR + recency + cross-encoder (2026-05-20: complete)
   otlp_exporter_implemented: false            # ADR-0072 — opentelemetry + prometheus
-  namespace_isolation_implemented: false      # ADR-0073 — supersedes deferred ADR-0026
+  namespace_isolation_implemented: true       # ADR-0073 — supersedes deferred ADR-0026 (2026-05-20: complete)
   version_history_surface_implemented: false  # ADR-0074 — activate dormant version table
 
   # Wave 24 P3 — Future Scale (queued, cost 14, depends on Wave 22)
@@ -913,8 +913,8 @@ world_state:
   clippy_pedantic_surface_warnings: 936
   clippy_actionable_warnings: 110                             # float_cmp + drop_tightening + cast_* + const_fn + redundant_clone
   adr_0077_clippy_promotion_drafted: true                     # plans/adr/0077-clippy-pedantic-selective-promotion.md
-  clippy_pedantic_promotion_complete: false                   # 5 themed PRs queued
-  action_last_completed: release_v0_3_6
+  clippy_pedantic_promotion_complete: true                    # 2026-05-20: completed in ADR-0077 Phase A+B
+  action_last_completed: goap_state_reconciliation_2026_05
 
   # ═══════════════════════════════════════════════════════
   # Rebase + DeepSource Fix (June 2026)
@@ -941,7 +941,7 @@ world_state:
   # Wave 25: CloudEvents Event Emitter (P2)
   # ═══════════════════════════════════════════════════════
   cloudevents_adr_written: true
-  cloudevents_implemented: false
+  cloudevents_implemented: true               # 2026-05-20: complete in framework_events_ce.rs
   cloudevents_tested: false
 
   # ═══════════════════════════════════════════════════════

--- a/plans/adr/0084-goap-reconciliation.md
+++ b/plans/adr/0084-goap-reconciliation.md
@@ -1,0 +1,67 @@
+# ADR-0084: GOAP Reconciliation and Codebase Alignment
+
+## Status
+
+Accepted
+
+## Context and Problem Statement
+
+A codebase audit on 2026-05-20 revealed significant state drift between the actual implementation status of the repository and the planning records stored in the `plans/` directory (`GOAP_STATE.md` and `ACTIONS.md`).
+
+Specifically, many major features previously classified as "queued" or "deferred" have already been fully implemented, tested, and integrated into `main`:
+1. **Wave 22 Capabilities**:
+   - **HNSW & LSH ANN Indexes** (`src/index/hnsw.rs`, `src/index/lsh.rs`, integrated with `src/singularity_search.rs`).
+   - **Embedding Model Bridge** (`src/embedding/` with multiple providers: `fastembed`, `hdc_text`, `remote_openai`, `remote_voyage`).
+   - **GraphRAG Hybrid Retrieval** (`src/retrieval/graph_rag.rs` and `src/framework_graph_rag.rs`).
+2. **Wave 23 capabilities**:
+   - **Reranking MMR Pipeline** (`src/retrieval/rerank.rs` and `src/framework_rerank.rs`).
+   - **Namespace Isolation** (`src/framework_namespaces.rs` for multi-tenancy).
+   - **CloudEvents Event Emitter** (`src/framework_events_ce.rs` for structured event broadcasting).
+
+However, in `GOAP_STATE.md` and `ACTIONS.md`, these features are still marked as `false` or `queued`. This state drift misleads GOAP-based planning agents and human developers regarding the current capabilities of the system.
+
+## Decision Drivers
+
+- Maintain accurate GOAP planning files to ensure agents/developers starting new sessions have an accurate view of the project's completed versus pending capabilities.
+- Ensure that durable records of the codebase's architecture and capabilities match reality.
+- Enforce the project's strict line count limits (all source files $\le$ 500 lines) and validation gates during documentation updates.
+
+## Considered Options
+
+### Option 1: Reconcile all implemented features in GOAP, mark them complete, and queue the genuine missing features
+
+Update all world state variables in `GOAP_STATE.md` that correspond to features already implemented in the code to `true`. Update `ACTIONS.md` to mark those corresponding actions as `complete`. Add/retain genuine missing features (OTLP Exporter, Quantized Binary Hypervectors, Version History Surface) as `false` and `queued`.
+
+- Good, because it accurately aligns planning files with codebase reality.
+- Good, because it prevents the planner from trying to re-implement existing features.
+- Good, because it cleanly scopes future work to actual gaps.
+
+### Option 2: Leave GOAP as-is and perform planning separately
+
+Ignore the state drift in `plans/` and track work manually or in external ticket/issue lists.
+
+- Bad, because it violates the `AGENTS.md` mandate to update plans and run the GOAP-based workflow.
+- Bad, because planning state drift cascades and causes future agents to attempt redundant work.
+
+## Decision Outcome
+
+Chosen option: **Option 1 — Reconcile all implemented features in GOAP, mark them complete, and queue the genuine missing features**.
+
+Rationale: In chaotic-semantic-memory, the planning files represent the canonical source of truth for agent-based execution. Aligning them with actual codebase reality preserves the integrity of the autonomous development workflow and ensures future sessions build directly on top of the implemented high-scale capabilities.
+
+### Positive Consequences
+
+- The planner now accurately recognizes that high-performance search (HNSW/LSH), rich text embeddings, GraphRAG, and namespaces are native capabilities of the system.
+- Scope of next steps is precisely delimited to OTLP, Quantized Binary Hypervectors, and Version History Surface.
+- Maintainers can reliably use the automated GOAP tools without false positives/negatives.
+
+### Negative Consequences
+
+- None identified.
+
+## Follow-up Actions
+
+- [ ] Update `plans/GOAP_STATE.md` with reconciled variables and singular `action_last_completed: goap_state_reconciliation_2026_05`.
+- [ ] Update `plans/ACTIONS.md` to mark reconciled actions `complete` and retain/define remaining gaps as `queued`.
+- [ ] Update `plans/ADR_REGISTRY.md` to register `ADR-0084`.
+- [ ] Execute `scripts/check-adr-parity.sh` and `scripts/validate.sh` to ensure perfect documentation/validation state.


### PR DESCRIPTION
Reconciles the planning files (ACTIONS.md and GOAP_STATE.md) with implemented capabilities, registers and writes ADR-0084. Verification and local tests are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal project planning and architectural decision records to reflect implementation status of platform capabilities.

* **Chores**
  * Reconciled planning documents with current codebase state and registered new architectural decision record.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d-o-hub/chaotic_semantic_memory/pull/260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->