### PR TITLE
docs: audit and synchronize documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ are never blocked by database writes.
 |---|---|---|
 | `inject_concept` | O(1) amortized | HashMap insert + dense vector append |
 | `associate` | O(1) amortized | HashMap insert with optional eviction |
-| `probe` (exact scan) | O(n) | Cosine similarity over all n concepts; parallelized via Rayon on native. Zero-allocation caching: uses hashed keys and `Arc` to share cache results. |
+ `probe` (exact scan) | O(n) | Cosine similarity over all n concepts; parallelized via Rayon on native. Zero-copy caching: uses hashed keys and `Arc` to share cache results. |
 | `probe` (bucket candidates) | O(n / 2^w) | w-bit bucket width narrows candidate set before exact scoring |
 | `probe` (graph candidates) | O(f^d) | BFS from nearest neighbor at depth d, fanout f |
 

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ are never blocked by database writes.
 |---|---|---|
 | `inject_concept` | O(1) amortized | HashMap insert + dense vector append |
 | `associate` | O(1) amortized | HashMap insert with optional eviction |
-| `probe` (exact scan) | O(n) | Cosine similarity over all n concepts; parallelized via Rayon on native |
+| `probe` (exact scan) | O(n) | Cosine similarity over all n concepts; parallelized via Rayon on native. Zero-allocation caching: uses hashed keys and `Arc` to share cache results. |
 | `probe` (bucket candidates) | O(n / 2^w) | w-bit bucket width narrows candidate set before exact scoring |
 | `probe` (graph candidates) | O(f^d) | BFS from nearest neighbor at depth d, fanout f |
 
@@ -450,22 +450,18 @@ cargo clippy --quiet -- -D warnings
 
 LOC policy: each source file in `src/` must stay at or below 500 lines.
 
-## Mutation Testing
+### Additional Testing
 
-Install cargo-mutants once:
-
+**Mutation Testing**:
 ```bash
 cargo install cargo-mutants
-```
-
-Run profiles:
-
-```bash
 scripts/mutation_test.sh fast
-scripts/mutation_test.sh full
 ```
 
-Reports are written under `progress/mutation/`.
+**Fuzz Testing**:
+```bash
+cargo +nightly fuzz run hvec_from_bytes
+```
 
 ## Test Coverage
 
@@ -477,6 +473,7 @@ Reports are written under `progress/mutation/`.
 | Source LOC | 12,140 (excluding inline tests) |
 | Inline test LOC | 2684 (in src modules) |
 | Test:Source ratio | **93%** (target: 90%) ✅ |
+| Fuzz coverage | `fuzz/fuzz_targets/` |
 
 ### Test Types
 
@@ -511,9 +508,9 @@ csm import backup.json --merge --database test.db
 | CLI Binary | ✅ Ready | All commands pass |
 | WASM/npm | ✅ Ready | Export/import fixed in v0.3.5 (PR #138) |
 
-**WASM Export Fix**: `exportToBytes()` / `importFromBytes()` now uses `BinaryExportPayload` for bincode serialization, resolving the previous UTF-8 error with `serde_json::Value` metadata.
+**WASM Export**: `exportToBytes()` / `importFromBytes()` uses `BinaryExportPayload` for bincode serialization, handling `serde_json::Value` metadata.
 
-## Benchmark Gates
+### Benchmark & Performance Gates
 
 ```bash
 cargo bench --bench benchmark -- --save-baseline main

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -44,7 +44,7 @@ Concept storage and semantic search:
 
 - HashMap-based concept storage
 - Association graph (weighted edges)
-- Zero-allocation query cache for similarity queries
+- Zero-copy query cache for similarity queries
 - Rayon-parallel similarity search
 
 ### Framework (`framework.rs`)

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -44,7 +44,7 @@ Concept storage and semantic search:
 
 - HashMap-based concept storage
 - Association graph (weighted edges)
-- LRU cache for similarity queries
+- Zero-allocation query cache for similarity queries
 - Rayon-parallel similarity search
 
 ### Framework (`framework.rs`)
@@ -91,3 +91,5 @@ process_sequence(inputs)
 | LOC per file | ≤500 | Maintainability |
 | Spectral radius | [0.9, 1.1] | Edge of chaos |
 | WASM threading | Gated | Browser compatibility |
+| Mutation testing | scripts/mutation_test.sh | Prevent regressions |
+| Fuzz testing | cargo +nightly fuzz run hvec_from_bytes | Prevent regressions |

--- a/book/src/wasm.md
+++ b/book/src/wasm.md
@@ -87,7 +87,7 @@ declare class WasmFramework {
 
 ## Limitations
 
-- **No persistence** - WASM build excludes filesystem access
+- **No persistence** - `libSQL` persistence is bypassed/unavailable on `wasm32-unknown-unknown` and threading guards dictate compilation.
 - **No threading** - Rayon parallelization is gated
 - **Memory only** - All data is in-memory for browser context
 

--- a/docs/architecture/context.yaml
+++ b/docs/architecture/context.yaml
@@ -250,6 +250,12 @@ validation:
     - name: wasm
       command: cargo check --target wasm32-unknown-unknown
       
+    - name: fuzz
+      command: cargo +nightly fuzz run hvec_from_bytes
+
+    - name: mutation
+      command: scripts/mutation_test.sh fast
+
   script: scripts/validate.sh
   description: Run before commit
   

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -948,7 +948,7 @@ are never blocked by database writes.
 |---|---|---|
 | `inject_concept` | O(1) amortized | HashMap insert + dense vector append |
 | `associate` | O(1) amortized | HashMap insert with optional eviction |
-| `probe` (exact scan) | O(n) | Cosine similarity over all n concepts; parallelized via Rayon on native |
+| `probe` (exact scan) | O(n) | Cosine similarity over all n concepts; parallelized via Rayon on native. Zero-allocation caching: uses hashed keys and `Arc` to share cache results. |
 | `probe` (bucket candidates) | O(n / 2^w) | w-bit bucket width narrows candidate set before exact scoring |
 | `probe` (graph candidates) | O(f^d) | BFS from nearest neighbor at depth d, fanout f |
 
@@ -993,22 +993,18 @@ cargo clippy --quiet -- -D warnings
 
 LOC policy: each source file in `src/` must stay at or below 500 lines.
 
-#### Mutation Testing
+##### Additional Testing
 
-Install cargo-mutants once:
-
+**Mutation Testing**:
 ```bash
 cargo install cargo-mutants
-```
-
-Run profiles:
-
-```bash
 scripts/mutation_test.sh fast
-scripts/mutation_test.sh full
 ```
 
-Reports are written under `progress/mutation/`.
+**Fuzz Testing**:
+```bash
+cargo +nightly fuzz run hvec_from_bytes
+```
 
 #### Test Coverage
 
@@ -1020,6 +1016,7 @@ Reports are written under `progress/mutation/`.
 | Source LOC | 12,140 (excluding inline tests) |
 | Inline test LOC | 2684 (in src modules) |
 | Test:Source ratio | **93%** (target: 90%) ✅ |
+| Fuzz coverage | `fuzz/fuzz_targets/` |
 
 ##### Test Types
 
@@ -1054,9 +1051,9 @@ csm inject my-concept --database csm_memory.db
 | CLI Binary | ✅ Ready | All commands pass |
 | WASM/npm | ✅ Ready | Export/import fixed in v0.3.5 (PR #138) |
 
-**WASM Export Fix**: `exportToBytes()` / `importFromBytes()` now uses `BinaryExportPayload` for bincode serialization, resolving the previous UTF-8 error with `serde_json::Value` metadata.
+**WASM Export**: `exportToBytes()` / `importFromBytes()` uses `BinaryExportPayload` for bincode serialization, handling `serde_json::Value` metadata.
 
-#### Benchmark Gates
+##### Benchmark & Performance Gates
 
 ```bash
 cargo bench --bench benchmark -- --save-baseline main

--- a/llms.txt
+++ b/llms.txt
@@ -954,7 +954,7 @@ are never blocked by database writes.
 |---|---|---|
 | `inject_concept` | O(1) amortized | HashMap insert + dense vector append |
 | `associate` | O(1) amortized | HashMap insert with optional eviction |
-| `probe` (exact scan) | O(n) | Cosine similarity over all n concepts; parallelized via Rayon on native |
+| `probe` (exact scan) | O(n) | Cosine similarity over all n concepts; parallelized via Rayon on native. Zero-allocation caching: uses hashed keys and `Arc` to share cache results. |
 | `probe` (bucket candidates) | O(n / 2^w) | w-bit bucket width narrows candidate set before exact scoring |
 | `probe` (graph candidates) | O(f^d) | BFS from nearest neighbor at depth d, fanout f |
 
@@ -999,22 +999,18 @@ cargo clippy --quiet -- -D warnings
 
 LOC policy: each source file in `src/` must stay at or below 500 lines.
 
-#### Mutation Testing
+##### Additional Testing
 
-Install cargo-mutants once:
-
+**Mutation Testing**:
 ```bash
 cargo install cargo-mutants
-```
-
-Run profiles:
-
-```bash
 scripts/mutation_test.sh fast
-scripts/mutation_test.sh full
 ```
 
-Reports are written under `progress/mutation/`.
+**Fuzz Testing**:
+```bash
+cargo +nightly fuzz run hvec_from_bytes
+```
 
 #### Test Coverage
 
@@ -1026,6 +1022,7 @@ Reports are written under `progress/mutation/`.
 | Source LOC | 12,140 (excluding inline tests) |
 | Inline test LOC | 2684 (in src modules) |
 | Test:Source ratio | **93%** (target: 90%) ✅ |
+| Fuzz coverage | `fuzz/fuzz_targets/` |
 
 ##### Test Types
 
@@ -1060,9 +1057,9 @@ csm inject my-concept --database csm_memory.db
 | CLI Binary | ✅ Ready | All commands pass |
 | WASM/npm | ✅ Ready | Export/import fixed in v0.3.5 (PR #138) |
 
-**WASM Export Fix**: `exportToBytes()` / `importFromBytes()` now uses `BinaryExportPayload` for bincode serialization, resolving the previous UTF-8 error with `serde_json::Value` metadata.
+**WASM Export**: `exportToBytes()` / `importFromBytes()` uses `BinaryExportPayload` for bincode serialization, handling `serde_json::Value` metadata.
 
-#### Benchmark Gates
+##### Benchmark & Performance Gates
 
 ```bash
 cargo bench --bench benchmark -- --save-baseline main

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -951,7 +951,7 @@ world_state:
     registry_count: 80
     disk_count: 79
     parity_satisfied: true
-  action_last_completed: goap_orchestrator_verification_2026_05_21
+  action_last_completed: synchronize_documentation_audit_2026_05
 
   # ═══════════════════════════════════════════════════════
   # Pre-Release Gate Fixes (2026-05-21)

--- a/progress/PROGRESS.md
+++ b/progress/PROGRESS.md
@@ -1,3 +1,8 @@
+## 2026-05-23: Documentation Audit
+
+### Summary
+Synchronized README, architecture docs, and books with current implementation state, explicitly detailing zero-allocation query caches and WASM limitations while removing outdated fluff.
+
 ## 2026-04-11: Persistence Field Integrity Hardening
 
 ### Summary


### PR DESCRIPTION
Synchronized `README.md`, `docs/architecture/context.yaml`, and `book/` contents with the current implementation state. 

- Removed outdated marketing fluff and 'NEW' markers, particularly regarding WASM export serialization.
- Explicitly documented the zero-allocation query cache in `Singularity`.
- Clarified that `libSQL` persistence is bypassed on the `wasm32-unknown-unknown` target.
- Added `fuzz` testing (`cargo fuzz`) and `cargo-mutants` to the formal Development/Validation Gates.
- Consolidated development gates under unified headers in context files.
- Recorded the documentation audit in `progress/PROGRESS.md` and `plans/GOAP_STATE.md`.

---
*PR created automatically by Jules for task [7793719081082420418](https://jules.google.com/task/7793719081082420418) started by @d-o-hub*