### PR TITLE
fix(adr): align HNSW migration numbering, table name, and add parity tests

### DIFF
--- a/migrations/007_add_hnsw_graph.sql
+++ b/migrations/007_add_hnsw_graph.sql
@@ -1,4 +1,4 @@
--- Migration 005: Add HNSW graph table for index persistence
+-- Migration 007: Add HNSW graph table for index persistence
 CREATE TABLE IF NOT EXISTS csm_hnsw_graph (
     id TEXT PRIMARY KEY,
     data BLOB NOT NULL,

--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -3337,7 +3337,7 @@ actions:
     file: plans/adr/0068-hnsw-ann-index.md
     description: |
       Add AnnIndex trait + 3 backends (BruteForce default, HNSW opt-in, LSH opt-in).
-      Migration 005_add_hnsw_graph.sql for serialized index persistence.
+      Migration 007_add_hnsw_graph.sql for serialized index persistence.
       Bench targets at 50k/200k/1M concepts. Recall@10 ≥ 0.95 vs brute force.
       p50 ≤ 5 ms at 1M concepts.
 

--- a/plans/adr/0068-hnsw-ann-index.md
+++ b/plans/adr/0068-hnsw-ann-index.md
@@ -94,8 +94,8 @@ framework_builder.with_index_backend(IndexBackend::Hnsw {
 
 ### Persistence
 
-- HNSW graph serialized alongside concepts in libSQL (new table `hnsw_graph`)
-- Migration `005_add_hnsw_graph.sql`
+- HNSW graph serialized alongside concepts in libSQL (new table `csm_hnsw_graph`)
+- Migration `007_add_hnsw_graph.sql`
 - On load: detect serialized graph, deserialize; otherwise rebuild from concepts
 
 ### Cargo features

--- a/tests/migration_parity.rs
+++ b/tests/migration_parity.rs
@@ -1,0 +1,138 @@
+//! Structural parity checks for migration files and ADR references.
+//!
+//! 1. Migration header parity: each `migrations/NNN_*.sql` file must have
+//!    `-- Migration NNN:` as its first line, matching the filename prefix.
+//! 2. ADR migration reference parity: every `` `NNN_name.sql` `` reference
+//!    in `plans/adr/*.md` must correspond to an existing file in
+//!    `migrations/`. Proposed-status ADRs are allowed to reference future
+//!    migrations that do not yet exist on disk.
+
+use std::path::{Path, PathBuf};
+
+fn crate_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn migrations_dir() -> PathBuf {
+    crate_root().join("migrations")
+}
+
+fn adr_dir() -> PathBuf {
+    crate_root().join("plans").join("adr")
+}
+
+fn is_proposed_adr(path: &Path) -> bool {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    content.lines().any(|l| l.trim().starts_with("Proposed"))
+}
+
+#[test]
+fn migration_file_headers_match_filenames() {
+    let dir = migrations_dir();
+    let mut failures = Vec::new();
+
+    for entry in std::fs::read_dir(&dir).expect("migrations/ directory not found") {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("sql") {
+            continue;
+        }
+
+        let stem = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .expect("non-UTF8 migration filename");
+
+        let expected_prefix: &str = &stem[..3];
+        let content = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+
+        let first_line = content.lines().next().unwrap_or("");
+        let expected_header = format!("-- Migration {expected_prefix}:");
+        if !first_line.starts_with(&expected_header) {
+            let filename = path.file_name().unwrap().to_str().unwrap();
+            failures.push(format!(
+                "{filename}: expected header starting with \"{expected_header}\", got \"{first_line}\"",
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "Migration header/filename mismatches:\n  {}",
+        failures.join("\n  "),
+    );
+}
+
+#[test]
+fn adr_migration_references_exist_on_disk() {
+    let adr = adr_dir();
+    let mig = migrations_dir();
+
+    if !adr.exists() {
+        eprintln!("plans/adr/ not found — skipping ADR migration reference check");
+        return;
+    }
+
+    let mut failures = Vec::new();
+    let mut proposed_skipped = Vec::new();
+
+    for entry in std::fs::read_dir(&adr).expect("plans/adr/ directory not found") {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("md") {
+            continue;
+        }
+
+        let is_proposed = is_proposed_adr(&path);
+        let content = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+
+        let adr_filename = path.file_name().unwrap().to_str().unwrap().to_string();
+        for (lineno, line) in content.lines().enumerate() {
+            let lineno = lineno + 1;
+            for captured in line
+                .split('`')
+                .enumerate()
+                .filter(|(i, _)| i % 2 == 1)
+                .map(|(_, s)| s)
+            {
+                let trimmed = captured.trim();
+                if !trimmed.ends_with(".sql") {
+                    continue;
+                }
+                if !trimmed.chars().take(3).all(|c| c.is_ascii_digit()) {
+                    continue;
+                }
+                let mig_path = mig.join(trimmed);
+                if !mig_path.exists() {
+                    if is_proposed {
+                        proposed_skipped.push(format!(
+                            "{adr_filename}:{lineno} (Proposed, skipped): references \"{trimmed}\" (not yet on disk)",
+                        ));
+                    } else {
+                        failures.push(format!(
+                            "{adr_filename}:{lineno}: references \"{trimmed}\" but no such file in migrations/",
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    if !proposed_skipped.is_empty() {
+        eprintln!(
+            "info: Proposed ADRs reference future migrations (not checked):\n  {}",
+            proposed_skipped.join("\n  "),
+        );
+    }
+
+    assert!(
+        failures.is_empty(),
+        "ADR migration reference mismatches:\n  {}",
+        failures.join("\n  "),
+    );
+}


### PR DESCRIPTION
## Summary

- Fix migration header comment in `007_add_hnsw_graph.sql` from `005` to `007`
- Fix ADR-0068 table name reference: `hnsw_graph` -> `csm_hnsw_graph`
- Fix ADR-0068 migration reference: `005_add_hnsw_graph.sql` -> `007_add_hnsw_graph.sql`
- Fix ACTIONS.md migration reference: `005_add_hnsw_graph.sql` -> `007_add_hnsw_graph.sql`
- Add `tests/migration_parity.rs` with two structural checks:
  1. **Migration header parity**: each `migrations/NNN_*.sql` file header must match its filename prefix
  2. **ADR migration reference parity**: every backtick-quoted `NNN_name.sql` reference in non-Proposed ADRs must correspond to an actual file in `migrations/`

## Testing
- `cargo test --test migration_parity` - 2 tests pass
- `cargo test --test migration_errors` - 5 tests pass (unaffected)
- `cargo check`, `cargo fmt`, `cargo clippy` - all clean
- `./scripts/check-adr-parity.sh` - parity ok (registry=80, disk=79)
