### PR TITLE
feat(skills): add codacy static analysis skill

### DIFF
--- a/.agents/skills/codacy/SKILL.md
+++ b/.agents/skills/codacy/SKILL.md
@@ -33,8 +33,8 @@ export CODACY_API_TOKEN=<your-api-token>
 ### PR Triage
 1. **Fetch Analysis**:
    `codacy pull-request gh <org> <repo> <prNumber> --output json > /tmp/codacy-pr.json`
-2. **Review Issues**:
-   Examine `newIssues` in the JSON. Note the `resultDataId` for any false positives.
+2. **Review Status & Issues**:
+   Check `qualityGateStatus` for the overall status (Passed, Warning, Failed). Examine `newIssues` in the JSON and note the `resultDataId` for any false positives.
 3. **Suppress False Positives**:
    `codacy pull-request gh <org> <repo> <prNumber> --ignore-issue <resultDataId> --ignore-reason FalsePositive`
 

--- a/.agents/skills/codacy/SKILL.md
+++ b/.agents/skills/codacy/SKILL.md
@@ -33,8 +33,8 @@ export CODACY_API_TOKEN=<your-api-token>
 ### PR Triage
 1. **Fetch Analysis**:
    `codacy pull-request gh <org> <repo> <prNumber> --output json > /tmp/codacy-pr.json`
-2. **Review Status & Issues**:
-   Check `qualityGateStatus` for the overall status (Passed, Warning, Failed). Examine `newIssues` in the JSON and note the `resultDataId` for any false positives.
+2. **Review Issues**:
+   Examine `newIssues` in the JSON. Note the `resultDataId` for any false positives.
 3. **Suppress False Positives**:
    `codacy pull-request gh <org> <repo> <prNumber> --ignore-issue <resultDataId> --ignore-reason FalsePositive`
 

--- a/.agents/skills/codacy/SKILL.md
+++ b/.agents/skills/codacy/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: codacy
+description: "Orchestrate static analysis using Codacy CLIs. Use when Codacy blocks a PR, for fixing quality gate failures, or suppressing false positives in this Rust/Shell codebase."
+---
+
+# Codacy Static Analysis
+
+Use Codacy CLIs (Analysis CLI for local, Cloud CLI for remote) to maintain code quality and security standards.
+
+## When to Use
+
+- When a PR is blocked by a Codacy quality gate.
+- To triage and fix static analysis findings (Rust, Shell, Markdown).
+- To suppress false positives identified in the Codacy dashboard.
+- To verify local changes before pushing (for supported tools).
+
+## Do NOT Use
+
+- For architectural changes or logic bugs not caught by static analysis.
+- As the sole source of truth for Rust analysis (local `cargo clippy` is more precise).
+- For local analysis of languages requiring complex runtimes not in the environment.
+
+## Installation & Auth
+
+```bash
+# Requires Node.js
+npm i -g @codacy/analysis-cli @codacy/codacy-cloud-cli
+export CODACY_API_TOKEN=<your-api-token>
+```
+
+## Workflows
+
+### PR Triage
+1. **Fetch Analysis**:
+   `codacy pull-request gh <org> <repo> <prNumber> --output json > /tmp/codacy-pr.json`
+2. **Review Issues**:
+   Examine `newIssues` in the JSON. Note the `resultDataId` for any false positives.
+3. **Suppress False Positives**:
+   `codacy pull-request gh <org> <repo> <prNumber> --ignore-issue <resultDataId> --ignore-reason FalsePositive`
+
+### Local Verification
+```bash
+# Initialize if missing
+codacy-analysis init --default
+
+# Run local analysis on current branch
+codacy-analysis analyze --pr --output-format json
+```
+
+## Tool Support Matrix
+
+| Tool | Focus | Local Support |
+|------|-------|---------------|
+| **Opengrep** | Rust/Security | ✅ Partial |
+| **ShellCheck** | Shell Scripts | ✅ Full |
+| **markdownlint** | Documentation | ✅ Full |
+| **Trivy** | Security/SBOM | ✅ Full |
+| **Clippy** | Rust Lints | ❌ Cloud Only (via Codacy) |
+
+## Key Constraints
+
+- **resultDataId**: Always use the numeric `resultDataId` for CLI suppressions. The `hash` is NOT supported for this operation.
+- **Cloud Source of Truth**: Local analysis is a subset. If the Cloud dashboard shows issues not found locally, the Cloud results are authoritative.
+- **Ignore Reason**: Suppressions require a valid `--ignore-reason` (e.g., `FalsePositive`, `Won't Fix`).
+
+## References
+
+- `references/output-format.md`: JSON schema for PR analysis.
+- `references/supported-tools.md`: Detailed tool availability.
+- `references/config-format.md`: `.codacy.yml` configuration syntax.

--- a/.agents/skills/codacy/SKILL.md
+++ b/.agents/skills/codacy/SKILL.md
@@ -31,14 +31,18 @@ export CODACY_API_TOKEN=<your-api-token>
 ## Workflows
 
 ### PR Triage
+
 1. **Fetch Analysis**:
    `codacy pull-request gh <org> <repo> <prNumber> --output json > /tmp/codacy-pr.json`
+
 2. **Review Issues**:
    Examine `newIssues` in the JSON. Note the `resultDataId` for any false positives.
+
 3. **Suppress False Positives**:
    `codacy pull-request gh <org> <repo> <prNumber> --ignore-issue <resultDataId> --ignore-reason FalsePositive`
 
 ### Local Verification
+
 ```bash
 # Initialize if missing
 codacy-analysis init --default

--- a/.agents/skills/codacy/evals/evals.json
+++ b/.agents/skills/codacy/evals/evals.json
@@ -35,9 +35,9 @@
     {
       "id": 4,
       "prompt": "I've updated the .codacy.yml file. How can I verify that the syntax is correct before committing?",
-      "expected_output": "The agent should suggest using the `codacy-analysis discover` command to check the configuration file locally.",
+      "expected_output": "The agent should suggest using the `codacy-analysis-cli validate-configuration` command to check the configuration file locally.",
       "assertions": [
-        "Mentions `codacy-analysis discover`",
+        "Mentions `codacy-analysis-cli validate-configuration`",
         "Specifies the `--directory` flag or implies running from root",
         "Correctly identifies the tool for configuration validation"
       ]

--- a/.agents/skills/codacy/evals/evals.json
+++ b/.agents/skills/codacy/evals/evals.json
@@ -35,9 +35,9 @@
     {
       "id": 4,
       "prompt": "I've updated the .codacy.yml file. How can I verify that the syntax is correct before committing?",
-      "expected_output": "The agent should suggest using the `codacy-analysis-cli validate-configuration` command to check the configuration file locally.",
+      "expected_output": "The agent should suggest using the `codacy-analysis discover` command to check the configuration file locally.",
       "assertions": [
-        "Mentions `codacy-analysis-cli validate-configuration`",
+        "Mentions `codacy-analysis discover`",
         "Specifies the `--directory` flag or implies running from root",
         "Correctly identifies the tool for configuration validation"
       ]

--- a/.agents/skills/codacy/evals/evals.json
+++ b/.agents/skills/codacy/evals/evals.json
@@ -31,6 +31,16 @@
         "Notes local analysis is a subset",
         "References Cloud as source of truth for full results"
       ]
+    },
+    {
+      "id": 4,
+      "prompt": "I've updated the .codacy.yml file. How can I verify that the syntax is correct before committing?",
+      "expected_output": "The agent should suggest using the `codacy-analysis-cli validate-configuration` command to check the configuration file locally.",
+      "assertions": [
+        "Mentions `codacy-analysis-cli validate-configuration`",
+        "Specifies the `--directory` flag or implies running from root",
+        "Correctly identifies the tool for configuration validation"
+      ]
     }
   ]
 }

--- a/.agents/skills/codacy/evals/evals.json
+++ b/.agents/skills/codacy/evals/evals.json
@@ -1,0 +1,36 @@
+{
+  "skill_name": "codacy",
+  "version": "1.0.0",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "How do I check why Codacy is failing on PR #150?",
+      "expected_output": "The agent should suggest using `codacy pull-request gh <org> <repo> 150 --output json` and parsing the `newIssues` and `qualityGateStatus` fields.",
+      "assertions": [
+        "Uses `codacy pull-request`",
+        "Includes `--output json`",
+        "Mentions checking qualityGateStatus"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "I have a false positive in a shell script. How do I suppress it using the CLI?",
+      "expected_output": "The agent should identify that the numeric `resultDataId` is required and suggest `codacy pull-request ... --ignore-issue <id> --ignore-reason FalsePositive`.",
+      "assertions": [
+        "Mentions numeric resultDataId",
+        "Uses --ignore-issue",
+        "Uses --ignore-reason"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Can I run Codacy analysis locally for my Rust changes?",
+      "expected_output": "The agent should explain that `codacy-analysis analyze` supports some tools locally (like Opengrep or Trivy) but note that it's a subset and recommends checking the Cloud dashboard for full Clippy integration.",
+      "assertions": [
+        "Mentions `codacy-analysis analyze`",
+        "Notes local analysis is a subset",
+        "References Cloud as source of truth for full results"
+      ]
+    }
+  ]
+}

--- a/.agents/skills/codacy/references/config-format.md
+++ b/.agents/skills/codacy/references/config-format.md
@@ -44,5 +44,5 @@ engines:
 
 Validate your configuration locally:
 ```bash
-codacy-analysis-cli validate-configuration --directory .
+codacy-analysis validate-configuration --directory .
 ```

--- a/.agents/skills/codacy/references/config-format.md
+++ b/.agents/skills/codacy/references/config-format.md
@@ -1,34 +1,48 @@
 # Codacy Configuration Format
 
-The repository uses `.codacy/codacy.config.json` for advanced configuration.
+The repository uses `.codacy.yml` or `.codacy.yaml` for advanced configuration.
 
 ## Basic Structure
 
-```json
-{
-  "tools": [
-    {
-      "name": "eslint-9",
-      "enabled": true
-    }
-  ],
-  "exclude_paths": [
-    "target/**",
-    "node_modules/**"
-  ]
-}
+```yaml
+---
+exclude_paths:
+  - "target/**"
+  - "node_modules/**"
+  - "benches/fixtures/**"
+
+languages:
+  rust:
+    enabled: true
+  shell:
+    enabled: true
+
+engines:
+  duplication:
+    enabled: true
+    exclude_paths:
+      - "tests/**"
 ```
 
-## Local Initialization
+## Tool-Specific Configuration
 
-Generate a default configuration based on repository discovery:
-```bash
-codacy-analysis init --default
+You can tune specific engines under the `engines` key:
+
+```yaml
+engines:
+  shellcheck:
+    exclude_paths:
+      - "scripts/legacy/**"
+  metric:
+    # Cyclomatic complexity thresholds
+    config:
+      languages:
+        - "rust"
 ```
 
 ## Validation
 
-Current versions of the Analysis CLI perform implicit validation during `analyze` or `discover`. To check for configuration-related issues:
+Validate your configuration locally using the Codacy Analysis CLI:
 ```bash
-codacy-analysis discover .
+codacy-analysis-cli validate-configuration --directory .
 ```

--- a/.agents/skills/codacy/references/config-format.md
+++ b/.agents/skills/codacy/references/config-format.md
@@ -44,5 +44,5 @@ engines:
 
 Validate your configuration locally:
 ```bash
-codacy-analysis validate-configuration --directory .
+codacy-analysis-cli validate-configuration --directory .
 ```

--- a/.agents/skills/codacy/references/config-format.md
+++ b/.agents/skills/codacy/references/config-format.md
@@ -1,0 +1,48 @@
+# Codacy Configuration Format
+
+The repository uses `.codacy.yml` or `.codacy.yaml` for advanced configuration.
+
+## Basic Structure
+
+```yaml
+---
+exclude_paths:
+  - "target/**"
+  - "node_modules/**"
+  - "benches/fixtures/**"
+
+languages:
+  rust:
+    enabled: true
+  shell:
+    enabled: true
+
+engines:
+  duplication:
+    enabled: true
+    exclude_paths:
+      - "tests/**"
+```
+
+## Tool-Specific Configuration
+
+You can tune specific engines under the `engines` key:
+
+```yaml
+engines:
+  shellcheck:
+    exclude_paths:
+      - "scripts/legacy/**"
+  metric:
+    # Cyclomatic complexity thresholds
+    config:
+      languages:
+        - "rust"
+```
+
+## Validation
+
+Validate your configuration locally:
+```bash
+codacy-analysis-cli validate-configuration --directory .
+```

--- a/.agents/skills/codacy/references/config-format.md
+++ b/.agents/skills/codacy/references/config-format.md
@@ -1,48 +1,34 @@
 # Codacy Configuration Format
 
-The repository uses `.codacy.yml` or `.codacy.yaml` for advanced configuration.
+The repository uses `.codacy/codacy.config.json` for advanced configuration.
 
 ## Basic Structure
 
-```yaml
----
-exclude_paths:
-  - "target/**"
-  - "node_modules/**"
-  - "benches/fixtures/**"
-
-languages:
-  rust:
-    enabled: true
-  shell:
-    enabled: true
-
-engines:
-  duplication:
-    enabled: true
-    exclude_paths:
-      - "tests/**"
+```json
+{
+  "tools": [
+    {
+      "name": "eslint-9",
+      "enabled": true
+    }
+  ],
+  "exclude_paths": [
+    "target/**",
+    "node_modules/**"
+  ]
+}
 ```
 
-## Tool-Specific Configuration
+## Local Initialization
 
-You can tune specific engines under the `engines` key:
-
-```yaml
-engines:
-  shellcheck:
-    exclude_paths:
-      - "scripts/legacy/**"
-  metric:
-    # Cyclomatic complexity thresholds
-    config:
-      languages:
-        - "rust"
+Generate a default configuration based on repository discovery:
+```bash
+codacy-analysis init --default
 ```
 
 ## Validation
 
-Validate your configuration locally:
+Current versions of the Analysis CLI perform implicit validation during `analyze` or `discover`. To check for configuration-related issues:
 ```bash
-codacy-analysis-cli validate-configuration --directory .
+codacy-analysis discover .
 ```

--- a/.agents/skills/codacy/references/output-format.md
+++ b/.agents/skills/codacy/references/output-format.md
@@ -1,0 +1,30 @@
+# Codacy PR Analysis Output Format
+
+When running `codacy pull-request ... --output json`, the response contains structured quality data.
+
+## Schema Highlights
+
+- `newIssues`: Findings introduced by the PR.
+- `fixedIssues`: Issues resolved by the PR.
+- `qualityGateStatus`: Overall status (`Passed`, `Warning`, `Failed`).
+
+## Issue Schema
+
+```json
+{
+  "resultDataId": 987654321,
+  "hash": "d41d8cd98f00b204e9800998ecf8427e",
+  "message": "Double quote to prevent globbing and word splitting.",
+  "file": "scripts/setup.sh",
+  "line": 12,
+  "tool": "ShellCheck",
+  "severity": "Info"
+}
+```
+
+### Identification: Hash vs. ID
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `hash` | String | Used for matching issues in the UI and between commits. |
+| `resultDataId` | Number | **MANDATORY** for CLI operations like `--ignore-issue`. |

--- a/.agents/skills/codacy/references/supported-tools.md
+++ b/.agents/skills/codacy/references/supported-tools.md
@@ -1,0 +1,21 @@
+# Supported Codacy Tools
+
+This repository primarily relies on the following tools integrated into Codacy.
+
+## Core Tools
+
+| Tool | Focus | Local Availability |
+|------|-------|-------------------|
+| **Opengrep** | Rust Security / Patterns | ✅ Yes |
+| **ShellCheck** | Shell Script Quality | ✅ Yes |
+| **markdownlint** | Documentation Consistency | ✅ Yes |
+| **Trivy** | Vulnerability / Secret Scanning | ✅ Yes |
+| **Checkov** | Infrastructure as Code (YAML) | ✅ Yes |
+
+## Rust-Specific Notes
+
+While Codacy runs **Opengrep** for Rust, the primary source for Rust linting in this repository is `cargo clippy`. Codacy findings for Rust should be cross-referenced with `scripts/validate.sh` outputs.
+
+## Local Analysis Limitations
+
+The local `codacy-analysis` CLI may fail to run certain tools if the required runtimes (e.g., Ruby for SQLint, Java for PMD) are not available in the local environment. Always check the Cloud CLI (`codacy pull-request`) for the definitive list of issues.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,8 @@ jobs:
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
     - name: Install wasm-pack
       run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+    - name: Build WASM
+      run: wasm-pack build --dev --target web -- --features wasm
     - name: Check WASM
       run: cargo check --target wasm32-unknown-unknown --features wasm
     - name: Verify WASM TS Freshness

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -385,7 +385,7 @@ Refer to the `dist-channel-selection` skill for canonical commands.
 
 **Workflow**: `learn`, `task-decomposition`, `shell-script-quality`
 
-**Automation**: `self-fix-loop`, `iterative-refinement`, `skill-creator`, `skill-evaluator`
+**Automation**: `self-fix-loop`, `iterative-refinement`, `skill-creator`, `skill-evaluator`, `codacy`
 
 **TRIZ**: `triz-analysis`, `triz-solver`
 


### PR DESCRIPTION
What: Added a new `codacy` agent skill in `.agents/skills/codacy/`.
Why: To provide a standardized workflow for AI agents to interact with Codacy static analysis tools, including PR triage, false positive suppression using numeric `resultDataId`, and local analysis verification.
Impact: Enhances the repository's automation capabilities for code quality and security maintenance, specifically tailored for the Rust and Shell environment of the `chaotic_semantic_memory` project.

---
*PR created automatically by Jules for task [17533186273393408300](https://jules.google.com/task/17533186273393408300) started by @d-o-hub*