### PR TITLE
Clean up redundant #[cfg] attributes in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,6 @@ mod hyperdim_simd_bundle;
 pub mod mcp;
 pub mod metadata_filter;
 #[cfg(all(not(target_arch = "wasm32"), feature = "persistence"))]
-#[cfg(all(not(target_arch = "wasm32"), feature = "persistence"))]
 mod persistence_concepts;
 pub mod semantic_triples;
 pub use metadata_filter::MetadataFilter;
@@ -98,7 +97,6 @@ mod persistence_ops;
 #[cfg(all(not(target_arch = "wasm32"), feature = "persistence"))]
 mod persistence_versions;
 #[cfg(target_arch = "wasm32")]
-#[cfg(target_arch = "wasm32")]
 pub mod persistence_wasm;
 pub mod reservoir;
 mod reservoir_inertial; // ADR-0064
@@ -113,7 +111,6 @@ mod singularity_search; // Extracted from singularity.rs for LOC gate
 pub mod singularity_state;
 mod singularity_ttl;
 
-#[cfg(target_arch = "wasm32")]
 #[cfg(target_arch = "wasm32")]
 pub use crate::persistence_wasm as persistence;
 


### PR DESCRIPTION
This change removes three instances of redundant consecutive identical #[cfg] attributes in src/lib.rs that were likely added during copy-paste. The functionality remains unchanged as multiple identical #[cfg] attributes are idempotent.

Fixes #291

---
*PR created automatically by Jules for task [6106388175690249227](https://jules.google.com/task/6106388175690249227) started by @d-o-hub*