### PR TITLE
fix(workflow): pin peter-evans/create-pull-request to SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
 
     - name: Create pull request with regenerated llms.txt
       if: steps.tag.outputs.release-needed == 'true'
-      uses: peter-evans/create-pull-request@v8
+      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: "chore: regenerate llms.txt for release [skip ci]"


### PR DESCRIPTION
Pin the 'peter-evans/create-pull-request' action in '.github/workflows/release.yml' to a full commit SHA (5f6978faf089d4d20b00c7766989d076bb2fc7f1) for security and supply chain integrity. Includes a comment for version v8.1.1.

---
*PR created automatically by Jules for task [6360944372453988833](https://jules.google.com/task/6360944372453988833) started by @d-o-hub*