### PR TITLE
ci: restrict miri to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
   miri:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    if: github.event_name == 'push'
     env:
       PROTOC: /usr/bin/protoc
     steps:


### PR DESCRIPTION
## Summary
The `miri` job in `.github/workflows/ci.yml` previously ran on both `push` and `pull_request` events. Miri is slow (60min timeout) and most signal comes from the post-merge main run.

## Change
Add `if: github.event_name == 'push'` to the miri job so it only runs on direct pushes to main, not on every PR.

## Effect
- Push to main → miri runs (post-merge UB check)
- Pull request to main → miri skipped
- Saves ~60min of CI per PR

## Validation
- YAML syntax validated
- Pre-commit hooks passed