### PR TITLE
ci: upgrade actions to node 24 and increase miri timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
     env:
       PROTOC: /usr/bin/protoc
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
     - name: Install Rust
-      uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
     - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
     - name: Run tests
       run: cargo test --all-features --locked -- --quiet
 
@@ -37,28 +37,28 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
     - name: Install Rust
-      uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
     - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
     - name: Run DuckDB tests
       run: cargo test -p chaotic_semantic_memory_duckdb --locked -- --test-threads=1 --quiet
 
   miri:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       PROTOC: /usr/bin/protoc
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
     - name: Install Rust nightly
-      uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
       with:
         toolchain: nightly
         components: miri
     - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
     - name: Run Miri tests
       run: cargo miri test -p chaotic_semantic_memory --no-default-features --features ann-hnsw --lib
       env:
@@ -94,15 +94,15 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
     - name: Install Rust
-      uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
       with:
         target: ${{ matrix.target }}
 
     - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
 
     - name: Install cross-compilation linker (Linux arm64)
       if: matrix.target == 'aarch64-unknown-linux-gnu'
@@ -120,13 +120,13 @@ jobs:
     env:
       PROTOC: /usr/bin/protoc
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
     - name: Install Protobuf Compiler
       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
     - name: Install Rust
-      uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
     - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
     - name: Build MCP feature
       run: cargo build --features mcp --locked
     - name: Test MCP feature
@@ -137,15 +137,15 @@ jobs:
     timeout-minutes: 30
     needs: test
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       with:
         fetch-depth: 0
     - name: Install Rust
-      uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
     - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
     - name: Install cargo-mutants
-      uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2
+      uses: taiki-e/install-action@25435dc8dd3baed7417e0c96d3fe89013a5b2e09 # v2.81.3
       with:
         tool: cargo-mutants
     - name: Run mutation tests
@@ -158,13 +158,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
     - name: Install Rust
-      uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
       with:
         target: wasm32-unknown-unknown
     - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
     - name: Install wasm-pack
       run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
     - name: Build WASM
@@ -180,13 +180,13 @@ jobs:
     env:
       PROTOC: /usr/bin/protoc
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
     - name: Install Rust
-      uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
       with:
         components: clippy, rustfmt
     - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
     - name: Format check
       run: cargo fmt --all -- --check
     - name: Clippy

--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -3797,3 +3797,14 @@ actions:
       Add --ci mode to mutation_test.sh with threshold parsing (default 85%),
       add mutation-test job to ci.yml and pre-release-gate.yml that fails
       if score drops below threshold. Closes #300.
+  - name: fix_ci_node_deprecations_and_miri_timeout
+    preconditions:
+      - ci_node_20_deprecations_identified: true
+    effects:
+      - ci_node_deprecations_resolved: true
+      - miri_job_timeout_increased: true
+    cost: 2
+    status: complete
+    description: |
+      Upgraded GitHub Actions in ci.yml to Node 24 native versions and increased
+      Miri timeout to 60 minutes to resolve deprecation warnings and job cancellations.

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -1068,4 +1068,4 @@ world_state:
   mutation_ci_in_diff_enabled: true        # --in-diff scoped to PR changes
   mutation_ci_fetch_depth_zero: true       # fetch-depth: 0 in checkout
   wasm_freshness_sort_stable: true         # check-wasm-freshness.sh sorts lines before diff
-  action_last_completed: pr_322_codacy_feedback_review_resolution
+  action_last_completed: fix_ci_node_deprecations_and_miri_timeout

--- a/progress/LEARNINGS.md
+++ b/progress/LEARNINGS.md
@@ -61,3 +61,8 @@
 - **CLI table name prefix**: The persistence layer uses `csm_`-prefixed table names (`csm_concepts`, `csm_associations`, `csm_schema_version`). Direct SQL access must account for this prefix.
 - **No native archive command**: The CLI has `delete` but no `archive`. Archive is handled via marker concepts with metadata `{"status":"archived","target":"<id>"}`. If archive becomes a common workflow, consider adding a native `csm archive <id>` command.
 - **Export/import roundtrip fidelity**: JSON export preserves metadata, vector data, and associations. Import into a fresh DB produces identical probe results (same similarity scores), confirming no precision loss in serialization.
+
+### CI/CD Maintenance
+- **Node 20 Deprecation**: GitHub Actions using Node 20 runtime can be resolved by upgrading to versions that natively support Node 24 (e.g., `actions/checkout@v5`, `Swatinem/rust-cache@v2.9.1`).
+- **Miri Job Reliability**: Miri tests are significantly slower than standard tests. For a suite of ~220 tests, a 30-minute timeout is often insufficient, and 60 minutes is a safer baseline for initial reliability.
+- **Action Pinning**: Use `git ls-remote --tags <url>` to find the exact SHA for a specific version tag to ensure security and reproducible CI environments.


### PR DESCRIPTION
Upgraded actions/checkout, actions-rust-lang/setup-rust-toolchain, Swatinem/rust-cache, and taiki-e/install-action to Node 24 compatible versions with pinned SHAs in .github/workflows/ci.yml. Increased the miri job timeout from 30 to 60 minutes to prevent job cancellation during the 223 tests. Updated project state and learnings accordingly.

---
*PR created automatically by Jules for task [17041061904671664782](https://jules.google.com/task/17041061904671664782) started by @d-o-hub*