### PR TITLE
fix(framework): add missing input validation to public APIs

### DIFF
--- a/src/framework_events.rs
+++ b/src/framework_events.rs
@@ -79,6 +79,7 @@ impl ChaoticSemanticFramework {
     /// Update a concept's vector (WASM-only, memory-only).
     #[cfg(target_arch = "wasm32")]
     pub async fn update_concept_vector(&self, id: &str, vector: HVec10240) -> Result<()> {
+        Self::validate_concept_id(id)?;
         let ns = self.namespace.read().await;
         self.singularity.write().await.update(&ns, id, vector)?;
         self.emit_event(MemoryEvent::ConceptUpdated {
@@ -96,6 +97,8 @@ impl ChaoticSemanticFramework {
         id: &str,
         metadata: HashMap<String, serde_json::Value>,
     ) -> Result<()> {
+        Self::validate_concept_id(id)?;
+        Self::validate_metadata_bytes(&metadata, self.config.max_metadata_bytes)?;
         let ns = self.namespace.read().await;
         self.singularity
             .write()
@@ -112,6 +115,8 @@ impl ChaoticSemanticFramework {
     /// Remove an association (WASM-only, memory-only).
     #[cfg(target_arch = "wasm32")]
     pub async fn disassociate(&self, from: &str, to: &str) -> Result<()> {
+        Self::validate_concept_id(from)?;
+        Self::validate_concept_id(to)?;
         let ns = self.namespace.read().await;
         self.singularity.write().await.disassociate(&ns, from, to)?;
         self.emit_event(MemoryEvent::Disassociated {

--- a/src/framework_ops.rs
+++ b/src/framework_ops.rs
@@ -464,9 +464,6 @@ impl ChaoticSemanticFramework {
     /// Bundle multiple concepts into a single hypervector (strict version).
     pub async fn bundle_concepts_strict(&self, ids: &[String]) -> Result<HVec10240> {
         self.validate_batch_size(ids.len())?;
-        for id in ids {
-            Self::validate_concept_id(id)?;
-        }
         let sing = self.singularity.read().await;
         let ns = self.namespace.read().await;
         sing.bundle_concepts_strict(&ns, ids)

--- a/src/framework_ops.rs
+++ b/src/framework_ops.rs
@@ -464,6 +464,9 @@ impl ChaoticSemanticFramework {
     /// Bundle multiple concepts into a single hypervector (strict version).
     pub async fn bundle_concepts_strict(&self, ids: &[String]) -> Result<HVec10240> {
         self.validate_batch_size(ids.len())?;
+        for id in ids {
+            Self::validate_concept_id(id)?;
+        }
         let sing = self.singularity.read().await;
         let ns = self.namespace.read().await;
         sing.bundle_concepts_strict(&ns, ids)

--- a/src/framework_ops.rs
+++ b/src/framework_ops.rs
@@ -366,6 +366,7 @@ impl ChaoticSemanticFramework {
     /// Update a concept's vector.
     #[instrument(err, skip(self), fields(id))]
     pub async fn update_concept_vector(&self, id: &str, vector: HVec10240) -> Result<()> {
+        Self::validate_concept_id(id)?;
         let concept = {
             let mut sing = self.singularity.write().await;
             let ns = self.namespace.read().await;
@@ -392,6 +393,8 @@ impl ChaoticSemanticFramework {
         id: &str,
         metadata: std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<()> {
+        Self::validate_concept_id(id)?;
+        Self::validate_metadata_bytes(&metadata, self.config.max_metadata_bytes)?;
         let concept = {
             let mut sing = self.singularity.write().await;
             let ns = self.namespace.read().await;
@@ -414,6 +417,8 @@ impl ChaoticSemanticFramework {
     /// Remove an association between two concepts.
     #[instrument(err, skip(self), fields(from, to))]
     pub async fn disassociate(&self, from: &str, to: &str) -> Result<()> {
+        Self::validate_concept_id(from)?;
+        Self::validate_concept_id(to)?;
         {
             let mut sing = self.singularity.write().await;
             let ns = self.namespace.read().await;
@@ -435,6 +440,7 @@ impl ChaoticSemanticFramework {
     /// Clear all outbound associations for a concept.
     #[instrument(err, skip(self), fields(id))]
     pub async fn clear_associations(&self, id: &str) -> Result<()> {
+        Self::validate_concept_id(id)?;
         {
             let mut sing = self.singularity.write().await;
             let ns = self.namespace.read().await;
@@ -457,6 +463,7 @@ impl ChaoticSemanticFramework {
 
     /// Bundle multiple concepts into a single hypervector (strict version).
     pub async fn bundle_concepts_strict(&self, ids: &[String]) -> Result<HVec10240> {
+        self.validate_batch_size(ids.len())?;
         let sing = self.singularity.read().await;
         let ns = self.namespace.read().await;
         sing.bundle_concepts_strict(&ns, ids)

--- a/tests/validation_errors.rs
+++ b/tests/validation_errors.rs
@@ -160,7 +160,9 @@ async fn update_concept_vector_id_validation_fails() {
         .await
         .unwrap();
 
-    let result = framework.update_concept_vector("", HVec10240::random()).await;
+    let result = framework
+        .update_concept_vector("", HVec10240::random())
+        .await;
     assert!(result.is_err());
 }
 
@@ -174,14 +176,17 @@ async fn update_concept_metadata_validation_fails() {
         .unwrap();
 
     // Invalid ID
-    let result = framework.update_concept_metadata("", std::collections::HashMap::new()).await;
+    let result = framework
+        .update_concept_metadata("", std::collections::HashMap::new())
+        .await;
     assert!(result.is_err());
 
     // Too large metadata
-    let large_metadata = std::collections::HashMap::from([
-        ("key1".to_string(), serde_json::json!("value1")),
-    ]);
-    let result = framework.update_concept_metadata("some-id", large_metadata).await;
+    let large_metadata =
+        std::collections::HashMap::from([("key1".to_string(), serde_json::json!("value1"))]);
+    let result = framework
+        .update_concept_metadata("some-id", large_metadata)
+        .await;
     assert!(result.is_err());
 }
 

--- a/tests/validation_errors.rs
+++ b/tests/validation_errors.rs
@@ -151,3 +151,79 @@ async fn batch_size_exceeded_fails() {
     let result = framework.inject_concepts(&concepts).await;
     assert!(result.is_err());
 }
+
+#[tokio::test]
+async fn update_concept_vector_id_validation_fails() {
+    let framework = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .build()
+        .await
+        .unwrap();
+
+    let result = framework.update_concept_vector("", HVec10240::random()).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn update_concept_metadata_validation_fails() {
+    let framework = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .with_max_metadata_bytes(10)
+        .build()
+        .await
+        .unwrap();
+
+    // Invalid ID
+    let result = framework.update_concept_metadata("", std::collections::HashMap::new()).await;
+    assert!(result.is_err());
+
+    // Too large metadata
+    let large_metadata = std::collections::HashMap::from([
+        ("key1".to_string(), serde_json::json!("value1")),
+    ]);
+    let result = framework.update_concept_metadata("some-id", large_metadata).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn disassociate_id_validation_fails() {
+    let framework = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .build()
+        .await
+        .unwrap();
+
+    // Invalid 'from'
+    let result = framework.disassociate("", "to-id").await;
+    assert!(result.is_err());
+
+    // Invalid 'to'
+    let result = framework.disassociate("from-id", "").await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn clear_associations_id_validation_fails() {
+    let framework = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .build()
+        .await
+        .unwrap();
+
+    let result = framework.clear_associations("").await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn bundle_concepts_strict_batch_size_fails() {
+    let framework = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .with_max_batch_size(2)
+        .build()
+        .await
+        .unwrap();
+
+    let ids = vec!["c1".to_string(), "c2".to_string(), "c3".to_string()];
+    let result = framework.bundle_concepts_strict(&ids).await;
+    assert!(result.is_err());
+}


### PR DESCRIPTION
**Severity:** MEDIUM
**Finding:** Multiple public methods in `ChaoticSemanticFramework` lacked input validation for concept IDs, metadata size, or batch sizes.
**Impact:** An attacker or malicious user could potentially cause resource exhaustion (memory or CPU) or denial-of-service by providing extremely large concept IDs, metadata, or batch lists.
**Fix:** Added calls to `Self::validate_concept_id`, `Self::validate_metadata_bytes`, and `self.validate_batch_size` in the affected methods in `src/framework_ops.rs` and `src/framework_events.rs`.
**Verification:** all gates pass — `cargo test` (222 lib tests, multiple integration tests) and `cargo audit` / `cargo deny check` were successful.

---
*PR created automatically by Jules for task [18159902336404485128](https://jules.google.com/task/18159902336404485128) started by @d-o-hub*