### PR TITLE
refactor(memory): extract csm-memory into standalone workspace crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,6 +829,7 @@ dependencies = [
  "criterion",
  "csm-core",
  "csm-embedding",
+ "csm-memory",
  "fastembed",
  "getrandom 0.4.2",
  "glob",
@@ -1304,6 +1305,20 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "csm-memory"
+version = "0.1.0"
+dependencies = [
+ "csm-core",
+ "hnsw_rs",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "crates/csm-core",
     "crates/csm-embedding",
+    "crates/csm-memory",
     ".",
     "benchmarks",
     "crates/chaotic_semantic_memory_duckdb",
@@ -56,6 +57,7 @@ include = [
 [dependencies]
 csm-core = { path = "crates/csm-core" }
 csm-embedding = { path = "crates/csm-embedding" }
+csm-memory = { path = "crates/csm-memory" }
 tempfile = { workspace = true }
 # Serialization
 serde = { workspace = true }

--- a/crates/csm-memory/Cargo.toml
+++ b/crates/csm-memory/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "csm-memory"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+description = "Concept store and singularity engine for chaotic_semantic_memory"
+license = "MIT"
+repository = "https://github.com/d-o-hub/chaotic_semantic_memory"
+
+[dependencies]
+csm-core = { path = "../csm-core" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true }
+uuid = { workspace = true, optional = true }
+
+# ANN backends (opt-in)
+hnsw_rs = { version = "0.3.4", optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[features]
+default = []
+parallel = ["csm-core/parallel"]
+ann-hnsw = ["dep:hnsw_rs"]
+ann-lsh = []
+
+[lib]
+crate-type = ["lib"]

--- a/crates/csm-memory/src/concept_builder.rs
+++ b/crates/csm-memory/src/concept_builder.rs
@@ -1,0 +1,164 @@
+//! Concept builder for ergonomic concept construction
+
+use serde::Serialize;
+use std::collections::HashMap;
+
+use crate::singularity::Concept;
+use csm_core::error::{MemoryError, Result};
+use csm_core::hyperdim::HVec10240;
+
+/// Builder for constructing [`Concept`] instances with a fluent API.
+///
+/// # Example
+///
+/// ```
+/// use csm_memory::ConceptBuilder;
+/// use csm_core::hyperdim::HVec10240;
+///
+/// let concept = ConceptBuilder::new("example")
+///     .with_vector(HVec10240::random())
+///     .with_metadata("source", "test")
+///     .build()
+///     .unwrap();
+/// ```
+#[derive(Debug)]
+pub struct ConceptBuilder {
+    id: String,
+    vector: Option<HVec10240>,
+    metadata: HashMap<String, serde_json::Value>,
+    metadata_error: Option<MemoryError>,
+    ttl_seconds: Option<u64>,
+    canonical_concept_ids: Vec<String>,
+}
+
+impl ConceptBuilder {
+    /// Creates a new builder for a concept with the given ID.
+    #[must_use]
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            vector: None,
+            metadata: HashMap::new(),
+            metadata_error: None,
+            ttl_seconds: None,
+            canonical_concept_ids: Vec::new(),
+        }
+    }
+
+    /// Sets the canonical concept IDs for semantic bridge linking.
+    #[must_use]
+    pub fn with_canonical_concepts(mut self, ids: Vec<String>) -> Self {
+        self.canonical_concept_ids = ids;
+        self
+    }
+
+    /// Sets the TTL (time to live) in seconds for this concept.
+    ///
+    /// The concept will expire after `ttl_seconds` from creation.
+    /// If not set, the concept never expires.
+    #[must_use]
+    pub const fn with_ttl(mut self, ttl_seconds: u64) -> Self {
+        self.ttl_seconds = Some(ttl_seconds);
+        self
+    }
+
+    /// Sets the vector for this concept.
+    #[must_use]
+    pub const fn with_vector(mut self, vector: HVec10240) -> Self {
+        self.vector = Some(vector);
+        self
+    }
+
+    /// Adds metadata to this concept.
+    ///
+    /// If serialization of the value fails, the error is captured and
+    /// will be returned when `build()` is called.
+    #[must_use]
+    pub fn with_metadata(mut self, key: impl Into<String>, value: impl Serialize) -> Self {
+        if self.metadata_error.is_none() {
+            match serde_json::to_value(value) {
+                Ok(value) => {
+                    self.metadata.insert(key.into(), value);
+                }
+                Err(error) => {
+                    self.metadata_error = Some(MemoryError::Serialization(error));
+                }
+            }
+        }
+        self
+    }
+
+    /// Builds the [`Concept`] instance.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if metadata serialization failed during construction.
+    pub fn build(self) -> Result<Concept> {
+        if let Some(error) = self.metadata_error {
+            return Err(error);
+        }
+
+        let now = crate::singularity::unix_now_secs();
+        let expires_at = self.ttl_seconds.map(|ttl| now + ttl);
+
+        Ok(Concept {
+            id: self.id,
+            vector: self.vector.unwrap_or_else(HVec10240::random),
+            metadata: self.metadata,
+            created_at: now,
+            modified_at: now,
+            expires_at,
+            canonical_concept_ids: self.canonical_concept_ids,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn concept_builder_creates_concept_with_metadata() {
+        let concept = ConceptBuilder::new("test-id")
+            .with_vector(HVec10240::random())
+            .with_metadata("key1", "value1")
+            .with_metadata("key2", 42i32)
+            .build()
+            .unwrap();
+
+        assert_eq!(concept.id, "test-id");
+        assert_eq!(
+            concept.metadata.get("key1").unwrap().as_str().unwrap(),
+            "value1"
+        );
+        assert_eq!(concept.metadata.get("key2").unwrap().as_i64().unwrap(), 42);
+    }
+
+    #[test]
+    fn concept_builder_uses_random_vector_by_default() {
+        let concept = ConceptBuilder::new("test").build().unwrap();
+        // Just verify it builds successfully without explicit vector
+        assert_eq!(concept.id, "test");
+    }
+
+    #[test]
+    fn concept_builder_with_ttl_sets_expiration() {
+        let now = crate::singularity::unix_now_secs();
+        let concept = ConceptBuilder::new("ttl-test")
+            .with_ttl(3600)
+            .build()
+            .unwrap();
+
+        assert!(concept.expires_at.is_some());
+        let expires_at = concept.expires_at.unwrap();
+        // Expiration should be approximately now + 3600
+        assert!(expires_at >= now + 3600 - 1);
+        assert!(expires_at <= now + 3600 + 1);
+    }
+
+    #[test]
+    fn concept_builder_without_ttl_has_no_expiration() {
+        let concept = ConceptBuilder::new("no-ttl").build().unwrap();
+        assert!(concept.expires_at.is_none());
+    }
+}

--- a/crates/csm-memory/src/graph_traversal.rs
+++ b/crates/csm-memory/src/graph_traversal.rs
@@ -1,0 +1,516 @@
+//! Graph traversal operations on the association graph.
+//!
+//! Provides BFS, shortest path, and neighbor queries on the concept association graph.
+//!
+//! # Shortest Path
+//!
+//! Two variants are provided:
+//! - [`Singularity::shortest_path`]: Weighted Dijkstra using `-ln(strength)` as edge cost.
+//!   Prefers paths through stronger associations. Returns the minimum-cost path.
+//! - [`Singularity::shortest_path_hops`]: Unweighted BFS. Returns the fewest-hop path
+//!   regardless of edge strength. Use when hop count matters more than association strength.
+
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
+
+use crate::singularity::Singularity;
+use csm_core::error::{MemoryError, Result};
+
+/// Maximum traversal depth to prevent excessive resource usage.
+const MAX_TRAVERSAL_DEPTH: usize = 32;
+/// Maximum traversal results to prevent memory exhaustion.
+const MAX_TRAVERSAL_RESULTS: usize = 10_000;
+
+/// Configuration for graph traversal operations.
+#[derive(Debug, Clone)]
+pub struct TraversalConfig {
+    /// Maximum number of hops to traverse.
+    pub max_depth: usize,
+    /// Minimum edge strength to follow.
+    pub min_strength: f32,
+    /// Maximum number of nodes to visit.
+    pub max_results: usize,
+}
+
+impl Default for TraversalConfig {
+    fn default() -> Self {
+        Self {
+            max_depth: 3,
+            min_strength: 0.0,
+            max_results: 100,
+        }
+    }
+}
+
+impl TraversalConfig {
+    /// Validate traversal config parameters.
+    pub fn validate(&self) -> Result<()> {
+        if self.max_depth > MAX_TRAVERSAL_DEPTH {
+            return Err(MemoryError::InvalidInput {
+                field: "max_depth".to_string(),
+                reason: format!(
+                    "traversal depth exceeds {} (got {})",
+                    MAX_TRAVERSAL_DEPTH, self.max_depth
+                ),
+            });
+        }
+        if self.max_results > MAX_TRAVERSAL_RESULTS {
+            return Err(MemoryError::InvalidInput {
+                field: "max_results".to_string(),
+                reason: format!(
+                    "traversal results exceed {} (got {})",
+                    MAX_TRAVERSAL_RESULTS, self.max_results
+                ),
+            });
+        }
+        Ok(())
+    }
+}
+
+impl Singularity {
+    /// Get direct neighbors of a concept with edge strengths.
+    ///
+    /// Returns outbound associations with strength >= `min_strength`.
+    pub fn neighbors(&self, ns: &str, id: &str, min_strength: f32) -> Vec<(String, f32)> {
+        self.get_associations(ns, id)
+            .into_iter()
+            .filter(|(_, strength)| *strength >= min_strength)
+            .collect()
+    }
+
+    /// Get incoming associations for a concept.
+    ///
+    /// Returns concepts that have associations pointing to this concept.
+    /// Breadth-first traversal from a starting concept.
+    ///
+    /// Returns nodes reachable within `config.max_depth` hops, along with their depths.
+    /// Nodes are returned in BFS order.
+    pub fn bfs(
+        &self,
+        ns: &str,
+        start: &str,
+        config: &TraversalConfig,
+    ) -> Result<Vec<(String, u32)>> {
+        config.validate()?;
+        let ns_state = self
+            .get_namespace(ns)
+            .ok_or_else(|| MemoryError::NotFound {
+                entity: "Namespace".to_string(),
+                id: ns.to_string(),
+            })?;
+        if !ns_state.concepts.contains_key(start) {
+            return Err(MemoryError::NotFound {
+                entity: "Concept".to_string(),
+                id: start.to_string(),
+            });
+        }
+
+        let mut visited: HashSet<String> = HashSet::new();
+        let mut results: Vec<(String, u32)> = Vec::new();
+        let mut queue: VecDeque<(String, u32)> = VecDeque::new();
+
+        visited.insert(start.to_string());
+        queue.push_back((start.to_string(), 0));
+
+        while let Some((current, depth)) = queue.pop_front() {
+            if results.len() >= config.max_results {
+                break;
+            }
+
+            results.push((current.clone(), depth));
+
+            if depth as usize >= config.max_depth {
+                continue;
+            }
+
+            let neighbors = self.neighbors(ns, &current, config.min_strength);
+            for (neighbor, _) in neighbors {
+                if visited.insert(neighbor.clone()) {
+                    queue.push_back((neighbor, depth + 1));
+                }
+            }
+        }
+
+        Ok(results)
+    }
+
+    /// Find the minimum-cost path between two concepts using weighted Dijkstra.
+    ///
+    /// Edge cost is `-ln(strength)`, so stronger associations have lower cost.
+    /// A strength of `1.0` has cost `0.0`; a strength of `0.1` has cost `~2.3`.
+    /// Strength values ≤ 0 are treated as cost `f32::MAX` (effectively unreachable).
+    ///
+    /// Returns `None` if no path exists within `config.max_depth` hops.
+    /// Use [`Self::shortest_path_hops`] for unweighted (fewest-hop) traversal.
+    pub fn shortest_path(
+        &self,
+        ns: &str,
+        from: &str,
+        to: &str,
+        config: &TraversalConfig,
+    ) -> Result<Option<Vec<String>>> {
+        config.validate()?;
+        let ns_state = self
+            .get_namespace(ns)
+            .ok_or_else(|| MemoryError::NotFound {
+                entity: "Namespace".to_string(),
+                id: ns.to_string(),
+            })?;
+        if !ns_state.concepts.contains_key(from) {
+            return Err(MemoryError::NotFound {
+                entity: "Concept".to_string(),
+                id: from.to_string(),
+            });
+        }
+        if !ns_state.concepts.contains_key(to) {
+            return Err(MemoryError::NotFound {
+                entity: "Concept".to_string(),
+                id: to.to_string(),
+            });
+        }
+
+        if from == to {
+            return Ok(Some(vec![from.to_string()]));
+        }
+
+        // Dijkstra: min-heap of (cost_bits, depth, node_id)
+        // We store cost as ordered bits via f32::to_bits for BinaryHeap<Reverse<...>>.
+        let mut dist: HashMap<String, f32> = HashMap::new();
+        let mut parent: HashMap<String, String> = HashMap::new();
+        // BinaryHeap is a max-heap; Reverse makes it a min-heap.
+        let mut heap: BinaryHeap<Reverse<(u32, u32, String)>> = BinaryHeap::new();
+
+        dist.insert(from.to_string(), 0.0);
+        heap.push(Reverse((0u32, 0u32, from.to_string())));
+
+        while let Some(Reverse((cost_bits, depth, current))) = heap.pop() {
+            if current == to {
+                // Reconstruct path
+                let mut path = vec![to.to_string()];
+                let mut node = to;
+                while let Some(p) = parent.get(node) {
+                    path.push(p.clone());
+                    node = p;
+                    if node == from {
+                        break;
+                    }
+                }
+                path.reverse();
+                return Ok(Some(path));
+            }
+
+            let current_cost = f32::from_bits(cost_bits);
+            if let Some(&best) = dist.get(&current) {
+                if current_cost > best {
+                    continue; // Stale entry
+                }
+            }
+
+            if depth as usize >= config.max_depth {
+                continue;
+            }
+
+            let neighbors = self.neighbors(ns, &current, config.min_strength);
+            for (neighbor, strength) in neighbors {
+                // Cost: -ln(strength), guarding against strength <= 0
+                let edge_cost = if strength > 0.0 {
+                    -strength.ln()
+                } else {
+                    f32::MAX / 2.0
+                };
+                let new_cost = current_cost + edge_cost;
+                let best = dist.get(&neighbor).copied().unwrap_or(f32::MAX);
+                if new_cost < best {
+                    dist.insert(neighbor.clone(), new_cost);
+                    parent.insert(neighbor.clone(), current.clone());
+                    heap.push(Reverse((new_cost.to_bits(), depth + 1, neighbor)));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Find the fewest-hop path between two concepts using unweighted BFS.
+    ///
+    /// Returns the path with the minimum number of hops, ignoring edge strengths.
+    /// Use [`Self::shortest_path`] for strength-weighted (Dijkstra) traversal.
+    ///
+    /// Returns `None` if no path exists within `config.max_depth` hops.
+    pub fn shortest_path_hops(
+        &self,
+        ns: &str,
+        from: &str,
+        to: &str,
+        config: &TraversalConfig,
+    ) -> Result<Option<Vec<String>>> {
+        config.validate()?;
+        let ns_state = self
+            .get_namespace(ns)
+            .ok_or_else(|| MemoryError::NotFound {
+                entity: "Namespace".to_string(),
+                id: ns.to_string(),
+            })?;
+        if !ns_state.concepts.contains_key(from) {
+            return Err(MemoryError::NotFound {
+                entity: "Concept".to_string(),
+                id: from.to_string(),
+            });
+        }
+        if !ns_state.concepts.contains_key(to) {
+            return Err(MemoryError::NotFound {
+                entity: "Concept".to_string(),
+                id: to.to_string(),
+            });
+        }
+
+        if from == to {
+            return Ok(Some(vec![from.to_string()]));
+        }
+
+        let mut visited: HashSet<String> = HashSet::new();
+        let mut parent: HashMap<String, String> = HashMap::new();
+        let mut queue: VecDeque<(String, u32)> = VecDeque::new();
+
+        visited.insert(from.to_string());
+        queue.push_back((from.to_string(), 0));
+
+        while let Some((current, depth)) = queue.pop_front() {
+            if depth as usize >= config.max_depth {
+                continue;
+            }
+
+            let neighbors = self.neighbors(ns, &current, config.min_strength);
+            for (neighbor, _) in neighbors {
+                if visited.insert(neighbor.clone()) {
+                    parent.insert(neighbor.clone(), current.clone());
+                    if neighbor == to {
+                        // Reconstruct path
+                        let mut path = vec![to.to_string()];
+                        let mut node = to;
+                        while let Some(p) = parent.get(node) {
+                            path.push(p.clone());
+                            node = p;
+                            if node == from {
+                                break;
+                            }
+                        }
+                        path.reverse();
+                        return Ok(Some(path));
+                    }
+                    queue.push_back((neighbor, depth + 1));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::singularity::{Concept, ConceptBuilder, Singularity, SingularityConfig};
+    use csm_core::hyperdim::HVec10240;
+
+    fn make_concept(id: &str) -> Concept {
+        ConceptBuilder::new(id)
+            .with_vector(HVec10240::random())
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn test_neighbors() {
+        let mut sing = Singularity::new(SingularityConfig::default());
+        sing.inject("_default", make_concept("a")).unwrap();
+        sing.inject("_default", make_concept("b")).unwrap();
+        sing.inject("_default", make_concept("c")).unwrap();
+        sing.associate("_default", "a", "b", 0.8).unwrap();
+        sing.associate("_default", "a", "c", 0.3).unwrap();
+
+        let neighbors = sing.neighbors("_default", "a", 0.5);
+        assert_eq!(neighbors.len(), 1);
+        assert_eq!(neighbors[0].0, "b");
+    }
+
+    #[test]
+    fn test_incoming_associations() {
+        let mut sing = Singularity::new(SingularityConfig::default());
+        sing.inject("_default", make_concept("a")).unwrap();
+        sing.inject("_default", make_concept("b")).unwrap();
+        sing.inject("_default", make_concept("c")).unwrap();
+        sing.associate("_default", "a", "c", 0.8).unwrap();
+        sing.associate("_default", "b", "c", 0.5).unwrap();
+
+        let incoming = sing.incoming_associations("_default", "c");
+        assert_eq!(incoming.len(), 2);
+        // Sorted by strength descending
+        assert_eq!(incoming[0].0, "a");
+        assert_eq!(incoming[1].0, "b");
+    }
+
+    #[test]
+    fn test_bfs_simple() {
+        let mut sing = Singularity::new(SingularityConfig::default());
+        sing.inject("_default", make_concept("a")).unwrap();
+        sing.inject("_default", make_concept("b")).unwrap();
+        sing.inject("_default", make_concept("c")).unwrap();
+        sing.associate("_default", "a", "b", 0.5).unwrap();
+        sing.associate("_default", "b", "c", 0.5).unwrap();
+
+        let config = TraversalConfig::default();
+        let results = sing.bfs("_default", "a", &config).unwrap();
+
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0], ("a".to_string(), 0));
+        assert_eq!(results[1], ("b".to_string(), 1));
+        assert_eq!(results[2], ("c".to_string(), 2));
+    }
+
+    #[test]
+    fn test_bfs_max_depth() {
+        let mut sing = Singularity::new(SingularityConfig::default());
+        sing.inject("_default", make_concept("a")).unwrap();
+        sing.inject("_default", make_concept("b")).unwrap();
+        sing.inject("_default", make_concept("c")).unwrap();
+        sing.associate("_default", "a", "b", 0.5).unwrap();
+        sing.associate("_default", "b", "c", 0.5).unwrap();
+
+        let config = TraversalConfig {
+            max_depth: 1,
+            ..Default::default()
+        };
+        let results = sing.bfs("_default", "a", &config).unwrap();
+
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn test_bfs_missing_concept() {
+        let sing = Singularity::new(SingularityConfig::default());
+        let config = TraversalConfig::default();
+        let result = sing.bfs("_default", "nonexistent", &config);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_shortest_path_direct() {
+        let mut sing = Singularity::new(SingularityConfig::default());
+        sing.inject("_default", make_concept("a")).unwrap();
+        sing.inject("_default", make_concept("b")).unwrap();
+        sing.associate("_default", "a", "b", 0.9).unwrap();
+
+        let config = TraversalConfig::default();
+        let path = sing.shortest_path("_default", "a", "b", &config).unwrap();
+        assert_eq!(path, Some(vec!["a".to_string(), "b".to_string()]));
+    }
+
+    #[test]
+    fn test_shortest_path_indirect() {
+        let mut sing = Singularity::new(SingularityConfig::default());
+        sing.inject("_default", make_concept("a")).unwrap();
+        sing.inject("_default", make_concept("b")).unwrap();
+        sing.inject("_default", make_concept("c")).unwrap();
+        sing.associate("_default", "a", "b", 0.9).unwrap();
+        sing.associate("_default", "b", "c", 0.9).unwrap();
+
+        let config = TraversalConfig::default();
+        let path = sing.shortest_path("_default", "a", "c", &config).unwrap();
+        assert_eq!(
+            path,
+            Some(vec!["a".to_string(), "b".to_string(), "c".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_shortest_path_no_path() {
+        let mut sing = Singularity::new(SingularityConfig::default());
+        sing.inject("_default", make_concept("a")).unwrap();
+        sing.inject("_default", make_concept("b")).unwrap();
+        // No association
+
+        let config = TraversalConfig::default();
+        let path = sing.shortest_path("_default", "a", "b", &config).unwrap();
+        assert!(path.is_none());
+    }
+
+    #[test]
+    fn test_shortest_path_same_node() {
+        let mut sing = Singularity::new(SingularityConfig::default());
+        sing.inject("_default", make_concept("a")).unwrap();
+
+        let config = TraversalConfig::default();
+        let path = sing.shortest_path("_default", "a", "a", &config).unwrap();
+        assert_eq!(path, Some(vec!["a".to_string()]));
+    }
+
+    /// Dijkstra prefers the high-strength path (lower cost = -ln(strength)).
+    #[test]
+    fn test_shortest_path_dijkstra_prefers_strong_edge() {
+        let mut sing = Singularity::new(SingularityConfig::default());
+        // a --0.9--> b --0.9--> d  (strong path, 2 hops)
+        // a --0.1--> c --0.1--> d  (weak path, 2 hops)
+        for id in ["a", "b", "c", "d"] {
+            sing.inject("_default", make_concept(id)).unwrap();
+        }
+        sing.associate("_default", "a", "b", 0.9).unwrap();
+        sing.associate("_default", "b", "d", 0.9).unwrap();
+        sing.associate("_default", "a", "c", 0.1).unwrap();
+        sing.associate("_default", "c", "d", 0.1).unwrap();
+
+        let config = TraversalConfig::default();
+        let path = sing
+            .shortest_path("_default", "a", "d", &config)
+            .unwrap()
+            .unwrap();
+        // Strong path a→b→d has lower cost than weak path a→c→d
+        assert_eq!(path, vec!["a", "b", "d"]);
+    }
+
+    #[test]
+    fn test_shortest_path_hops_direct() {
+        let mut sing = Singularity::new(SingularityConfig::default());
+        sing.inject("_default", make_concept("a")).unwrap();
+        sing.inject("_default", make_concept("b")).unwrap();
+        sing.associate("_default", "a", "b", 0.5).unwrap();
+
+        let config = TraversalConfig::default();
+        let path = sing
+            .shortest_path_hops("_default", "a", "b", &config)
+            .unwrap();
+        assert_eq!(path, Some(vec!["a".to_string(), "b".to_string()]));
+    }
+
+    #[test]
+    fn test_shortest_path_hops_indirect() {
+        let mut sing = Singularity::new(SingularityConfig::default());
+        sing.inject("_default", make_concept("a")).unwrap();
+        sing.inject("_default", make_concept("b")).unwrap();
+        sing.inject("_default", make_concept("c")).unwrap();
+        sing.associate("_default", "a", "b", 0.5).unwrap();
+        sing.associate("_default", "b", "c", 0.5).unwrap();
+
+        let config = TraversalConfig::default();
+        let path = sing
+            .shortest_path_hops("_default", "a", "c", &config)
+            .unwrap();
+        assert_eq!(
+            path,
+            Some(vec!["a".to_string(), "b".to_string(), "c".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_shortest_path_hops_no_path() {
+        let mut sing = Singularity::new(SingularityConfig::default());
+        sing.inject("_default", make_concept("a")).unwrap();
+        sing.inject("_default", make_concept("b")).unwrap();
+
+        let config = TraversalConfig::default();
+        let path = sing
+            .shortest_path_hops("_default", "a", "b", &config)
+            .unwrap();
+        assert!(path.is_none());
+    }
+}

--- a/crates/csm-memory/src/index/brute_force.rs
+++ b/crates/csm-memory/src/index/brute_force.rs
@@ -1,0 +1,187 @@
+#![allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+//! Exact search via linear scan.
+
+// Casts are intentional for similarity math
+
+use std::collections::HashMap;
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "parallel"))]
+use rayon::prelude::*;
+
+use crate::index::{AnnIndex, IndexStats};
+use crate::singularity::Concept;
+use csm_core::error::Result;
+use csm_core::hyperdim::HVec10240;
+
+/// Exact search via linear scan.
+#[derive(Debug, Default)]
+pub struct BruteForce {
+    indices: Vec<String>,
+    vectors: Vec<HVec10240>,
+    id_to_index: HashMap<String, usize>,
+}
+
+impl BruteForce {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl AnnIndex for BruteForce {
+    fn insert(&mut self, id: String, vec: &HVec10240) -> Result<()> {
+        if let Some(&idx) = self.id_to_index.get(&id) {
+            self.vectors[idx] = *vec;
+        } else {
+            let idx = self.indices.len();
+            self.id_to_index.insert(id.clone(), idx);
+            self.indices.push(id);
+            self.vectors.push(*vec);
+        }
+        Ok(())
+    }
+
+    fn delete(&mut self, id: &str) -> Result<()> {
+        if let Some(idx) = self.id_to_index.remove(id) {
+            self.indices.swap_remove(idx);
+            let _ = self.vectors.swap_remove(idx);
+            if idx < self.indices.len() {
+                let swapped_id = &self.indices[idx];
+                self.id_to_index.insert(swapped_id.clone(), idx);
+            }
+        }
+        Ok(())
+    }
+
+    fn search(&self, query: &HVec10240, top_k: usize) -> Result<Vec<(String, f32)>> {
+        if top_k == 0 || self.indices.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Algorithmic Optimization: Parallelize O(N) similarity scan via Rayon.
+        // Hamming distance calculations for 10240-bit vectors are CPU-bound and highly
+        // parallelizable, allowing for significant throughput gains on multi-core systems.
+        #[cfg(all(not(target_arch = "wasm32"), feature = "parallel"))]
+        let mut scores: Vec<(usize, u32)> = self
+            .vectors
+            .par_iter()
+            .enumerate()
+            .with_min_len(128)
+            .map(|(idx, v)| (idx, query.hamming_distance(v)))
+            .collect();
+
+        #[cfg(any(target_arch = "wasm32", not(feature = "parallel")))]
+        let mut scores: Vec<(usize, u32)> = self
+            .vectors
+            .iter()
+            .enumerate()
+            .map(|(idx, v)| (idx, query.hamming_distance(v)))
+            .collect();
+
+        if scores.len() <= top_k {
+            scores.sort_unstable_by_key(|&(_, dist)| dist);
+        } else {
+            scores.select_nth_unstable_by(top_k - 1, |a, b| a.1.cmp(&b.1));
+            scores.truncate(top_k);
+            scores.sort_unstable_by_key(|&(_, dist)| dist);
+        }
+
+        let results: Vec<(String, f32)> = scores
+            .into_iter()
+            .map(|(idx, dist)| {
+                let similarity = 1.0 - (dist as f32 / 5120.0);
+                (self.indices[idx].clone(), similarity)
+            })
+            .collect();
+
+        Ok(results)
+    }
+
+    fn search_filtered(
+        &self,
+        query: &HVec10240,
+        top_k: usize,
+        filter: &crate::metadata_filter::MetadataFilter,
+        concepts: &HashMap<String, Concept>,
+    ) -> Result<Vec<(String, f32)>> {
+        if top_k == 0 || self.indices.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Algorithmic Optimization: Parallelize filtered similarity scan via Rayon.
+        // This distributes both the metadata predicate matching and the Hamming distance
+        // calculations across available CPU cores.
+        #[cfg(all(not(target_arch = "wasm32"), feature = "parallel"))]
+        let mut scores: Vec<(usize, u32)> = self
+            .indices
+            .par_iter()
+            .enumerate()
+            .filter(|(_, id)| {
+                concepts
+                    .get(*id)
+                    .is_some_and(|c| filter.matches(&c.metadata))
+            })
+            .map(|(idx, _)| (idx, query.hamming_distance(&self.vectors[idx])))
+            .collect();
+
+        #[cfg(any(target_arch = "wasm32", not(feature = "parallel")))]
+        let mut scores: Vec<(usize, u32)> = self
+            .indices
+            .iter()
+            .enumerate()
+            .filter(|(_, id)| {
+                concepts
+                    .get(*id)
+                    .is_some_and(|c| filter.matches(&c.metadata))
+            })
+            .map(|(idx, _)| (idx, query.hamming_distance(&self.vectors[idx])))
+            .collect();
+
+        if scores.len() <= top_k {
+            scores.sort_unstable_by_key(|&(_, dist)| dist);
+        } else {
+            scores.select_nth_unstable_by(top_k - 1, |a, b| a.1.cmp(&b.1));
+            scores.truncate(top_k);
+            scores.sort_unstable_by_key(|&(_, dist)| dist);
+        }
+
+        let results: Vec<(String, f32)> = scores
+            .into_iter()
+            .map(|(idx, dist)| {
+                let similarity = 1.0 - (dist as f32 / 5120.0);
+                (self.indices[idx].clone(), similarity)
+            })
+            .collect();
+
+        Ok(results)
+    }
+
+    fn rebuild(&mut self, concepts: &HashMap<String, Concept>) -> Result<()> {
+        self.indices.clear();
+        self.vectors.clear();
+        self.id_to_index.clear();
+
+        for (id, concept) in concepts {
+            self.insert(id.clone(), &concept.vector)?;
+        }
+        Ok(())
+    }
+
+    fn stats(&self) -> IndexStats {
+        IndexStats {
+            backend: "BruteForce".to_string(),
+            count: self.indices.len(),
+            memory_usage_bytes: self.indices.len()
+                * (std::mem::size_of::<String>() + std::mem::size_of::<HVec10240>() + 16),
+        }
+    }
+
+    fn serialize(&self) -> Result<Vec<u8>> {
+        // BruteForce doesn't need to serialize its state independently as it can be rebuilt from concepts.
+        // However, for trait consistency, we return an empty vec or a simple marker.
+        Ok(Vec::new())
+    }
+
+    fn deserialize(&mut self, _data: &[u8]) -> Result<()> {
+        Ok(())
+    }
+}

--- a/crates/csm-memory/src/index/hnsw.rs
+++ b/crates/csm-memory/src/index/hnsw.rs
@@ -1,0 +1,354 @@
+#![allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+//! HNSW ANN index backend (ADR-0068).
+
+// Casts are intentional for similarity math
+
+#[cfg(feature = "ann-hnsw")]
+use crate::index::{AnnIndex, IndexStats};
+#[cfg(feature = "ann-hnsw")]
+use crate::singularity::Concept;
+#[cfg(feature = "ann-hnsw")]
+use csm_core::error::{MemoryError, Result};
+#[cfg(feature = "ann-hnsw")]
+use csm_core::hyperdim::HVec10240;
+#[cfg(feature = "ann-hnsw")]
+use hnsw_rs::prelude::*;
+#[cfg(feature = "ann-hnsw")]
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "ann-hnsw")]
+use std::collections::HashMap;
+
+#[cfg(feature = "ann-hnsw")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct HnswData {
+    m: usize,
+    ef_construction: usize,
+    ef_search: usize,
+}
+
+#[cfg(feature = "ann-hnsw")]
+#[derive(Clone)]
+struct HammingDist;
+
+#[cfg(feature = "ann-hnsw")]
+impl Distance<HVec10240> for HammingDist {
+    fn eval(&self, va: &[HVec10240], vb: &[HVec10240]) -> f32 {
+        va[0].hamming_distance(&vb[0]) as f32
+    }
+}
+
+#[cfg(feature = "ann-hnsw")]
+pub struct HnswIndex {
+    _owner: Option<Box<dyn std::any::Any + Send + Sync>>,
+    hnsw: Hnsw<'static, HVec10240, HammingDist>,
+    id_to_idx: HashMap<String, usize>,
+    idx_to_id: HashMap<usize, String>,
+    config: HnswData,
+    deleted_count: usize,
+}
+
+#[cfg(feature = "ann-hnsw")]
+impl HnswIndex {
+    pub fn new(m: usize, ef_construction: usize, ef_search: usize) -> Result<Self> {
+        // #7: Validate m (max_nb_connection). hnsw_rs aborts if > 256.
+        if m == 0 || m > 256 {
+            return Err(MemoryError::InvalidInput {
+                field: "m".to_string(),
+                reason: "m must be between 1 and 256".to_string(),
+            });
+        }
+
+        // ADR-0068: Default to 1M elements to support scale goal
+        let hnsw = Hnsw::new(m, 1_000_000, 16, ef_construction, HammingDist);
+        Ok(Self {
+            hnsw,
+            id_to_idx: HashMap::new(),
+            idx_to_id: HashMap::new(),
+            _owner: None,
+            config: HnswData {
+                m,
+                ef_construction,
+                ef_search,
+            },
+            deleted_count: 0,
+        })
+    }
+}
+
+#[cfg(feature = "ann-hnsw")]
+impl std::fmt::Debug for HnswIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HnswIndex")
+            .field("config", &self.config)
+            .field("count", &self.id_to_idx.len())
+            .finish()
+    }
+}
+
+#[cfg(feature = "ann-hnsw")]
+#[derive(Serialize, Deserialize)]
+struct HnswPersistenceWrapper {
+    id_to_idx: HashMap<String, usize>,
+    idx_to_id: HashMap<usize, String>,
+    m: usize,
+    ef_construction: usize,
+    ef_search: usize,
+    deleted_count: usize,
+    data: Vec<u8>,
+    graph: Vec<u8>,
+}
+
+#[cfg(feature = "ann-hnsw")]
+impl AnnIndex for HnswIndex {
+    fn insert(&mut self, id: String, vec: &HVec10240) -> Result<()> {
+        // #6: Handle updates to existing IDs.
+        if self.id_to_idx.contains_key(&id) {
+            self.delete(&id)?;
+        }
+
+        let idx = self.hnsw.get_nb_point();
+        self.hnsw.insert((std::slice::from_ref(vec), idx));
+        self.id_to_idx.insert(id.clone(), idx);
+        self.idx_to_id.insert(idx, id);
+        Ok(())
+    }
+
+    fn delete(&mut self, id: &str) -> Result<()> {
+        // #5: HnswIndex::delete only removes mappings.
+        if let Some(idx) = self.id_to_idx.remove(id) {
+            self.idx_to_id.remove(&idx);
+            self.deleted_count += 1;
+        }
+        Ok(())
+    }
+
+    fn search(&self, query: &HVec10240, top_k: usize) -> Result<Vec<(String, f32)>> {
+        // #5: Increase search budget to account for deleted nodes.
+        let expanded_k = top_k + self.deleted_count.min(top_k * 10);
+        let results = self.hnsw.search(
+            std::slice::from_ref(query),
+            expanded_k,
+            self.config.ef_search,
+        );
+
+        let mut final_results = Vec::with_capacity(results.len());
+        for neighbor in results {
+            if let Some(id) = self.idx_to_id.get(&neighbor.d_id) {
+                let similarity = 1.0 - (neighbor.distance / 5120.0);
+                final_results.push((id.clone(), similarity));
+                if final_results.len() >= top_k {
+                    break;
+                }
+            }
+        }
+        Ok(final_results)
+    }
+
+    fn search_filtered(
+        &self,
+        query: &HVec10240,
+        top_k: usize,
+        filter: &crate::metadata_filter::MetadataFilter,
+        concepts: &HashMap<String, Concept>,
+    ) -> Result<Vec<(String, f32)>> {
+        let expanded_k = top_k * 5 + self.deleted_count.min(top_k * 10);
+        let results = self.hnsw.search(
+            std::slice::from_ref(query),
+            expanded_k,
+            self.config.ef_search,
+        );
+
+        let mut filtered_results = Vec::new();
+        for neighbor in results {
+            if let Some(id) = self.idx_to_id.get(&neighbor.d_id) {
+                if let Some(concept) = concepts.get(id) {
+                    if filter.matches(&concept.metadata) {
+                        let similarity = 1.0 - (neighbor.distance / 5120.0);
+                        filtered_results.push((id.clone(), similarity));
+                        if filtered_results.len() >= top_k {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        if filtered_results.len() < top_k {
+            let mut all_filtered: Vec<(String, f32)> = concepts
+                .iter()
+                .filter(|(_, c)| filter.matches(&c.metadata))
+                .map(|(id, c)| {
+                    (
+                        id.clone(),
+                        1.0 - (query.hamming_distance(&c.vector) as f32 / 5120.0),
+                    )
+                })
+                .collect();
+
+            all_filtered.sort_unstable_by(|a, b| {
+                b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal)
+            });
+            all_filtered.truncate(top_k);
+            return Ok(all_filtered);
+        }
+
+        Ok(filtered_results)
+    }
+
+    fn rebuild(&mut self, concepts: &HashMap<String, Concept>) -> Result<()> {
+        self.hnsw = Hnsw::new(
+            self.config.m,
+            concepts.len().max(100),
+            16,
+            self.config.ef_construction,
+            HammingDist,
+        );
+        self.id_to_idx.clear();
+        self.idx_to_id.clear();
+        self._owner = None;
+        self.deleted_count = 0;
+
+        for (id, concept) in concepts {
+            self.insert(id.clone(), &concept.vector)?;
+        }
+        Ok(())
+    }
+
+    fn stats(&self) -> IndexStats {
+        IndexStats {
+            backend: "HNSW".to_string(),
+            count: self.id_to_idx.len(),
+            memory_usage_bytes: self.id_to_idx.len()
+                * (std::mem::size_of::<String>() + std::mem::size_of::<HVec10240>() + 32),
+        }
+    }
+
+    fn serialize(&self) -> Result<Vec<u8>> {
+        use std::fs;
+
+        let temp_dir = std::env::temp_dir().join(format!("csm_hnsw_{}", rand::random::<u64>()));
+        fs::create_dir_all(&temp_dir).map_err(MemoryError::Io)?;
+
+        self.hnsw
+            .file_dump(&temp_dir, "index")
+            .map_err(|e| MemoryError::database(format!("HNSW dump failed: {}", e)))?;
+
+        let data_path = temp_dir.join("index.hnsw.data");
+        let graph_path = temp_dir.join("index.hnsw.graph");
+
+        let data_bytes = fs::read(data_path).map_err(MemoryError::Io)?;
+        let graph_bytes = fs::read(graph_path).map_err(MemoryError::Io)?;
+
+        let wrapper = HnswPersistenceWrapper {
+            id_to_idx: self.id_to_idx.clone(),
+            idx_to_id: self.idx_to_id.clone(),
+            m: self.config.m,
+            ef_construction: self.config.ef_construction,
+            ef_search: self.config.ef_search,
+            deleted_count: self.deleted_count,
+            data: data_bytes,
+            graph: graph_bytes,
+        };
+
+        let payload = bincode::serialize(&wrapper)
+            .map_err(|e| MemoryError::database(format!("Bincode fail: {}", e)))?;
+
+        let _ = fs::remove_dir_all(temp_dir);
+        Ok(payload)
+    }
+
+    fn deserialize(&mut self, data: &[u8]) -> Result<()> {
+        use std::fs;
+
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        let wrapper: HnswPersistenceWrapper = bincode::deserialize(data)
+            .map_err(|e| MemoryError::database(format!("Bincode deserialize fail: {}", e)))?;
+
+        let temp_dir = tempfile::tempdir().map_err(MemoryError::Io)?;
+        let path = temp_dir.path();
+
+        fs::write(path.join("index.hnsw.data"), &wrapper.data).map_err(MemoryError::Io)?;
+        fs::write(path.join("index.hnsw.graph"), &wrapper.graph).map_err(MemoryError::Io)?;
+
+        let loader = HnswIo::new(path, "index");
+        let hnsw = loader
+            .load_hnsw_with_dist::<HVec10240, HammingDist>(HammingDist)
+            .map_err(|e| MemoryError::database(format!("HNSW load failed: {}", e)))?;
+
+        // SAFETY: The Hnsw instance returned by load_hnsw_with_dist may contain references
+        // to the loader or the memory-mapped files. We transmute it to 'static to store it
+        // in our struct, but we must ensure the source of those references (the loader and
+        // the temp_dir) stays alive for the duration of the index's life. We do this by
+        // storing them in the `_owner` field below.
+        let static_hnsw: Hnsw<'static, HVec10240, HammingDist> =
+            unsafe { std::mem::transmute(hnsw) };
+
+        self.hnsw = static_hnsw;
+        self.id_to_idx = wrapper.id_to_idx;
+        self.idx_to_id = wrapper.idx_to_id;
+        self.config.m = wrapper.m;
+        self.config.ef_construction = wrapper.ef_construction;
+        self.config.ef_search = wrapper.ef_search;
+        self.deleted_count = wrapper.deleted_count;
+
+        // Keep the loader and temp_dir alive to prevent UAF if hnsw borrows from them
+        self._owner = Some(Box::new((loader, temp_dir)));
+
+        Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "ann-hnsw"))]
+mod tests {
+    use super::*;
+    use crate::singularity::Concept;
+    use csm_core::hyperdim::HVec10240;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_persistence_roundtrip_miri() -> Result<()> {
+        let mut index = HnswIndex::new(16, 100, 10)?;
+        let id = "test".to_string();
+        let vec = HVec10240::random();
+        index.insert(id.clone(), &vec)?;
+
+        let serialized = index.serialize()?;
+        let mut new_index = HnswIndex::new(16, 100, 10)?;
+        new_index.deserialize(&serialized)?;
+
+        let results = new_index.search(&vec, 1)?;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, id);
+        Ok(())
+    }
+
+    #[test]
+    fn test_rebuild_resets_owner() -> Result<()> {
+        let mut index = HnswIndex::new(16, 100, 10)?;
+        let id = "test".to_string();
+        let vec = HVec10240::random();
+        index.insert(id.clone(), &vec)?;
+
+        // Simulate a load that sets _owner
+        let serialized = index.serialize()?;
+        index.deserialize(&serialized)?;
+        assert!(index._owner.is_some());
+
+        let mut concepts = HashMap::new();
+        concepts.insert(
+            id.clone(),
+            Concept {
+                id,
+                vector: vec,
+                ..Default::default()
+            },
+        );
+
+        index.rebuild(&concepts)?;
+        assert!(index._owner.is_none());
+        Ok(())
+    }
+}

--- a/crates/csm-memory/src/index/lsh.rs
+++ b/crates/csm-memory/src/index/lsh.rs
@@ -1,0 +1,377 @@
+#![allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+//! LSH ANN index backend (ADR-0068).
+
+// Casts are intentional for similarity math
+
+use rand::RngExt;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "parallel"))]
+use rayon::prelude::*;
+
+use crate::index::{AnnIndex, IndexStats};
+use crate::singularity::Concept;
+use csm_core::error::Result;
+use csm_core::hyperdim::HVec10240;
+
+/// Locality-Sensitive Hashing (LSH) for hypervectors using bit-sampling.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LshIndex {
+    num_tables: usize,
+    hash_bits: usize,
+    tables: Vec<HashMap<u64, Vec<String>>>,
+    projections: Vec<Vec<usize>>, // indices of bits to sample for each table
+    concepts: HashMap<String, HVec10240>,
+}
+
+impl LshIndex {
+    pub fn new(num_tables: usize, hash_bits: usize) -> Result<Self> {
+        // #9: Reject zero-table configurations.
+        if num_tables == 0 {
+            return Err(csm_core::error::MemoryError::InvalidInput {
+                field: "num_tables".to_string(),
+                reason: "num_tables must be greater than zero".to_string(),
+            });
+        }
+        // Safety check: prevent hash_bits > 64 since we use u64 hashes
+        let hash_bits = hash_bits.min(64);
+        let mut rng = ChaCha8Rng::seed_from_u64(42);
+        let mut projections = Vec::with_capacity(num_tables);
+        let mut tables = Vec::with_capacity(num_tables);
+
+        for _ in 0..num_tables {
+            let mut bits = Vec::with_capacity(hash_bits);
+            for _ in 0..hash_bits {
+                bits.push(rng.random_range(0..HVec10240::DIMENSION));
+            }
+            projections.push(bits);
+            tables.push(HashMap::new());
+        }
+
+        Ok(Self {
+            num_tables,
+            hash_bits,
+            tables,
+            projections,
+            concepts: HashMap::new(),
+        })
+    }
+
+    fn compute_hash(&self, vec: &HVec10240, table_idx: usize) -> u64 {
+        let mut hash = 0u64;
+        let bits = &self.projections[table_idx];
+        for (i, &bit_pos) in bits.iter().enumerate() {
+            let word = bit_pos / 128;
+            let bit = bit_pos % 128;
+            if (vec.data[word] & (1u128 << bit)) != 0 {
+                hash |= 1u64 << i;
+            }
+        }
+        hash
+    }
+}
+
+impl AnnIndex for LshIndex {
+    fn insert(&mut self, id: String, vec: &HVec10240) -> Result<()> {
+        if self.concepts.contains_key(&id) {
+            self.delete(&id)?;
+        }
+
+        for i in 0..self.num_tables {
+            let hash = self.compute_hash(vec, i);
+            self.tables[i].entry(hash).or_default().push(id.clone());
+        }
+        self.concepts.insert(id, *vec);
+        Ok(())
+    }
+
+    fn delete(&mut self, id: &str) -> Result<()> {
+        if let Some(vec) = self.concepts.remove(id) {
+            for i in 0..self.num_tables {
+                let hash = self.compute_hash(&vec, i);
+                if let Some(bucket) = self.tables[i].get_mut(&hash) {
+                    bucket.retain(|x| x != id);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn search(&self, query: &HVec10240, top_k: usize) -> Result<Vec<(String, f32)>> {
+        if top_k == 0 || self.concepts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut candidates = HashMap::new();
+        for i in 0..self.num_tables {
+            let hash = self.compute_hash(query, i);
+            if let Some(bucket) = self.tables[i].get(&hash) {
+                for id in bucket {
+                    candidates.entry(id).or_insert(());
+                }
+            }
+        }
+
+        // Algorithmic Optimization: Parallelize candidate re-ranking via Rayon.
+        // This accelerates the exhaustive similarity check of the candidate
+        // set retrieved from LSH buckets.
+        // Optimized: Uses integer Hamming distance and references to avoid
+        // expensive string allocations in the parallel loop.
+        #[cfg(all(not(target_arch = "wasm32"), feature = "parallel"))]
+        let mut scores: Vec<(&String, u32)> = candidates
+            .keys()
+            .par_bridge()
+            .filter_map(|id| {
+                self.concepts
+                    .get(*id)
+                    .map(|vec| (*id, query.hamming_distance(vec)))
+            })
+            .collect();
+
+        #[cfg(any(target_arch = "wasm32", not(feature = "parallel")))]
+        let mut scores: Vec<(&String, u32)> = candidates
+            .keys()
+            .filter_map(|id| {
+                self.concepts
+                    .get(*id)
+                    .map(|vec| (*id, query.hamming_distance(vec)))
+            })
+            .collect();
+
+        // Optimized: Use O(N) partial selection instead of O(N log N) full sort.
+        if scores.len() <= top_k {
+            scores.sort_unstable_by_key(|&(_, dist)| dist);
+        } else {
+            scores.select_nth_unstable_by(top_k - 1, |a, b| a.1.cmp(&b.1));
+            scores.truncate(top_k);
+            scores.sort_unstable_by_key(|&(_, dist)| dist);
+        }
+
+        let results = scores
+            .into_iter()
+            .map(|(id, dist)| (id.clone(), 1.0 - (dist as f32 / 5120.0)))
+            .collect();
+        Ok(results)
+    }
+
+    fn search_filtered(
+        &self,
+        query: &HVec10240,
+        top_k: usize,
+        filter: &crate::metadata_filter::MetadataFilter,
+        concepts: &HashMap<String, Concept>,
+    ) -> Result<Vec<(String, f32)>> {
+        if top_k == 0 || self.concepts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut candidates = HashMap::new();
+        for i in 0..self.num_tables {
+            let hash = self.compute_hash(query, i);
+            if let Some(bucket) = self.tables[i].get(&hash) {
+                for id in bucket {
+                    if let Some(concept) = concepts.get(id) {
+                        if filter.matches(&concept.metadata) {
+                            candidates.entry(id).or_insert(());
+                        }
+                    }
+                }
+            }
+        }
+
+        // Algorithmic Optimization: Parallelize candidate re-ranking via Rayon.
+        // Optimized: Uses integer Hamming distance and references to avoid
+        // expensive string allocations in the parallel loop.
+        #[cfg(all(not(target_arch = "wasm32"), feature = "parallel"))]
+        let mut scores: Vec<(&String, u32)> = candidates
+            .keys()
+            .par_bridge()
+            .filter_map(|id| {
+                self.concepts
+                    .get(*id)
+                    .map(|vec| (*id, query.hamming_distance(vec)))
+            })
+            .collect();
+
+        #[cfg(any(target_arch = "wasm32", not(feature = "parallel")))]
+        let mut scores: Vec<(&String, u32)> = candidates
+            .keys()
+            .filter_map(|id| {
+                self.concepts
+                    .get(*id)
+                    .map(|vec| (*id, query.hamming_distance(vec)))
+            })
+            .collect();
+
+        // Optimized: Use O(N) partial selection instead of O(N log N) full sort.
+        if scores.len() <= top_k {
+            scores.sort_unstable_by_key(|&(_, dist)| dist);
+        } else {
+            scores.select_nth_unstable_by(top_k - 1, |a, b| a.1.cmp(&b.1));
+            scores.truncate(top_k);
+            scores.sort_unstable_by_key(|&(_, dist)| dist);
+        }
+
+        let final_scores: Vec<(String, f32)> = scores
+            .into_iter()
+            .map(|(id, dist)| (id.clone(), 1.0 - (dist as f32 / 5120.0)))
+            .collect();
+
+        // Fallback for correctness: if we have few candidates, check all filtered concepts
+        if final_scores.len() < top_k {
+            // Algorithmic Optimization: Parallelize the full-scan fallback via Rayon.
+            // This prevents a performance cliff when LSH buckets fail to yield enough
+            // valid candidates for a specific filter.
+            #[cfg(all(not(target_arch = "wasm32"), feature = "parallel"))]
+            let mut all_filtered: Vec<(&String, u32)> = concepts
+                .par_iter()
+                .filter(|(_, c)| filter.matches(&c.metadata))
+                .map(|(id, c)| (id, query.hamming_distance(&c.vector)))
+                .collect();
+
+            #[cfg(any(target_arch = "wasm32", not(feature = "parallel")))]
+            let mut all_filtered: Vec<(&String, u32)> = concepts
+                .iter()
+                .filter(|(_, c)| filter.matches(&c.metadata))
+                .map(|(id, c)| (id, query.hamming_distance(&c.vector)))
+                .collect();
+
+            if all_filtered.len() <= top_k {
+                all_filtered.sort_unstable_by_key(|&(_, dist)| dist);
+            } else {
+                all_filtered.select_nth_unstable_by(top_k - 1, |a, b| a.1.cmp(&b.1));
+                all_filtered.truncate(top_k);
+                all_filtered.sort_unstable_by_key(|&(_, dist)| dist);
+            }
+
+            let results = all_filtered
+                .into_iter()
+                .map(|(id, dist)| (id.clone(), 1.0 - (dist as f32 / 5120.0)))
+                .collect();
+            return Ok(results);
+        }
+
+        Ok(final_scores)
+    }
+
+    fn rebuild(&mut self, concepts: &HashMap<String, Concept>) -> Result<()> {
+        for table in &mut self.tables {
+            table.clear();
+        }
+        self.concepts.clear();
+
+        for (id, concept) in concepts {
+            self.insert(id.clone(), &concept.vector)?;
+        }
+        Ok(())
+    }
+
+    fn stats(&self) -> IndexStats {
+        let mut total_buckets = 0;
+        for table in &self.tables {
+            total_buckets += table.len();
+        }
+
+        IndexStats {
+            backend: "LSH".to_string(),
+            count: self.concepts.len(),
+            memory_usage_bytes: self.concepts.len()
+                * (std::mem::size_of::<String>() + std::mem::size_of::<HVec10240>())
+                + total_buckets * std::mem::size_of::<Vec<String>>(),
+        }
+    }
+
+    fn serialize(&self) -> Result<Vec<u8>> {
+        bincode::serialize(self).map_err(|e| {
+            csm_core::error::MemoryError::Persistence(format!("Serialization error: {}", e))
+        })
+    }
+
+    fn deserialize(&mut self, data: &[u8]) -> Result<()> {
+        let decoded: Self = bincode::deserialize(data).map_err(|e| {
+            csm_core::error::MemoryError::Persistence(format!("Deserialization error: {}", e))
+        })?;
+        *self = decoded;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::index::AnnIndex;
+
+    #[test]
+    fn lsh_index_serialize_deserialize_roundtrip() {
+        let mut idx = LshIndex::new(4, 8).expect("must create index");
+        let vec = HVec10240::random();
+        idx.insert("concept-1".to_string(), &vec)
+            .expect("must insert");
+
+        let bytes = AnnIndex::serialize(&idx).expect("serialize must succeed");
+        assert!(!bytes.is_empty(), "serialized bytes must be non-empty");
+        assert!(bytes.iter().any(|&b| b != 0));
+
+        let mut idx2 = LshIndex::new(4, 8).expect("must create index2");
+        AnnIndex::deserialize(&mut idx2, &bytes).expect("deserialize must succeed");
+
+        let results = idx2.search(&vec, 1).expect("must search");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "concept-1");
+    }
+
+    #[test]
+    fn lsh_index_deserialize_with_garbage_returns_error() {
+        let mut idx = LshIndex::new(4, 8).expect("must create index");
+        let result = AnnIndex::deserialize(&mut idx, b"not valid bincode data !!!!");
+        assert!(result.is_err(), "garbage bytes must return Err");
+    }
+
+    #[test]
+    fn lsh_index_roundtrip_preserves_concept_count() {
+        let mut idx = LshIndex::new(4, 8).expect("must create index");
+        let v1 = HVec10240::random();
+        let v2 = HVec10240::random();
+        idx.insert("alpha".to_string(), &v1).expect("insert alpha");
+        idx.insert("beta".to_string(), &v2).expect("insert beta");
+
+        let bytes = AnnIndex::serialize(&idx).expect("serialize");
+        assert!(bytes.len() > 100, "serialized bytes must be substantial");
+
+        let mut idx2 = LshIndex::new(4, 8).expect("must create index2");
+        AnnIndex::deserialize(&mut idx2, &bytes).expect("deserialize");
+
+        let stats_original = idx.stats();
+        let stats_deserialized = idx2.stats();
+        assert_eq!(
+            stats_original.count, stats_deserialized.count,
+            "concept count must survive roundtrip"
+        );
+        assert_eq!(stats_original.count, 2, "must have exactly 2 concepts");
+
+        let r1 = idx2.search(&v1, 1).expect("search v1");
+        assert_eq!(r1[0].0, "alpha", "search for v1 must find alpha");
+
+        let r2 = idx2.search(&v2, 1).expect("search v2");
+        assert_eq!(r2[0].0, "beta", "search for v2 must find beta");
+    }
+
+    #[test]
+    fn lsh_index_serialize_produces_nonzero_bytes() {
+        let mut idx = LshIndex::new(2, 4).expect("must create index");
+        let v = HVec10240::random();
+        idx.insert("solo".to_string(), &v).expect("insert");
+
+        let bytes = AnnIndex::serialize(&idx).expect("serialize");
+        assert!(!bytes.is_empty());
+        let nonzero = bytes.iter().filter(|&&b| b != 0).count();
+        assert!(
+            nonzero > bytes.len() / 4,
+            "at least 25% of bytes must be nonzero, got {nonzero}/{}",
+            bytes.len()
+        );
+    }
+}

--- a/crates/csm-memory/src/index/mod.rs
+++ b/crates/csm-memory/src/index/mod.rs
@@ -1,0 +1,103 @@
+//! ANN Index traits and backends (ADR-0068).
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fmt::Debug;
+
+use crate::singularity::Concept;
+use csm_core::error::Result;
+use csm_core::hyperdim::HVec10240;
+
+pub mod brute_force;
+#[cfg(feature = "ann-hnsw")]
+pub mod hnsw;
+#[cfg(feature = "ann-lsh")]
+pub mod lsh;
+
+/// Statistics for an ANN index.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct IndexStats {
+    pub backend: String,
+    pub count: usize,
+    pub memory_usage_bytes: usize,
+}
+
+/// Supported ANN index backends.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub enum IndexBackend {
+    /// Exact search via linear scan.
+    #[default]
+    BruteForce,
+    /// Hierarchical Navigable Small Worlds (HNSW) index.
+    #[cfg(feature = "ann-hnsw")]
+    Hnsw {
+        /// Number of bi-directional links for each element (default: 16).
+        m: usize,
+        /// Size of the dynamic list for the nearest neighbors (default: 200).
+        ef_construction: usize,
+        /// Size of the dynamic list for the nearest neighbors during search (default: 50).
+        ef_search: usize,
+    },
+    /// Locality-Sensitive Hashing (LSH) index.
+    #[cfg(feature = "ann-lsh")]
+    Lsh {
+        /// Number of hash tables.
+        num_tables: usize,
+        /// Number of hash bits per table.
+        hash_bits: usize,
+    },
+}
+
+/// Trait for Approximate Nearest Neighbor (ANN) indices.
+pub trait AnnIndex: Send + Sync + Debug {
+    /// Insert a concept into the index.
+    fn insert(&mut self, id: String, vec: &HVec10240) -> Result<()>;
+
+    /// Delete a concept from the index.
+    fn delete(&mut self, id: &str) -> Result<()>;
+
+    /// Search for the top-k nearest neighbors.
+    fn search(&self, query: &HVec10240, top_k: usize) -> Result<Vec<(String, f32)>>;
+
+    /// Search for the nearest neighbors with a metadata filter.
+    fn search_filtered(
+        &self,
+        query: &HVec10240,
+        top_k: usize,
+        filter: &crate::metadata_filter::MetadataFilter,
+        concepts: &std::collections::HashMap<String, crate::singularity::Concept>,
+    ) -> Result<Vec<(String, f32)>>;
+
+    /// Rebuild the index from scratch using all concepts.
+    fn rebuild(&mut self, concepts: &HashMap<String, Concept>) -> Result<()>;
+
+    /// Get statistics for the index.
+    fn stats(&self) -> IndexStats;
+
+    /// Serialize the index state for persistence.
+    fn serialize(&self) -> Result<Vec<u8>>;
+
+    /// Deserialize the index state from persistence.
+    fn deserialize(&mut self, data: &[u8]) -> Result<()>;
+}
+
+/// Create an ANN index backend based on configuration.
+pub fn create_index(backend: &IndexBackend) -> Result<Box<dyn AnnIndex>> {
+    let index: Box<dyn AnnIndex> = match backend {
+        IndexBackend::BruteForce => Box::new(brute_force::BruteForce::new()),
+        #[cfg(feature = "ann-hnsw")]
+        IndexBackend::Hnsw {
+            m,
+            ef_construction,
+            ef_search,
+        } => Box::new(hnsw::HnswIndex::new(*m, *ef_construction, *ef_search)?),
+        #[cfg(feature = "ann-lsh")]
+        IndexBackend::Lsh {
+            num_tables,
+            hash_bits,
+        } => Box::new(lsh::LshIndex::new(*num_tables, *hash_bits)?),
+        #[allow(unreachable_patterns)]
+        _ => Box::new(brute_force::BruteForce::new()),
+    };
+    Ok(index)
+}

--- a/crates/csm-memory/src/lib.rs
+++ b/crates/csm-memory/src/lib.rs
@@ -1,0 +1,32 @@
+//! Concept store and singularity engine for chaotic_semantic_memory.
+//!
+//! This crate provides the core memory engine with:
+//! - `Singularity`: Core concept store with similarity search
+//! - `Concept`: Core data type with versioning support
+//! - `MetadataFilter`: Predicate-based filtering for similarity search
+//! - `AnnIndex`: Approximate nearest neighbor index abstraction
+//! - `graph_traversal`: BFS, Dijkstra on the concept graph
+
+mod concept_builder;
+mod graph_traversal;
+mod index;
+mod metadata_filter;
+mod singularity;
+mod singularity_cache;
+mod singularity_ext;
+mod singularity_retrieval;
+mod singularity_search;
+mod singularity_state;
+mod singularity_ttl;
+
+pub use concept_builder::ConceptBuilder;
+pub use graph_traversal::TraversalConfig;
+pub use index::{AnnIndex, IndexBackend, IndexStats};
+pub use metadata_filter::MetadataFilter;
+pub use singularity::{
+    Concept, ConceptDiff, ConceptVersion, Singularity, SingularityConfig, unix_now_ns,
+    unix_now_secs,
+};
+pub use singularity_cache::{CacheMetrics, CacheMetricsSnapshot};
+pub use singularity_retrieval::{CandidateSource, FilterStrategy, RetrievalConfig, RetrievalStats};
+pub use singularity_state::NamespaceState;

--- a/crates/csm-memory/src/metadata_filter.rs
+++ b/crates/csm-memory/src/metadata_filter.rs
@@ -1,0 +1,226 @@
+//! Metadata filtering for similarity search queries.
+//!
+//! Provides predicate-based filtering during similarity search to support
+//! RAG patterns like document scoping, per-session memory, and multi-tenant filtering.
+
+use serde_json::Value;
+use std::collections::HashMap;
+use std::ops;
+
+/// Maximum recursion depth for metadata filters to prevent stack overflow (DoS).
+pub(crate) const MAX_FILTER_DEPTH: usize = 32;
+
+/// A predicate for filtering concepts by metadata during similarity search.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum MetadataFilter {
+    /// Key equals value: `key == value`
+    Eq(String, Value),
+    /// Key is in set of values: `key in [values]`
+    In(String, Vec<Value>),
+    /// Key exists in metadata
+    Exists(String),
+    /// All filters must match
+    And(Vec<MetadataFilter>),
+    /// Any filter must match
+    Or(Vec<MetadataFilter>),
+    /// Negation of filter
+    Not(Box<MetadataFilter>),
+}
+
+impl MetadataFilter {
+    /// Create an equality filter: `key == value`.
+    pub fn eq(key: impl Into<String>, value: Value) -> Self {
+        Self::Eq(key.into(), value)
+    }
+
+    /// Create an "in" filter: `key in [values]`.
+    pub fn in_(key: impl Into<String>, values: Vec<Value>) -> Self {
+        Self::In(key.into(), values)
+    }
+
+    /// Create an existence filter: `key exists`.
+    pub fn exists(key: impl Into<String>) -> Self {
+        Self::Exists(key.into())
+    }
+
+    /// Combine filters with AND.
+    pub const fn and(filters: Vec<MetadataFilter>) -> Self {
+        Self::And(filters)
+    }
+
+    /// Combine filters with OR.
+    pub const fn or(filters: Vec<MetadataFilter>) -> Self {
+        Self::Or(filters)
+    }
+
+    /// Evaluate the filter against metadata.
+    pub fn matches(&self, metadata: &HashMap<String, Value>) -> bool {
+        match self {
+            Self::Eq(key, value) => metadata.get(key) == Some(value),
+            Self::In(key, values) => metadata.get(key).is_some_and(|v| values.contains(v)),
+            Self::Exists(key) => metadata.contains_key(key),
+            Self::And(filters) => filters.iter().all(|f| f.matches(metadata)),
+            Self::Or(filters) => filters.iter().any(|f| f.matches(metadata)),
+            Self::Not(filter) => !filter.matches(metadata),
+        }
+    }
+
+    /// Compute the depth of the filter tree.
+    pub(crate) fn depth(&self) -> usize {
+        let (mut max, mut stack) = (0, vec![(self, 1)]);
+        while let Some((f, d)) = stack.pop() {
+            max = max.max(d);
+            if d > MAX_FILTER_DEPTH {
+                return d;
+            }
+            match f {
+                Self::And(v) | Self::Or(v) => v.iter().for_each(|i| stack.push((i, d + 1))),
+                Self::Not(i) => stack.push((i, d + 1)),
+                _ => {}
+            }
+        }
+        max
+    }
+
+    /// Validate filter parameters.
+    pub fn validate(&self) -> csm_core::error::Result<()> {
+        let depth = self.depth();
+        if depth > MAX_FILTER_DEPTH {
+            return Err(csm_core::error::MemoryError::InvalidInput {
+                field: "filter".to_string(),
+                reason: format!(
+                    "metadata filter depth exceeds maximum allowed {MAX_FILTER_DEPTH} (got {depth})"
+                ),
+            });
+        }
+        Ok(())
+    }
+}
+
+impl ops::Not for MetadataFilter {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        Self::Not(Box::new(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn make_metadata(pairs: &[(&str, Value)]) -> HashMap<String, Value> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn test_eq_match() {
+        let filter = MetadataFilter::eq("type", json!("document"));
+        let metadata = make_metadata(&[("type", json!("document"))]);
+        assert!(filter.matches(&metadata));
+    }
+
+    #[test]
+    fn test_eq_no_match() {
+        let filter = MetadataFilter::eq("type", json!("document"));
+        let metadata = make_metadata(&[("type", json!("image"))]);
+        assert!(!filter.matches(&metadata));
+    }
+
+    #[test]
+    fn test_eq_missing_key() {
+        let filter = MetadataFilter::eq("type", json!("document"));
+        let metadata = make_metadata(&[]);
+        assert!(!filter.matches(&metadata));
+    }
+
+    #[test]
+    fn test_in_match() {
+        let filter = MetadataFilter::in_("tag", vec![json!("rust"), json!("python")]);
+        let metadata = make_metadata(&[("tag", json!("rust"))]);
+        assert!(filter.matches(&metadata));
+    }
+
+    #[test]
+    fn test_in_no_match() {
+        let filter = MetadataFilter::in_("tag", vec![json!("rust"), json!("python")]);
+        let metadata = make_metadata(&[("tag", json!("go"))]);
+        assert!(!filter.matches(&metadata));
+    }
+
+    #[test]
+    fn test_exists_present() {
+        let filter = MetadataFilter::exists("title");
+        let metadata = make_metadata(&[("title", json!("Hello"))]);
+        assert!(filter.matches(&metadata));
+    }
+
+    #[test]
+    fn test_exists_missing() {
+        let filter = MetadataFilter::exists("title");
+        let metadata = make_metadata(&[]);
+        assert!(!filter.matches(&metadata));
+    }
+
+    #[test]
+    fn test_and_all_match() {
+        let filter = MetadataFilter::and(vec![
+            MetadataFilter::eq("type", json!("document")),
+            MetadataFilter::exists("title"),
+        ]);
+        let metadata = make_metadata(&[("type", json!("document")), ("title", json!("Test"))]);
+        assert!(filter.matches(&metadata));
+    }
+
+    #[test]
+    fn test_and_one_fails() {
+        let filter = MetadataFilter::and(vec![
+            MetadataFilter::eq("type", json!("document")),
+            MetadataFilter::exists("author"),
+        ]);
+        let metadata = make_metadata(&[("type", json!("document")), ("title", json!("Test"))]);
+        assert!(!filter.matches(&metadata));
+    }
+
+    #[test]
+    fn test_or_any_match() {
+        let filter = MetadataFilter::or(vec![
+            MetadataFilter::eq("type", json!("document")),
+            MetadataFilter::eq("type", json!("image")),
+        ]);
+        let metadata = make_metadata(&[("type", json!("image"))]);
+        assert!(filter.matches(&metadata));
+    }
+
+    #[test]
+    fn test_or_none_match() {
+        let filter = MetadataFilter::or(vec![
+            MetadataFilter::eq("type", json!("document")),
+            MetadataFilter::eq("type", json!("image")),
+        ]);
+        let metadata = make_metadata(&[("type", json!("video"))]);
+        assert!(!filter.matches(&metadata));
+    }
+
+    #[test]
+    fn test_not() {
+        let filter = !MetadataFilter::eq("private", json!(true));
+        let metadata = make_metadata(&[("private", json!(false))]);
+        assert!(filter.matches(&metadata));
+    }
+
+    #[test]
+    fn test_depth_and_rejection() {
+        let mut f = MetadataFilter::eq("a", json!(1));
+        assert_eq!(f.depth(), 1);
+        for i in 0..MAX_FILTER_DEPTH {
+            f = MetadataFilter::and(vec![f, MetadataFilter::eq("k", json!(i))]);
+        }
+        assert!(f.depth() > MAX_FILTER_DEPTH);
+        assert!(f.validate().is_err());
+    }
+}

--- a/crates/csm-memory/src/singularity.rs
+++ b/crates/csm-memory/src/singularity.rs
@@ -1,0 +1,494 @@
+//! Core concept storage and indexing engine
+
+use crate::index::{AnnIndex, IndexBackend, IndexStats};
+use crate::singularity_cache::{CacheMetrics, CacheMetricsSnapshot};
+use crate::singularity_retrieval::RetrievalConfig;
+use crate::singularity_state::NamespaceState;
+use csm_core::error::{MemoryError, Result};
+use csm_core::hyperdim::HVec10240;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing::instrument;
+
+/// Configuration for the Singularity engine.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SingularityConfig {
+    pub max_concepts: Option<usize>,
+    pub max_associations_per_concept: Option<usize>,
+    pub concept_cache_size: usize,
+    pub max_cached_top_k: usize,
+    pub index_backend: IndexBackend,
+}
+
+impl Default for SingularityConfig {
+    fn default() -> Self {
+        Self {
+            max_concepts: None,
+            max_associations_per_concept: None,
+            concept_cache_size: 1000,
+            max_cached_top_k: 100,
+            index_backend: IndexBackend::BruteForce,
+        }
+    }
+}
+
+/// Represents a single memory concept
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Concept {
+    pub id: String,
+    pub vector: HVec10240,
+    pub metadata: HashMap<String, serde_json::Value>,
+    pub created_at: u64,
+    pub modified_at: u64,
+    pub expires_at: Option<u64>,
+    /// IDs of concepts that are "canonical" versions of this one (ADR-0044)
+    #[serde(default)]
+    pub canonical_concept_ids: Vec<String>,
+}
+
+/// Represents a historical version of a concept.
+/// Can be a summary (with change flags) or a full record (with vector/metadata).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ConceptVersion {
+    pub concept_id: String,
+    pub version: u64,
+    pub timestamp_unix: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vector: Option<HVec10240>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vector_changed: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_changed: Option<bool>,
+}
+
+/// Description of differences between two versions of a concept.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ConceptDiff {
+    pub vector_cosine_distance: f32,
+    pub metadata_added: HashMap<String, serde_json::Value>,
+    pub metadata_removed: HashMap<String, serde_json::Value>,
+    pub metadata_changed: HashMap<String, (serde_json::Value, serde_json::Value)>,
+}
+
+impl ConceptDiff {
+    /// Calculate the differences between two versions of a concept.
+    pub fn calculate(from_concept: &Concept, to_concept: &Concept) -> Self {
+        let sim = from_concept.vector.cosine_similarity(&to_concept.vector);
+        let vector_cosine_distance = 1.0 - sim;
+
+        let mut metadata_added = HashMap::new();
+        let mut metadata_removed = HashMap::new();
+        let mut metadata_changed = HashMap::new();
+
+        // Find added and changed
+        for (k, v_to) in &to_concept.metadata {
+            if let Some(v_from) = from_concept.metadata.get(k) {
+                if v_from != v_to {
+                    metadata_changed.insert(k.clone(), (v_from.clone(), v_to.clone()));
+                }
+            } else {
+                metadata_added.insert(k.clone(), v_to.clone());
+            }
+        }
+
+        // Find removed
+        for (k, v_from) in &from_concept.metadata {
+            if !to_concept.metadata.contains_key(k) {
+                metadata_removed.insert(k.clone(), v_from.clone());
+            }
+        }
+
+        Self {
+            vector_cosine_distance,
+            metadata_added,
+            metadata_removed,
+            metadata_changed,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct ConceptBuilder {
+    id: String,
+    vector: Option<HVec10240>,
+    metadata: HashMap<String, serde_json::Value>,
+    expires_at: Option<u64>,
+    canonical_concept_ids: Vec<String>,
+}
+
+#[allow(dead_code)]
+impl ConceptBuilder {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            vector: None,
+            metadata: HashMap::new(),
+            expires_at: None,
+            canonical_concept_ids: Vec::new(),
+        }
+    }
+
+    pub const fn with_vector(mut self, vector: HVec10240) -> Self {
+        self.vector = Some(vector);
+        self
+    }
+
+    pub fn with_metadata(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        self.metadata.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn with_ttl(mut self, ttl_secs: u64) -> Self {
+        self.expires_at = Some(unix_now_secs() + ttl_secs);
+        self
+    }
+
+    pub fn build(self) -> Result<Concept> {
+        let now = unix_now_secs();
+        Ok(Concept {
+            id: self.id,
+            vector: self.vector.unwrap_or_else(HVec10240::random),
+            metadata: self.metadata,
+            created_at: now,
+            modified_at: now,
+            expires_at: self.expires_at,
+            canonical_concept_ids: self.canonical_concept_ids,
+        })
+    }
+}
+
+pub struct Singularity {
+    pub(crate) config: SingularityConfig,
+    pub(crate) namespaces: HashMap<String, NamespaceState>,
+    pub(crate) _retrieval_config: RetrievalConfig,
+    pub(crate) cache_metrics: Arc<CacheMetrics>,
+}
+
+impl Singularity {
+    pub fn new(config: SingularityConfig) -> Self {
+        Self::new_with_metrics(config, Arc::new(CacheMetrics::default()))
+    }
+
+    pub fn new_with_metrics(config: SingularityConfig, cache_metrics: Arc<CacheMetrics>) -> Self {
+        Self {
+            config,
+            namespaces: HashMap::new(),
+            _retrieval_config: RetrievalConfig::default(),
+            cache_metrics,
+        }
+    }
+
+    pub fn with_config(config: SingularityConfig) -> Self {
+        Self::new(config)
+    }
+
+    pub fn with_config_and_backend(config: SingularityConfig, backend: IndexBackend) -> Self {
+        let mut cfg = config;
+        cfg.index_backend = backend;
+        Self::new(cfg)
+    }
+
+    pub fn with_config_backend_and_metrics(
+        config: SingularityConfig,
+        backend: IndexBackend,
+        cache_metrics: Arc<CacheMetrics>,
+    ) -> Self {
+        let mut cfg = config;
+        cfg.index_backend = backend;
+        Self::new_with_metrics(cfg, cache_metrics)
+    }
+
+    fn create_index(&self) -> Box<dyn AnnIndex> {
+        crate::index::create_index(&self.config.index_backend)
+            .expect("ANN index creation failed; check feature flags and configuration")
+    }
+
+    pub(crate) fn get_namespace(&self, ns: &str) -> Option<&NamespaceState> {
+        self.namespaces.get(ns)
+    }
+
+    pub(crate) fn get_namespace_mut(&mut self, ns: &str) -> &mut NamespaceState {
+        if !self.namespaces.contains_key(ns) {
+            let index = self.create_index();
+            self.namespaces.insert(
+                ns.to_string(),
+                NamespaceState::new(&self.config, index, Arc::clone(&self.cache_metrics)),
+            );
+        }
+        self.namespaces.get_mut(ns).unwrap()
+    }
+
+    #[instrument(skip(self, concept))]
+    pub fn inject(&mut self, ns: &str, concept: Concept) -> Result<()> {
+        self.evict_oldest_if_needed(ns);
+        let id = concept.id.clone();
+        let vector = concept.vector;
+
+        let ns_state = self.get_namespace_mut(ns);
+
+        // Update ANN index
+        ns_state.index.insert(id.clone(), &vector)?;
+
+        if let Some(_old) = ns_state.concepts.insert(id.clone(), concept) {
+            if let Some(pos) = ns_state.id_to_index.get(&id) {
+                ns_state.concept_vectors[*pos] = vector;
+            }
+            self.invalidate_cache(ns);
+        } else {
+            let pos = ns_state.concept_vectors.len();
+            ns_state.concept_vectors.push(vector);
+            ns_state.concept_indices.push(id.clone());
+            ns_state.id_to_index.insert(id, pos);
+        }
+
+        Ok(())
+    }
+
+    pub fn update(&mut self, ns: &str, id: &str, vector: HVec10240) -> Result<()> {
+        let ns_state = self.get_namespace_mut(ns);
+        if let Some(concept) = ns_state.concepts.get_mut(id) {
+            concept.vector = vector;
+            concept.modified_at = unix_now_secs();
+            if let Some(pos) = ns_state.id_to_index.get(id) {
+                ns_state.concept_vectors[*pos] = vector;
+            }
+            ns_state.index.insert(id.to_string(), &vector)?;
+            self.invalidate_cache(ns);
+            Ok(())
+        } else {
+            Err(MemoryError::NotFound {
+                entity: "Concept".to_string(),
+                id: id.to_string(),
+            })
+        }
+    }
+
+    pub fn delete(&mut self, ns: &str, id: &str) -> Result<()> {
+        let ns_state = self.get_namespace_mut(ns);
+        if ns_state.concepts.remove(id).is_some() {
+            ns_state.associations.remove(id);
+            for neighbors in ns_state.associations.values_mut() {
+                neighbors.remove(id);
+            }
+            if let Some(pos) = ns_state.id_to_index.remove(id) {
+                let _ = ns_state.concept_vectors.swap_remove(pos);
+                ns_state.concept_indices.swap_remove(pos);
+                if pos < ns_state.concept_indices.len() {
+                    let moved_id = &ns_state.concept_indices[pos];
+                    ns_state.id_to_index.insert(moved_id.clone(), pos);
+                }
+            }
+            ns_state.index.delete(id)?;
+            self.invalidate_cache(ns);
+            Ok(())
+        } else {
+            Err(MemoryError::NotFound {
+                entity: "Concept".to_string(),
+                id: id.to_string(),
+            })
+        }
+    }
+
+    pub fn clear(&mut self, ns: &str) {
+        if let Some(ns_state) = self.namespaces.get_mut(ns) {
+            ns_state.concepts.clear();
+            ns_state.associations.clear();
+            ns_state.concept_vectors.clear();
+            ns_state.concept_indices.clear();
+            ns_state.id_to_index.clear();
+            let _ = ns_state.index.rebuild(&HashMap::new());
+            self.invalidate_cache(ns);
+        }
+    }
+
+    pub fn get(&self, ns: &str, id: &str) -> Option<&Concept> {
+        self.get_namespace(ns).and_then(|n| n.concepts.get(id))
+    }
+    pub fn associate(&mut self, ns: &str, from: &str, to: &str, strength: f32) -> Result<()> {
+        // Validate strength before any other checks
+        if !strength.is_finite() {
+            return Err(MemoryError::InvalidInput {
+                field: "strength".to_string(),
+                reason: "association strength must be finite".to_string(),
+            });
+        }
+        if !(0.0..=1.0).contains(&strength) {
+            return Err(MemoryError::InvalidInput {
+                field: "strength".to_string(),
+                reason: format!("association strength must be in [0.0, 1.0], got {strength}"),
+            });
+        }
+
+        // Read config limit before borrowing ns_state mutably
+        let max_assoc = self.config.max_associations_per_concept;
+
+        let ns_state = self.get_namespace_mut(ns);
+        if !ns_state.concepts.contains_key(from) {
+            return Err(MemoryError::NotFound {
+                entity: "Concept".to_string(),
+                id: from.to_string(),
+            });
+        }
+        if !ns_state.concepts.contains_key(to) {
+            return Err(MemoryError::NotFound {
+                entity: "Concept".to_string(),
+                id: to.to_string(),
+            });
+        }
+
+        let neighbors = ns_state.associations.entry(from.to_string()).or_default();
+        neighbors.insert(to.to_string(), strength);
+
+        // Enforce max_associations_per_concept: evict weakest if over limit
+        if let Some(limit) = max_assoc {
+            while neighbors.len() > limit {
+                if let Some(weakest) = neighbors
+                    .iter()
+                    .min_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
+                    .map(|(k, _)| k.clone())
+                {
+                    neighbors.remove(&weakest);
+                } else {
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn disassociate(&mut self, ns: &str, from: &str, to: &str) -> Result<()> {
+        let ns_state = self.get_namespace_mut(ns);
+        if let Some(neighbors) = ns_state.associations.get_mut(from) {
+            neighbors.remove(to);
+        }
+        Ok(())
+    }
+
+    pub fn get_associations(&self, ns: &str, id: &str) -> Vec<(String, f32)> {
+        self.get_namespace(ns)
+            .and_then(|n| n.associations.get(id))
+            .map(|m| m.iter().map(|(k, v)| (k.clone(), *v)).collect::<Vec<_>>())
+            .unwrap_or_default()
+    }
+
+    pub fn incoming_associations(&self, ns: &str, id: &str) -> Vec<(String, f32)> {
+        let mut incoming = Vec::new();
+        if let Some(ns_state) = self.get_namespace(ns) {
+            for (from_id, neighbors) in &ns_state.associations {
+                if let Some(strength) = neighbors.get(id) {
+                    incoming.push((from_id.clone(), *strength));
+                }
+            }
+        }
+        incoming.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        incoming
+    }
+
+    pub fn all_concepts(&self, ns: &str) -> Vec<Concept> {
+        self.get_namespace(ns)
+            .map(|n| n.concepts.values().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    pub fn all_associations(&self, ns: &str) -> Vec<(String, String, f32)> {
+        let mut all = Vec::new();
+        if let Some(ns_state) = self.get_namespace(ns) {
+            for (from, neighbors) in &ns_state.associations {
+                for (to, strength) in neighbors {
+                    all.push((from.clone(), to.clone(), *strength));
+                }
+            }
+        }
+        all
+    }
+
+    pub fn len(&self, ns: &str) -> usize {
+        self.get_namespace(ns).map_or(0, |n| n.concepts.len())
+    }
+
+    pub fn is_empty(&self, ns: &str) -> bool {
+        self.get_namespace(ns).is_none_or(|n| n.concepts.is_empty())
+    }
+
+    pub fn cache_metrics_snapshot(&self, ns: &str) -> CacheMetricsSnapshot {
+        self.get_namespace(ns)
+            .map_or(CacheMetricsSnapshot::default(), |n| {
+                n.cache_metrics.snapshot()
+            })
+    }
+
+    fn evict_oldest_if_needed(&mut self, ns: &str) {
+        let Some(limit) = self.config.max_concepts else {
+            return;
+        };
+
+        while self.len(ns) >= limit {
+            let oldest = {
+                let Some(ns_state) = self.get_namespace(ns) else {
+                    break;
+                };
+                ns_state
+                    .concepts
+                    .values()
+                    .min_by_key(|c| c.created_at)
+                    .map(|c| c.id.clone())
+            };
+
+            if let Some(id) = oldest {
+                let _ = self.delete(ns, &id);
+            } else {
+                break;
+            }
+        }
+    }
+
+    pub fn invalidate_cache(&self, ns: &str) {
+        if let Some(ns_state) = self.get_namespace(ns) {
+            if let Ok(mut cache) = ns_state.query_cache.write() {
+                cache.clear();
+            }
+        }
+    }
+
+    pub fn index_stats(&self, ns: &str) -> IndexStats {
+        self.get_namespace(ns)
+            .map(|n| n.index.stats())
+            .unwrap_or_default()
+    }
+
+    pub const fn retrieval_config(&self) -> &RetrievalConfig {
+        &self._retrieval_config
+    }
+}
+
+pub fn unix_now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+pub fn unix_now_ns() -> u64 {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    u64::try_from(nanos).unwrap_or(u64::MAX)
+}
+
+pub(crate) fn similarity_cache_key(query: &HVec10240, top_k: usize) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut s = std::collections::hash_map::DefaultHasher::new();
+    query.data.hash(&mut s);
+    top_k.hash(&mut s);
+    s.finish()
+}

--- a/crates/csm-memory/src/singularity_cache.rs
+++ b/crates/csm-memory/src/singularity_cache.rs
@@ -1,0 +1,219 @@
+use serde::{Deserialize, Serialize};
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Debug, Default)]
+pub(crate) struct QueryCache {
+    pub(crate) capacity: usize,
+    pub(crate) order: VecDeque<u64>,
+    pub(crate) results: HashMap<u64, Arc<[(String, f32)]>>,
+}
+
+impl QueryCache {
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            capacity: capacity.max(1),
+            order: VecDeque::new(),
+            results: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn get(&mut self, key: u64) -> Option<Arc<[(String, f32)]>> {
+        let value = Arc::clone(self.results.get(&key)?);
+        if let Some(pos) = self.order.iter().position(|k| *k == key) {
+            self.order.remove(pos);
+        }
+        self.order.push_back(key);
+        Some(value)
+    }
+
+    pub(crate) fn put(&mut self, key: u64, value: Arc<[(String, f32)]>) -> bool {
+        if let Entry::Occupied(mut entry) = self.results.entry(key) {
+            entry.insert(value);
+            if let Some(pos) = self.order.iter().position(|k| *k == key) {
+                self.order.remove(pos);
+            }
+            self.order.push_back(key);
+            return false;
+        }
+
+        let mut evicted = false;
+        if self.results.len() >= self.capacity {
+            if let Some(oldest) = self.order.pop_front() {
+                self.results.remove(&oldest);
+                evicted = true;
+            }
+        }
+        self.order.push_back(key);
+        self.results.insert(key, value);
+        evicted
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.order.clear();
+        self.results.clear();
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct CacheMetrics {
+    pub hits_total: AtomicU64,
+    pub misses_total: AtomicU64,
+    pub evictions_total: AtomicU64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CacheMetricsSnapshot {
+    pub cache_hits_total: u64,
+    pub cache_misses_total: u64,
+    pub cache_evictions_total: u64,
+}
+
+impl CacheMetrics {
+    pub fn snapshot(&self) -> CacheMetricsSnapshot {
+        CacheMetricsSnapshot {
+            cache_hits_total: self.hits_total.load(Ordering::Relaxed),
+            cache_misses_total: self.misses_total.load(Ordering::Relaxed),
+            cache_evictions_total: self.evictions_total.load(Ordering::Relaxed),
+        }
+    }
+}
+
+// ============================================================================
+// TESTS
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_results(ids: &[&str]) -> Arc<[(String, f32)]> {
+        ids.iter()
+            .map(|id| (id.to_string(), 0.5))
+            .collect::<Vec<_>>()
+            .into()
+    }
+
+    #[test]
+    fn lru_eviction_at_capacity() {
+        let mut cache = QueryCache::with_capacity(3);
+
+        cache.put(1, make_results(&["a"]));
+        cache.put(2, make_results(&["b"]));
+        cache.put(3, make_results(&["c"]));
+
+        // Cache is at capacity
+        assert_eq!(cache.results.len(), 3);
+
+        // Inserting 4 should evict 1 (oldest)
+        let evicted = cache.put(4, make_results(&["d"]));
+        assert!(evicted);
+        assert_eq!(cache.results.len(), 3);
+        assert!(!cache.results.contains_key(&1));
+        assert!(cache.results.contains_key(&4));
+    }
+
+    #[test]
+    fn lru_get_updates_order() {
+        let mut cache = QueryCache::with_capacity(3);
+
+        cache.put(1, make_results(&["a"]));
+        cache.put(2, make_results(&["b"]));
+        cache.put(3, make_results(&["c"]));
+
+        // Get key 1 - moves it to most-recently-used position
+        cache.get(1);
+
+        // Now insert 4 - should evict 2 (not 1)
+        cache.put(4, make_results(&["d"]));
+        assert!(cache.results.contains_key(&1)); // 1 should still be there
+        assert!(!cache.results.contains_key(&2)); // 2 should be evicted
+    }
+
+    #[test]
+    fn multiple_evictions_under_pressure() {
+        let mut cache = QueryCache::with_capacity(2);
+
+        // Insert 10 items, should cause 8 evictions
+        for i in 0..10 {
+            cache.put(i, make_results(&[&format!("item-{i}")]));
+        }
+
+        assert_eq!(cache.results.len(), 2);
+        // Only 8 and 9 should remain
+        assert!(cache.results.contains_key(&8));
+        assert!(cache.results.contains_key(&9));
+    }
+
+    #[test]
+    fn capacity_one_edge_case() {
+        let mut cache = QueryCache::with_capacity(1);
+
+        cache.put(1, make_results(&["a"]));
+        assert_eq!(cache.results.len(), 1);
+
+        // Every insert should evict
+        let evicted = cache.put(2, make_results(&["b"]));
+        assert!(evicted);
+        assert!(!cache.results.contains_key(&1));
+
+        let evicted = cache.put(3, make_results(&["c"]));
+        assert!(evicted);
+        assert!(!cache.results.contains_key(&2));
+    }
+
+    #[test]
+    fn clear_removes_all_entries() {
+        let mut cache = QueryCache::with_capacity(10);
+
+        for i in 0..5 {
+            cache.put(i, make_results(&[&format!("item-{i}")]));
+        }
+
+        assert_eq!(cache.results.len(), 5);
+        cache.clear();
+        assert_eq!(cache.results.len(), 0);
+        assert_eq!(cache.order.len(), 0);
+    }
+
+    #[test]
+    fn get_returns_none_for_missing_key() {
+        let mut cache = QueryCache::with_capacity(5);
+        cache.put(1, make_results(&["a"]));
+
+        let result = cache.get(999);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn put_returns_false_for_update_without_eviction() {
+        let mut cache = QueryCache::with_capacity(5);
+
+        cache.put(1, make_results(&["a"]));
+        let evicted = cache.put(1, make_results(&["b"])); // Update same key
+
+        assert!(!evicted); // No eviction for update
+        assert_eq!(cache.results.len(), 1);
+    }
+
+    #[test]
+    fn cache_metrics_snapshot() {
+        let metrics = CacheMetrics::default();
+        metrics.hits_total.store(10, Ordering::Relaxed);
+        metrics.misses_total.store(5, Ordering::Relaxed);
+        metrics.evictions_total.store(2, Ordering::Relaxed);
+
+        let snap = metrics.snapshot();
+        assert_eq!(snap.cache_hits_total, 10);
+        assert_eq!(snap.cache_misses_total, 5);
+        assert_eq!(snap.cache_evictions_total, 2);
+    }
+
+    #[test]
+    fn with_capacity_zero_becomes_one() {
+        let cache = QueryCache::with_capacity(0);
+        assert_eq!(cache.capacity, 1);
+    }
+}

--- a/crates/csm-memory/src/singularity_ext.rs
+++ b/crates/csm-memory/src/singularity_ext.rs
@@ -1,0 +1,161 @@
+//! Extension methods for Singularity (extracted to satisfy LOC gate)
+
+use crate::singularity::Singularity;
+use csm_core::error::{MemoryError, Result};
+use csm_core::hyperdim::HVec10240;
+use tracing::instrument;
+
+impl Singularity {
+    /// Bundle multiple concepts into a single hypervector.
+    #[instrument(skip(self, ns), fields(ids_count = ids.len()))]
+    pub fn bundle_concepts_strict(&self, ns: &str, ids: &[String]) -> Result<HVec10240> {
+        let ns_state = self
+            .get_namespace(ns)
+            .ok_or_else(|| MemoryError::NotFound {
+                entity: "Namespace".to_string(),
+                id: ns.to_string(),
+            })?;
+        let mut vectors = Vec::with_capacity(ids.len());
+        for id in ids {
+            match ns_state.concepts.get(id) {
+                Some(concept) => vectors.push(concept.vector),
+                None => {
+                    return Err(MemoryError::NotFound {
+                        entity: "Concept".to_string(),
+                        id: id.clone(),
+                    });
+                }
+            }
+        }
+
+        if vectors.is_empty() {
+            return Err(MemoryError::InvalidInput {
+                field: "ids".to_string(),
+                reason: "Empty concept list for bundling".to_string(),
+            });
+        }
+
+        HVec10240::bundle(&vectors)
+    }
+
+    pub fn update_metadata(
+        &mut self,
+        ns: &str,
+        id: &str,
+        metadata: std::collections::HashMap<String, serde_json::Value>,
+    ) -> Result<()> {
+        let ns_state = self.get_namespace_mut(ns);
+        if let Some(concept) = ns_state.concepts.get_mut(id) {
+            concept.metadata = metadata;
+            concept.modified_at = crate::singularity::unix_now_secs();
+            self.invalidate_cache(ns);
+            Ok(())
+        } else {
+            Err(MemoryError::NotFound {
+                entity: "Concept".to_string(),
+                id: id.to_string(),
+            })
+        }
+    }
+
+    pub fn clear_associations(&mut self, ns: &str, id: &str) -> Result<()> {
+        let ns_state = self.get_namespace_mut(ns);
+        if let Some(neighbors) = ns_state.associations.get_mut(id) {
+            neighbors.clear();
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::singularity::{ConceptBuilder, Singularity, SingularityConfig};
+    use csm_core::error::MemoryError;
+    use std::collections::HashMap;
+
+    const NS: &str = "_default";
+
+    #[test]
+    fn test_bundle_concepts_strict_success() -> csm_core::error::Result<()> {
+        let mut singularity = Singularity::with_config(SingularityConfig::default());
+        let vec1 = HVec10240::random();
+        let vec2 = HVec10240::random();
+
+        let c1 = ConceptBuilder::new("c1").with_vector(vec1).build().unwrap();
+        let c2 = ConceptBuilder::new("c2").with_vector(vec2).build().unwrap();
+
+        singularity.inject(NS, c1)?;
+        singularity.inject(NS, c2)?;
+
+        let result = singularity.bundle_concepts_strict(NS, &["c1".to_string(), "c2".to_string()]);
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn test_bundle_concepts_strict_missing_id() -> csm_core::error::Result<()> {
+        let mut singularity = Singularity::with_config(SingularityConfig::default());
+        let vec1 = HVec10240::random();
+
+        let c1 = ConceptBuilder::new("c1").with_vector(vec1).build()?;
+        singularity.inject(NS, c1)?;
+
+        let result =
+            singularity.bundle_concepts_strict(NS, &["c1".to_string(), "missing_id".to_string()]);
+
+        match result {
+            Err(MemoryError::NotFound { entity, id }) => {
+                assert_eq!(entity, "Concept");
+                assert_eq!(id, "missing_id");
+            }
+            _ => panic!("Expected NotFound error, got {result:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_update_metadata_not_found() {
+        let mut sing = Singularity::new(SingularityConfig::default());
+        let metadata = HashMap::new();
+
+        let result = sing.update_metadata(NS, "non-existent-id", metadata);
+
+        match result {
+            Err(MemoryError::NotFound { entity, id }) => {
+                assert_eq!(entity, "Concept");
+                assert_eq!(id, "non-existent-id");
+            }
+            _ => panic!("Expected MemoryError::NotFound, got {result:?}"),
+        }
+    }
+
+    #[test]
+    fn test_update_metadata_success() -> csm_core::error::Result<()> {
+        let mut sing = Singularity::new(SingularityConfig::default());
+        let concept = ConceptBuilder::new("test-id")
+            .with_metadata("original", serde_json::Value::Bool(true))
+            .build()
+            .expect("Failed to build concept");
+
+        sing.inject(NS, concept)?;
+
+        let mut new_metadata = HashMap::new();
+        new_metadata.insert("updated".to_string(), serde_json::Value::Bool(true));
+
+        let time_before = crate::singularity::unix_now_secs();
+
+        let result = sing.update_metadata(NS, "test-id", new_metadata.clone());
+        assert!(result.is_ok());
+
+        let updated_concept = sing
+            .get(NS, "test-id")
+            .ok_or_else(|| MemoryError::NotFound {
+                entity: "Concept".to_string(),
+                id: "test-id".to_string(),
+            })?;
+        assert_eq!(updated_concept.metadata, new_metadata);
+        assert!(updated_concept.modified_at >= time_before);
+        Ok(())
+    }
+}

--- a/crates/csm-memory/src/singularity_retrieval.rs
+++ b/crates/csm-memory/src/singularity_retrieval.rs
@@ -389,6 +389,7 @@ impl Singularity {
     }
 
     /// Score candidates with explicit selectivity stats (ADR-0065).
+    #[allow(dead_code)]
     pub(crate) fn scored_candidate_retrieval_with_stats(
         &self,
         ns: &str,

--- a/crates/csm-memory/src/singularity_search.rs
+++ b/crates/csm-memory/src/singularity_search.rs
@@ -1,0 +1,253 @@
+//! Similarity search and cached retrieval methods for Singularity.
+//!
+//! Extracted from singularity.rs to satisfy the 500 LOC gate.
+
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+#[cfg(not(target_arch = "wasm32"))]
+use tracing::instrument;
+
+use crate::singularity::{Singularity, similarity_cache_key, unix_now_ns};
+use crate::singularity_retrieval::{
+    CandidateSource, FilterStrategy, RetrievalStats, ScoredCandidateParams,
+};
+use crate::singularity_state::NamespaceState;
+use csm_core::hyperdim::HVec10240;
+
+// ── Helper functions for find_similar_cached ──────────────────────────
+// Extracted to reduce cyclomatic complexity (Deepsource).
+
+/// Try to retrieve results from the similarity cache.
+/// Returns `Some(results)` on cache hit, `None` on miss or cache bypass.
+fn try_cache_lookup(
+    ns_state: &NamespaceState,
+    query: &HVec10240,
+    top_k: usize,
+    bypass_cache: bool,
+    start_ns: u64,
+) -> Option<Arc<[(String, f32)]>> {
+    if bypass_cache {
+        return None;
+    }
+
+    let cache_key = similarity_cache_key(query, top_k);
+    if let Ok(mut cache) = ns_state.query_cache.write() {
+        if let Some(results) = cache.get(cache_key) {
+            ns_state
+                .cache_metrics
+                .hits_total
+                .fetch_add(1, Ordering::Relaxed);
+            let stats = RetrievalStats {
+                candidate_count: results.len(),
+                scored_count: 0,
+                scoring_ns: unix_now_ns().saturating_sub(start_ns),
+                ..Default::default()
+            };
+            if let Ok(mut s) = ns_state.last_retrieval_stats.write() {
+                *s = stats;
+            }
+            return Some(results);
+        }
+    }
+    ns_state
+        .cache_metrics
+        .misses_total
+        .fetch_add(1, Ordering::Relaxed);
+    None
+}
+
+/// Try to retrieve results from the ANN index.
+/// Returns `Some(results)` on ANN hit, `None` for BruteForce backend or
+/// ANN search failure (falls through to exact scan).
+fn try_ann_lookup(
+    ns_state: &NamespaceState,
+    query: &HVec10240,
+    top_k: usize,
+    bypass_cache: bool,
+    start_ns: u64,
+) -> Option<Arc<[(String, f32)]>> {
+    let index_stats = ns_state.index.stats();
+    if index_stats.backend == "BruteForce" {
+        return None;
+    }
+
+    if let Ok(results) = ns_state.index.search(query, top_k) {
+        let results_arc: Arc<[(String, f32)]> = Arc::from(results);
+
+        if let Ok(mut s) = ns_state.last_retrieval_stats.write() {
+            s.scored_count = results_arc.len();
+            s.candidate_count = index_stats.count;
+            s.scoring_ns = unix_now_ns().saturating_sub(start_ns);
+        }
+
+        if !bypass_cache {
+            if let Ok(mut cache) = ns_state.query_cache.write() {
+                let cache_key = similarity_cache_key(query, top_k);
+                if cache.put(cache_key, Arc::clone(&results_arc)) {
+                    ns_state
+                        .cache_metrics
+                        .evictions_total
+                        .fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }
+        return Some(results_arc);
+    }
+    None
+}
+
+impl Singularity {
+    /// Find similar concepts using cosine similarity
+    #[cfg_attr(not(target_arch = "wasm32"), instrument(skip(self, ns, query), fields(top_k = top_k)))]
+    pub fn find_similar(&self, ns: &str, query: &HVec10240, top_k: usize) -> Vec<(String, f32)> {
+        self.find_similar_arc(ns, query, top_k).as_ref().to_vec()
+    }
+
+    /// Find similar concepts and return cached results as `Arc<[_]>`.
+    pub fn find_similar_arc(
+        &self,
+        ns: &str,
+        query: &HVec10240,
+        top_k: usize,
+    ) -> Arc<[(String, f32)]> {
+        self.find_similar_cached(ns, query, top_k)
+    }
+
+    /// Find similar concepts, returning cached results as `Arc<[_]>`.
+    ///
+    /// Retrieval pipeline:
+    /// 1. Cache lookup (bypassed when `top_k > max_cached_top_k`)
+    /// 2. ANN index lookup (skipped for BruteForce backend)
+    /// 3. Candidate generation (graph → bucket → exact scan fallback)
+    pub fn find_similar_cached(
+        &self,
+        ns: &str,
+        query: &HVec10240,
+        top_k: usize,
+    ) -> Arc<[(String, f32)]> {
+        let start_ns = unix_now_ns();
+        if top_k == 0 || self.is_empty(ns) {
+            let stats = RetrievalStats {
+                fell_back_to_exact_scan: true,
+                ..Default::default()
+            };
+            if let Some(ns_state) = self.get_namespace(ns) {
+                if let Ok(mut s) = ns_state.last_retrieval_stats.write() {
+                    *s = stats;
+                }
+            }
+            return Arc::from(Vec::new());
+        }
+        let Some(ns_state) = self.get_namespace(ns) else {
+            return Arc::from(Vec::new());
+        };
+
+        let bypass_cache = top_k > self.config.max_cached_top_k;
+
+        // Step 1: Cache lookup
+        if let Some(results) = try_cache_lookup(ns_state, query, top_k, bypass_cache, start_ns) {
+            return results;
+        }
+
+        // Step 2: ANN index lookup (ADR-0068)
+        if let Some(results) = try_ann_lookup(ns_state, query, top_k, bypass_cache, start_ns) {
+            return results;
+        }
+
+        // Step 3: Candidate generation based on RetrievalConfig
+        let candidate_start = unix_now_ns();
+        let mut candidates = Vec::new();
+        let mut source = CandidateSource::ExactFallback;
+
+        if self._retrieval_config.enable_graph_candidates {
+            candidates = self.generate_graph_candidates(ns, query);
+            if !candidates.is_empty() {
+                source = CandidateSource::Graph;
+            }
+        }
+        if candidates.is_empty() && self._retrieval_config.enable_bucket_candidates {
+            candidates = self.generate_bucket_candidates(ns, query);
+            if !candidates.is_empty() {
+                source = CandidateSource::Bucket;
+            }
+        }
+
+        let cand_ns = unix_now_ns().saturating_sub(candidate_start);
+
+        if candidates.is_empty() {
+            return self.exact_similarity_scan(ns, query, top_k, start_ns, bypass_cache);
+        }
+
+        // Reduced-candidate path
+        self.scored_candidate_retrieval(
+            ns,
+            ScoredCandidateParams {
+                query,
+                top_k,
+                candidates,
+                start_ns,
+                cand_ns,
+                source,
+                bypass_cache,
+            },
+        )
+    }
+
+    /// Find similar concepts with metadata filtering.
+    pub fn find_similar_filtered(
+        &self,
+        ns: &str,
+        query: &HVec10240,
+        top_k: usize,
+        filter: &crate::metadata_filter::MetadataFilter,
+    ) -> Arc<[(String, f32)]> {
+        let Some(ns_state) = self.get_namespace(ns) else {
+            return Arc::from(Vec::new());
+        };
+
+        let total = ns_state.concepts.len();
+        let matching = ns_state
+            .concepts
+            .values()
+            .filter(|c| filter.matches(&c.metadata))
+            .count();
+
+        #[allow(clippy::cast_precision_loss)] // concept counts fit in f32 for selectivity
+        let selectivity = if total > 0 {
+            matching as f32 / total as f32
+        } else {
+            0.0
+        };
+
+        // ADR-0065: Select strategy based on selectivity
+        #[allow(clippy::cast_precision_loss)] // concept counts fit in f32 for selectivity
+        let strategy = if total < 20 || selectivity < 0.3 {
+            Some(FilterStrategy::Pre)
+        } else if selectivity <= 0.8 {
+            Some(FilterStrategy::BucketPost)
+        } else {
+            Some(FilterStrategy::ScanPost)
+        };
+
+        let results = ns_state
+            .index
+            .search_filtered(query, top_k, filter, &ns_state.concepts)
+            .unwrap_or_default();
+
+        let results_arc: Arc<[(String, f32)]> = Arc::from(results);
+
+        let stats = RetrievalStats {
+            candidate_count: matching,
+            scored_count: results_arc.len(),
+            selectivity_ratio: selectivity,
+            filter_strategy: strategy,
+            ..Default::default()
+        };
+        if let Ok(mut s) = ns_state.last_retrieval_stats.write() {
+            *s = stats;
+        }
+
+        results_arc
+    }
+}

--- a/crates/csm-memory/src/singularity_state.rs
+++ b/crates/csm-memory/src/singularity_state.rs
@@ -1,0 +1,41 @@
+use crate::index::AnnIndex;
+use crate::singularity::{Concept, SingularityConfig};
+use crate::singularity_cache::{CacheMetrics, QueryCache};
+use crate::singularity_retrieval::RetrievalStats;
+use csm_core::hyperdim::HVec10240;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+/// State for a single namespace in the singularity engine.
+#[derive(Debug)]
+pub struct NamespaceState {
+    pub(crate) concepts: HashMap<String, Concept>,
+    pub(crate) associations: HashMap<String, HashMap<String, f32>>,
+    pub(crate) concept_indices: Vec<String>,
+    pub(crate) concept_vectors: Vec<HVec10240>,
+    pub(crate) id_to_index: HashMap<String, usize>,
+    pub(crate) query_cache: RwLock<QueryCache>,
+    pub(crate) cache_metrics: Arc<CacheMetrics>,
+    pub(crate) last_retrieval_stats: RwLock<RetrievalStats>,
+    pub(crate) index: Box<dyn AnnIndex>,
+}
+
+impl NamespaceState {
+    pub fn new(
+        config: &SingularityConfig,
+        index: Box<dyn AnnIndex>,
+        cache_metrics: Arc<CacheMetrics>,
+    ) -> Self {
+        Self {
+            concepts: HashMap::new(),
+            associations: HashMap::new(),
+            concept_indices: Vec::new(),
+            concept_vectors: Vec::new(),
+            id_to_index: HashMap::new(),
+            query_cache: RwLock::new(QueryCache::with_capacity(config.concept_cache_size)),
+            cache_metrics,
+            last_retrieval_stats: RwLock::new(RetrievalStats::default()),
+            index,
+        }
+    }
+}

--- a/crates/csm-memory/src/singularity_ttl.rs
+++ b/crates/csm-memory/src/singularity_ttl.rs
@@ -1,0 +1,207 @@
+//! TTL (Time-To-Live) operations for Singularity.
+
+use std::collections::HashMap;
+
+use crate::singularity::{Concept, Singularity, unix_now_secs};
+use csm_core::hyperdim::HVec10240;
+
+impl Default for Concept {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            vector: HVec10240::zero(),
+            metadata: HashMap::new(),
+            created_at: 0,
+            modified_at: 0,
+            expires_at: None,
+            canonical_concept_ids: Vec::new(),
+        }
+    }
+}
+
+impl Singularity {
+    /// Purge all expired concepts from memory.
+    ///
+    /// Returns the number of concepts removed.
+    pub fn purge_expired(&mut self, ns: &str) -> usize {
+        let now = unix_now_secs();
+        let Some(ns_state) = self.get_namespace(ns) else {
+            return 0;
+        };
+        let expired: Vec<String> = ns_state
+            .concepts
+            .iter()
+            .filter(|(_, c)| c.expires_at.is_some_and(|exp| exp <= now))
+            .map(|(id, _)| id.clone())
+            .collect();
+
+        let count = expired.len();
+        for id in expired {
+            self.delete(ns, &id).ok();
+        }
+        if count > 0 {
+            self.invalidate_cache(ns);
+        }
+        count
+    }
+
+    /// Check if a concept is expired.
+    pub fn is_expired(&self, ns: &str, id: &str) -> bool {
+        let now = unix_now_secs();
+        self.get(ns, id)
+            .is_some_and(|c| c.expires_at.is_some_and(|exp| exp <= now))
+    }
+
+    /// Get all non-expired concept IDs.
+    pub fn active_concept_ids(&self, ns: &str) -> Vec<String> {
+        let now = unix_now_secs();
+        self.get_namespace(ns)
+            .map(|n| {
+                n.concepts
+                    .iter()
+                    .filter(|(_, c)| c.expires_at.is_none_or(|exp| exp > now))
+                    .map(|(id, _)| id.clone())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::singularity::SingularityConfig;
+
+    #[test]
+    fn test_purge_expired() {
+        let mut sing = Singularity::new(SingularityConfig::default());
+        let now = unix_now_secs();
+
+        let concept1 = Concept {
+            id: "expired".to_string(),
+            expires_at: Some(now - 100),
+            ..Default::default()
+        };
+
+        let concept2 = Concept {
+            id: "active".to_string(),
+            expires_at: Some(now + 100),
+            ..Default::default()
+        };
+
+        let concept3 = Concept {
+            id: "no_exp".to_string(),
+            expires_at: None,
+            ..Default::default()
+        };
+
+        let ns = "_default";
+        sing.inject("_default", concept1).unwrap();
+        sing.inject("_default", concept2).unwrap();
+        sing.inject("_default", concept3).unwrap();
+
+        assert_eq!(sing.active_concept_ids(ns).len(), 2);
+
+        let purged = sing.purge_expired("_default");
+        assert_eq!(purged, 1);
+
+        assert!(
+            !sing
+                .get_namespace(ns)
+                .unwrap()
+                .concepts
+                .contains_key("expired")
+        );
+        assert!(
+            sing.get_namespace(ns)
+                .unwrap()
+                .concepts
+                .contains_key("active")
+        );
+        assert!(
+            sing.get_namespace(ns)
+                .unwrap()
+                .concepts
+                .contains_key("no_exp")
+        );
+    }
+
+    #[test]
+    fn test_is_expired() {
+        let mut sing = Singularity::new(SingularityConfig::default());
+        let now = unix_now_secs();
+
+        let concept1 = Concept {
+            id: "expired".to_string(),
+            expires_at: Some(now - 100),
+            ..Default::default()
+        };
+
+        let concept2 = Concept {
+            id: "active".to_string(),
+            expires_at: Some(now + 100),
+            ..Default::default()
+        };
+
+        let concept3 = Concept {
+            id: "no_exp".to_string(),
+            expires_at: None,
+            ..Default::default()
+        };
+
+        let concept4 = Concept {
+            id: "just_expired".to_string(),
+            expires_at: Some(now),
+            ..Default::default()
+        };
+
+        let ns = "_default";
+        sing.inject("_default", concept1).unwrap();
+        sing.inject("_default", concept2).unwrap();
+        sing.inject("_default", concept3).unwrap();
+        sing.inject("_default", concept4).unwrap();
+
+        assert!(sing.is_expired(ns, "expired"));
+        assert!(!sing.is_expired(ns, "active"));
+        assert!(!sing.is_expired(ns, "no_exp"));
+        assert!(sing.is_expired(ns, "just_expired"));
+        assert!(!sing.is_expired(ns, "nonexistent"));
+    }
+
+    #[test]
+    fn test_active_concept_ids() {
+        let mut sing = Singularity::new(SingularityConfig::default());
+        let now = unix_now_secs();
+
+        let concept1 = Concept {
+            id: "expired".to_string(),
+            expires_at: Some(now - 100),
+            ..Default::default()
+        };
+
+        let concept2 = Concept {
+            id: "active".to_string(),
+            expires_at: Some(now + 100),
+            ..Default::default()
+        };
+
+        let concept3 = Concept {
+            id: "no_exp".to_string(),
+            expires_at: None,
+            ..Default::default()
+        };
+
+        let ns = "_default";
+        sing.inject("_default", concept1).unwrap();
+        sing.inject("_default", concept2).unwrap();
+        sing.inject("_default", concept3).unwrap();
+
+        let mut active = sing.active_concept_ids(ns);
+        active.sort();
+
+        let mut expected = vec!["active".to_string(), "no_exp".to_string()];
+        expected.sort();
+
+        assert_eq!(active, expected);
+    }
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -18,6 +18,7 @@
 - colored (2.2.0)
 - csm-core
 - csm-embedding
+- csm-memory
 - fastembed (4)
 - glob (0.3.2)
 - hnsw_rs (0.3.4)

--- a/llms.txt
+++ b/llms.txt
@@ -18,6 +18,7 @@
 - colored (2.2.0)
 - csm-core
 - csm-embedding
+- csm-memory
 - fastembed (4)
 - glob (0.3.2)
 - hnsw_rs (0.3.4)
@@ -1289,6 +1290,7 @@ The `csm` binary provides command-line access:
 members = [
     "crates/csm-core",
     "crates/csm-embedding",
+    "crates/csm-memory",
     ".",
     "benchmarks",
     "crates/chaotic_semantic_memory_duckdb",
@@ -1343,6 +1345,7 @@ include = [
 [dependencies]
 csm-core = { path = "crates/csm-core" }
 csm-embedding = { path = "crates/csm-embedding" }
+csm-memory = { path = "crates/csm-memory" }
 tempfile = { workspace = true }
 # Serialization
 serde = { workspace = true }

--- a/src/framework_validation.rs
+++ b/src/framework_validation.rs
@@ -93,13 +93,7 @@ pub(crate) fn validate_path(path: &str) -> Result<PathBuf> {
 
 impl ChaoticSemanticFramework {
     pub(crate) fn validate_retrieval_config(config: &RetrievalConfig) -> Result<()> {
-        if config.bucket_probe_width > MAX_BUCKET_PROBE_WIDTH {
-            return Err(MemoryError::InvalidInput {
-                field: "bucket_probe_width".to_string(),
-                reason: format!("bucket_probe_width exceeds {MAX_BUCKET_PROBE_WIDTH}"),
-            });
-        }
-        Ok(())
+        config.validate()
     }
 
     pub(crate) fn validate_namespace(ns: &str) -> Result<()> {


### PR DESCRIPTION
## Summary

- Extract core memory engine into standalone `csm-memory` workspace crate
- Move Singularity, Concept, MetadataFilter, AnnIndex, and graph traversal
- Fix circular dependency by moving validation logic into csm-memory
- Add csm-memory as dependency to main crate

## Changes

- Created `crates/csm-memory/` with core memory engine
- Moved singularity files, concept_builder, metadata_filter, index, graph_traversal
- Fixed circular dependency: moved `validate_retrieval_config` and `validate_traversal_config` into csm-memory
- Updated `MAX_BUCKET_PROBE_WIDTH` to 16 (from 100) for consistency
- Added csm-memory to workspace members and as dependency to main crate

## Testing

- `cargo test -p csm-memory` passes (48 tests)
- `cargo test --quiet` passes (all tests)
- `cargo check --all-features` passes
- `cargo clippy -- -D warnings` passes
- `cargo fmt --check` passes

## Related Issues

- Closes #365