### PR TITLE
refactor(retrieval): extract csm-retrieval into standalone workspace crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +619,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bitpacking"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "bitstream-io"
 version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,6 +799,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "census"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4c707c6a209cbe82d10abd08e1ea8995e9ea937d2550646e02798948992be0"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +854,7 @@ dependencies = [
  "csm-core",
  "csm-embedding",
  "csm-memory",
+ "csm-retrieval",
  "fastembed",
  "getrandom 0.4.2",
  "glob",
@@ -1234,6 +1259,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1319,6 +1353,21 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "csm-retrieval"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "csm-core",
+ "csm-memory",
+ "serde",
+ "serde_json",
+ "tantivy",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1408,6 +1457,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -1519,6 +1578,12 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "duckdb"
@@ -1675,6 +1740,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fastdivide"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
+
+[[package]]
 name = "fastembed"
 version = "4.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,6 +1853,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs4"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
+dependencies = [
+ "rustix 0.38.44",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2142,6 +2223,12 @@ dependencies = [
  "libc",
  "windows-link",
 ]
+
+[[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
 name = "http"
@@ -2567,6 +2654,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2702,6 +2801,12 @@ name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
+name = "levenshtein_automata"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 
 [[package]]
 name = "lexical-core"
@@ -2996,10 +3101,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 
 [[package]]
 name = "mach2"
@@ -3062,10 +3182,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "measure_time"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbefd235b0aadd181626f281e1d684e116972988c14c264e42069d5e8a5775cc"
+dependencies = [
+ "instant",
+ "log",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mime"
@@ -3173,6 +3312,12 @@ dependencies = [
  "num-traits",
  "pxfm",
 ]
+
+[[package]]
+name = "murmurhash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "native-tls"
@@ -3316,6 +3461,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3394,6 +3545,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oneshot"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
 name = "onig"
@@ -3494,6 +3651,15 @@ dependencies = [
  "sha2",
  "tar",
  "ureq",
+]
+
+[[package]]
+name = "ownedbytes"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a059efb063b8f425b948e042e6b9bd85edfe60e913630ed727b23e2dfcc558"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3684,6 +3850,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -4043,6 +4215,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4346,6 +4528,16 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -4684,6 +4876,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4921,6 +5122,147 @@ dependencies = [
 ]
 
 [[package]]
+name = "tantivy"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96599ea6fccd844fc833fed21d2eecac2e6a7c1afd9e044057391d78b1feb141"
+dependencies = [
+ "aho-corasick",
+ "arc-swap",
+ "base64 0.22.1",
+ "bitpacking",
+ "byteorder",
+ "census",
+ "crc32fast",
+ "crossbeam-channel",
+ "downcast-rs",
+ "fastdivide",
+ "fnv",
+ "fs4",
+ "htmlescape",
+ "itertools 0.12.1",
+ "levenshtein_automata",
+ "log",
+ "lru",
+ "lz4_flex",
+ "measure_time",
+ "memmap2",
+ "num_cpus",
+ "once_cell",
+ "oneshot",
+ "rayon",
+ "regex",
+ "rust-stemmers",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "sketches-ddsketch",
+ "smallvec",
+ "tantivy-bitpacker",
+ "tantivy-columnar",
+ "tantivy-common",
+ "tantivy-fst",
+ "tantivy-query-grammar",
+ "tantivy-stacker",
+ "tantivy-tokenizer-api",
+ "tempfile",
+ "thiserror 1.0.69",
+ "time",
+ "uuid",
+ "winapi",
+]
+
+[[package]]
+name = "tantivy-bitpacker"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284899c2325d6832203ac6ff5891b297fc5239c3dc754c5bc1977855b23c10df"
+dependencies = [
+ "bitpacking",
+]
+
+[[package]]
+name = "tantivy-columnar"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12722224ffbe346c7fec3275c699e508fd0d4710e629e933d5736ec524a1f44e"
+dependencies = [
+ "downcast-rs",
+ "fastdivide",
+ "itertools 0.12.1",
+ "serde",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-sstable",
+ "tantivy-stacker",
+]
+
+[[package]]
+name = "tantivy-common"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8019e3cabcfd20a1380b491e13ff42f57bb38bf97c3d5fa5c07e50816e0621f4"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "ownedbytes",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "tantivy-fst"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d60769b80ad7953d8a7b2c70cdfe722bbcdcac6bccc8ac934c40c034d866fc18"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
+ "utf8-ranges",
+]
+
+[[package]]
+name = "tantivy-query-grammar"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847434d4af57b32e309f4ab1b4f1707a6c566656264caa427ff4285c4d9d0b82"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
+name = "tantivy-sstable"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c69578242e8e9fc989119f522ba5b49a38ac20f576fc778035b96cc94f41f98e"
+dependencies = [
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-fst",
+ "zstd",
+]
+
+[[package]]
+name = "tantivy-stacker"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56d6ff5591fc332739b3ce7035b57995a3ce29a93ffd6012660e0949c956ea8"
+dependencies = [
+ "murmurhash32",
+ "rand_distr",
+ "tantivy-common",
+]
+
+[[package]]
+name = "tantivy-tokenizer-api"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0dcade25819a89cfe6f17d932c9cedff11989936bf6dd4f336d50392053b04"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5017,6 +5359,37 @@ dependencies = [
  "quick-error 2.0.1",
  "weezl",
  "zune-jpeg 0.4.21",
+]
+
+[[package]]
+name = "time"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -5519,6 +5892,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
 name = "utf8_iter"
@@ -6469,6 +6848,34 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/csm-core",
     "crates/csm-embedding",
     "crates/csm-memory",
+    "crates/csm-retrieval",
     ".",
     "benchmarks",
     "crates/chaotic_semantic_memory_duckdb",
@@ -58,6 +59,7 @@ include = [
 csm-core = { path = "crates/csm-core" }
 csm-embedding = { path = "crates/csm-embedding" }
 csm-memory = { path = "crates/csm-memory" }
+csm-retrieval = { path = "crates/csm-retrieval" }
 tempfile = { workspace = true }
 # Serialization
 serde = { workspace = true }

--- a/crates/csm-retrieval/Cargo.toml
+++ b/crates/csm-retrieval/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "csm-retrieval"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+description = "Retrieval backends for chaotic_semantic_memory"
+license = "MIT"
+repository = "https://github.com/d-o-hub/chaotic_semantic_memory"
+
+[dependencies]
+csm-core = { path = "../csm-core" }
+csm-memory = { path = "../csm-memory" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true }
+async-trait = "0.1.83"
+
+# Optional BM25 dependencies
+tantivy = { version = "0.22", optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[features]
+default = []
+bm25 = ["dep:tantivy"]
+rerank-cross = []
+
+[lib]
+crate-type = ["lib"]

--- a/crates/csm-retrieval/src/bm25.rs
+++ b/crates/csm-retrieval/src/bm25.rs
@@ -1,0 +1,442 @@
+//! BM25 keyword search index for hybrid retrieval.
+//!
+//! Implements the Okapi BM25 ranking function for exact keyword matching.
+//! Used alongside HDC semantic search for improved short-query recall.
+//!
+//! # Algorithm
+//!
+//! BM25 scores documents based on:
+//! - Term frequency (TF) with saturation parameter k1
+//! - Inverse document frequency (IDF)
+//! - Document length normalization with parameter b
+//!
+//! # Example
+//!
+//! ```
+//! use csm_retrieval::Bm25Index;
+//!
+//! let mut index = Bm25Index::new();
+//! index.add_document("doc1", &["hello", "world"]);
+//! index.add_document("doc2", &["hello", "rust"]);
+//!
+//! let results = index.search(&["hello", "world"], 10);
+//! assert_eq!(results[0].0, "doc1"); // Exact match ranks first
+//! ```
+
+// Casts are intentional for BM25 math (document counts, term frequencies)
+#![allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+
+use serde::{Deserialize, Serialize};
+use std::cell::RefCell;
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::sync::RwLock;
+use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+
+/// Configuration for BM25 ranking algorithm.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct Bm25Config {
+    /// Controls term frequency saturation. Typical value: 1.2.
+    pub k1: f32,
+    /// Controls document length normalization. Typical value: 0.75.
+    pub b: f32,
+}
+
+impl Default for Bm25Config {
+    fn default() -> Self {
+        Self { k1: 1.2, b: 0.75 }
+    }
+}
+
+/// A document in the BM25 index.
+#[derive(Debug, Clone)]
+struct Document {
+    id: String,
+    term_freqs: HashMap<Arc<str>, u32>,
+    length: usize,
+}
+
+thread_local! {
+    static DOC_SCORES_BUFFER: RefCell<Vec<f32>> = const { RefCell::new(Vec::new()) };
+    static SCORES_COLLECT_BUFFER: RefCell<Vec<(usize, f32)>> = const { RefCell::new(Vec::new()) };
+}
+
+#[derive(Debug)]
+/// BM25-based document index for keyword search.
+pub struct Bm25Index {
+    config: Bm25Config,
+    documents: Vec<Document>,
+    doc_index: HashMap<String, usize>,
+    /// Inverted index mapping terms to (document_index, term_frequency)
+    postings: HashMap<Arc<str>, Vec<(usize, u32)>>,
+    /// Document terms (c2 * doc_len + c1) for fast scoring.
+    doc_term_bs: RwLock<Vec<f32>>,
+    /// Reciprocals (1.0 / (1.0 + b_val)) for the tf=1 fast path.
+    tf1_recips: RwLock<Vec<f32>>,
+    /// True when scoring factors are stale due to index mutations.
+    norm_cache_dirty: AtomicBool,
+    /// Document lengths for fast access in scoring loop
+    doc_lengths: Vec<f32>,
+    total_length: usize,
+}
+
+impl Default for Bm25Index {
+    fn default() -> Self {
+        Self {
+            config: Bm25Config::default(),
+            documents: Vec::new(),
+            doc_index: HashMap::new(),
+            postings: HashMap::new(),
+            doc_term_bs: RwLock::new(Vec::new()),
+            tf1_recips: RwLock::new(Vec::new()),
+            norm_cache_dirty: AtomicBool::new(true),
+            doc_lengths: Vec::new(),
+            total_length: 0,
+        }
+    }
+}
+
+impl Clone for Bm25Index {
+    fn clone(&self) -> Self {
+        Self {
+            config: self.config,
+            documents: self.documents.clone(),
+            doc_index: self.doc_index.clone(),
+            postings: self.postings.clone(),
+            doc_term_bs: RwLock::new(
+                self.doc_term_bs
+                    .read()
+                    .expect("Bm25Index doc_term_bs lock poisoned")
+                    .clone(),
+            ),
+            tf1_recips: RwLock::new(
+                self.tf1_recips
+                    .read()
+                    .expect("Bm25Index tf1_recips lock poisoned")
+                    .clone(),
+            ),
+            norm_cache_dirty: AtomicBool::new(self.norm_cache_dirty.load(AtomicOrdering::Acquire)),
+            doc_lengths: self.doc_lengths.clone(),
+            total_length: self.total_length,
+        }
+    }
+}
+
+impl Bm25Index {
+    /// Create a new BM25 index with default configuration.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a new BM25 index with custom configuration.
+    pub fn with_config(config: Bm25Config) -> Self {
+        Self {
+            config,
+            ..Default::default()
+        }
+    }
+
+    /// Add a document to the index.
+    ///
+    /// If a document with the same ID already exists, it will be replaced.
+    pub fn add_document<T: AsRef<str>>(&mut self, id: &str, tokens: &[T]) {
+        if let Some(idx) = self.doc_index.remove(id) {
+            self.remove_document_at(idx);
+        }
+
+        let mut term_freqs = HashMap::with_capacity(tokens.len().min(100));
+        for token in tokens {
+            let term = token.as_ref();
+            // Arc interning - share term strings between documents and postings
+            // Double lookup pattern to bypass lack of get_key_value_mut
+            if let Some(count) = term_freqs.get_mut(term) {
+                *count += 1;
+            } else {
+                // If term exists in index, reuse its Arc to save memory
+                let term_arc = self
+                    .postings
+                    .get_key_value(term)
+                    .map_or_else(|| Arc::from(term), |(k, _)| Arc::clone(k));
+
+                term_freqs.insert(term_arc, 1);
+            }
+        }
+
+        let length = tokens.len();
+        let doc = Document {
+            id: id.to_string(),
+            term_freqs,
+            length,
+        };
+
+        self.total_length += length;
+        let idx = self.documents.len();
+        self.doc_index.insert(id.to_string(), idx);
+
+        // Update postings list
+        for (term, &tf) in &doc.term_freqs {
+            self.postings
+                .entry(Arc::clone(term))
+                .or_default()
+                .push((idx, tf));
+        }
+
+        self.doc_lengths.push(length as f32);
+        self.documents.push(doc);
+        self.norm_cache_dirty.store(true, AtomicOrdering::Release);
+    }
+
+    /// Remove a document from the index.
+    pub fn remove_document(&mut self, id: &str) {
+        if let Some(idx) = self.doc_index.remove(id) {
+            self.remove_document_at(idx);
+        }
+    }
+
+    fn remove_document_at(&mut self, idx: usize) {
+        let last_idx = self.documents.len() - 1;
+
+        // Use swap_remove - gives ownership of the document
+        let doc = self.documents.swap_remove(idx);
+        self.doc_lengths.swap_remove(idx);
+
+        // Update postings and cleanup empty entries
+        for term in doc.term_freqs.keys() {
+            let mut needs_removal = false;
+            if let Some(entries) = self.postings.get_mut(term) {
+                if let Some(p_idx) = entries.iter().position(|&(d_idx, _)| d_idx == idx) {
+                    entries.swap_remove(p_idx);
+                }
+                needs_removal = entries.is_empty();
+            }
+            if needs_removal {
+                self.postings.remove(term);
+            }
+        }
+
+        self.total_length = self.total_length.saturating_sub(doc.length);
+
+        // If we swapped an element into idx, update its mapping
+        if idx < self.documents.len() {
+            let swapped_id = &self.documents[idx].id;
+            self.doc_index.insert(swapped_id.clone(), idx);
+
+            // Update indices in postings list for the swapped document
+            for term in self.documents[idx].term_freqs.keys() {
+                if let Some(entries) = self.postings.get_mut(term) {
+                    if let Some(p_idx) = entries.iter().position(|&(d_idx, _)| d_idx == last_idx) {
+                        entries[p_idx].0 = idx;
+                    }
+                }
+            }
+        }
+        self.norm_cache_dirty.store(true, AtomicOrdering::Release);
+    }
+
+    /// Search for documents matching the query.
+    ///
+    /// Returns up to `top_k` results sorted by BM25 score (descending).
+    // SAFETY: The read guard must span the entire scoring loop to guarantee
+    // cache vector stability. Tightening the drop would require re-acquiring
+    // the lock mid-loop, which is both slower and semantically incorrect.
+    #[allow(clippy::significant_drop_tightening)]
+    pub fn search<T: AsRef<str>>(&self, query_tokens: &[T], top_k: usize) -> Vec<(String, f32)> {
+        if top_k == 0 || query_tokens.is_empty() || self.is_empty() {
+            return Vec::new();
+        }
+
+        let n = self.len() as f32;
+        let num_docs = self.documents.len();
+
+        // Pre-calculate constants for scoring (hoisted out of loop)
+        let k1 = self.config.k1;
+        let k1_plus_1 = k1 + 1.0;
+
+        // Compute unique query terms and their weighted IDFs once.
+        // Optimization: Pre-fetch postings list references to minimize HashMap lookups in the scoring loop.
+        let mut query_weights = Vec::with_capacity(query_tokens.len());
+
+        // Fast-path for query deduplication: linear scan for short queries (<= 8 tokens).
+        if query_tokens.len() <= 8 {
+            #[allow(clippy::needless_range_loop)]
+            for i in 0..query_tokens.len() {
+                let term = query_tokens[i].as_ref();
+                let mut duplicate = false;
+                for j in 0..i {
+                    if query_tokens[j].as_ref() == term {
+                        duplicate = true;
+                        break;
+                    }
+                }
+                if !duplicate {
+                    self.push_query_weight(term, n, k1_plus_1, &mut query_weights);
+                }
+            }
+        } else {
+            let mut seen_terms = HashSet::with_capacity(query_tokens.len());
+            for token in query_tokens {
+                let term = token.as_ref();
+                if seen_terms.insert(term) {
+                    self.push_query_weight(term, n, k1_plus_1, &mut query_weights);
+                }
+            }
+        }
+
+        if query_weights.is_empty() {
+            return Vec::new();
+        }
+
+        // Optimization: Use thread-local buffer to eliminate O(N) allocation per search call.
+        DOC_SCORES_BUFFER.with(|buffer| {
+            let mut doc_scores = buffer.borrow_mut();
+            doc_scores.clear();
+            doc_scores.resize(num_docs, 0.0);
+
+            self.ensure_norm_cache();
+            {
+                let doc_term_bs = self
+                    .doc_term_bs
+                    .read()
+                    .expect("Bm25Index doc_term_bs lock poisoned");
+                let tf1_recips = self
+                    .tf1_recips
+                    .read()
+                    .expect("Bm25Index tf1_recips lock poisoned");
+
+                for (_, weighted_idf, entries) in query_weights {
+                    for &(doc_idx, tf) in entries {
+                        if tf == 1 {
+                            // Fast path for the most common case: single term frequency.
+                            doc_scores[doc_idx] += weighted_idf * tf1_recips[doc_idx];
+                        } else {
+                            let tf = tf as f32;
+                            let denominator = tf + doc_term_bs[doc_idx];
+                            doc_scores[doc_idx] += (tf * weighted_idf) / denominator;
+                        }
+                    }
+                }
+            }
+
+            SCORES_COLLECT_BUFFER.with(|collect_buffer| {
+                let mut scores = collect_buffer.borrow_mut();
+                scores.clear();
+
+                for (idx, &score) in doc_scores.iter().enumerate() {
+                    if score > 0.0 {
+                        scores.push((idx, score));
+                    }
+                }
+
+                // Partial select keeps complexity near O(n) for large corpora
+                if scores.len() > top_k {
+                    let nth = top_k - 1;
+                    scores.select_nth_unstable_by(nth, score_cmp_desc);
+                    scores.truncate(top_k);
+                }
+                scores.sort_unstable_by(score_cmp_desc);
+
+                // Map to final results, cloning IDs only for top_k
+                scores
+                    .iter()
+                    .map(|&(idx, score)| (self.documents[idx].id.clone(), score))
+                    .collect()
+            })
+        })
+    }
+
+    #[inline]
+    #[allow(clippy::type_complexity)]
+    fn push_query_weight<'a>(
+        &'a self,
+        term: &'a str,
+        n: f32,
+        k1_plus_1: f32,
+        query_weights: &mut Vec<(&'a str, f32, &'a Vec<(usize, u32)>)>,
+    ) {
+        if let Some(postings) = self.postings.get(term) {
+            let df = postings.len() as f32;
+            // idf = ln((N + 1.0) / (df + 0.5)) is always > 0 for all N >= df >= 1
+            let idf = ((n + 1.0) / (df + 0.5)).ln();
+            query_weights.push((term, idf * k1_plus_1, postings));
+        }
+    }
+
+    /// Clear all documents from the index.
+    pub fn clear(&mut self) {
+        self.documents.clear();
+        self.doc_lengths.clear();
+        self.doc_index.clear();
+        self.postings.clear();
+        self.total_length = 0;
+        self.norm_cache_dirty.store(true, AtomicOrdering::Release);
+    }
+
+    /// Get the number of documents in the index.
+    pub fn len(&self) -> usize {
+        self.documents.len()
+    }
+
+    /// Check if the index is empty.
+    pub fn is_empty(&self) -> bool {
+        self.documents.is_empty()
+    }
+
+    #[allow(clippy::significant_drop_tightening)]
+    fn ensure_norm_cache(&self) {
+        if !self.norm_cache_dirty.load(AtomicOrdering::Acquire) {
+            return;
+        }
+
+        if self.is_empty() {
+            self.norm_cache_dirty.store(false, AtomicOrdering::Release);
+            return;
+        }
+
+        let n = self.len() as f32;
+        let avgdl = self.total_length as f32 / n;
+        let k1 = self.config.k1;
+        let b = self.config.b;
+        let c1 = k1 * (1.0 - b);
+        let c2 = k1 * b / avgdl;
+
+        {
+            let mut bs = self
+                .doc_term_bs
+                .write()
+                .expect("Bm25Index doc_term_bs lock poisoned");
+            let mut recips = self
+                .tf1_recips
+                .write()
+                .expect("Bm25Index tf1_recips lock poisoned");
+
+            bs.clear();
+            recips.clear();
+
+            for &doc_len in &self.doc_lengths {
+                let b_val = c2.mul_add(doc_len, c1);
+                bs.push(b_val);
+                recips.push(1.0 / (1.0 + b_val));
+            }
+        }
+
+        self.norm_cache_dirty.store(false, AtomicOrdering::Release);
+    }
+
+    /// Get the average document length.
+    pub fn avg_doc_length(&self) -> f32 {
+        if self.is_empty() {
+            0.0
+        } else {
+            self.total_length as f32 / self.documents.len() as f32
+        }
+    }
+}
+
+fn score_cmp_desc(a: &(usize, f32), b: &(usize, f32)) -> Ordering {
+    b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal)
+}
+
+#[cfg(test)]
+#[path = "bm25/tests.rs"]
+mod tests;

--- a/crates/csm-retrieval/src/bm25/tests.rs
+++ b/crates/csm-retrieval/src/bm25/tests.rs
@@ -1,0 +1,500 @@
+// Exact float comparisons for BM25 score test assertions
+
+use super::super::*;
+
+#[test]
+fn test_add_document() {
+    let mut index = Bm25Index::new();
+    index.add_document("doc1", &["hello", "world"]);
+    assert_eq!(index.len(), 1);
+}
+
+#[test]
+fn test_search_exact_match() {
+    let mut index = Bm25Index::new();
+    index.add_document("doc1", &["hello", "world"]);
+    index.add_document("doc2", &["hello", "rust"]);
+
+    let results = index.search(&["hello", "world"], 10);
+    assert_eq!(results[0].0, "doc1");
+}
+
+#[test]
+fn test_search_partial_match() {
+    let mut index = Bm25Index::new();
+    index.add_document("doc1", &["hello", "world"]);
+    index.add_document("doc2", &["goodbye", "world"]);
+
+    let results = index.search(&["hello"], 10);
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].0, "doc1");
+}
+
+#[test]
+fn test_search_empty_index() {
+    let index = Bm25Index::new();
+    let results = index.search(&["hello"], 10);
+    assert!(results.is_empty());
+}
+
+#[test]
+fn test_search_empty_query() {
+    let mut index = Bm25Index::new();
+    index.add_document("doc1", &["hello", "world"]);
+
+    let results: Vec<(String, f32)> = index.search::<&str>(&[], 10);
+    assert!(results.is_empty());
+}
+
+#[test]
+fn test_remove_document() {
+    let mut index = Bm25Index::new();
+    index.add_document("doc1", &["hello", "world"]);
+    index.add_document("doc2", &["hello", "rust"]);
+    index.add_document("doc3", &["hello", "python"]);
+
+    // Removing "doc1" triggers swap_remove, doc3 moves to index 0
+    index.remove_document("doc1");
+    assert_eq!(index.len(), 2);
+
+    // Verify removed doc is gone
+    let results = index.search(&["world"], 10);
+    assert!(results.is_empty());
+
+    // Verify swapped doc is still findable (this catches the postings index update mutation)
+    let results = index.search(&["python"], 10);
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].0, "doc3");
+
+    // Verify common term still works for both
+    let results = index.search(&["hello"], 10);
+    assert_eq!(results.len(), 2);
+}
+
+#[test]
+fn test_replace_document() {
+    let mut index = Bm25Index::new();
+    index.add_document("doc1", &["hello", "world"]);
+    index.add_document("doc1", &["goodbye", "rust"]);
+
+    assert_eq!(index.len(), 1);
+
+    let results = index.search(&["rust"], 10);
+    assert_eq!(results[0].0, "doc1");
+}
+
+#[test]
+fn test_top_k() {
+    let mut index = Bm25Index::new();
+    index.add_document("doc1", &["hello", "world"]);
+    index.add_document("doc2", &["hello", "rust"]);
+    index.add_document("doc3", &["hello", "python"]);
+
+    let results = index.search(&["hello"], 2);
+    assert_eq!(results.len(), 2);
+}
+
+#[test]
+fn test_top_k_zero_returns_empty() {
+    let mut index = Bm25Index::new();
+    index.add_document("doc1", &["hello", "world"]);
+
+    let results = index.search(&["hello"], 0);
+    assert!(results.is_empty());
+}
+
+#[test]
+fn test_idf_rare_term_higher_score() {
+    let mut index = Bm25Index::new();
+
+    // "rare" appears in 1 doc, "common" appears in 3 docs
+    index.add_document("doc1", &["rare", "common"]);
+    index.add_document("doc2", &["common"]);
+    index.add_document("doc3", &["common"]);
+
+    // Searching for both should rank doc1 higher (contains rare term)
+    let results = index.search(&["rare", "common"], 10);
+    assert_eq!(results[0].0, "doc1");
+}
+
+#[test]
+fn test_doc_length_normalization() {
+    let mut index = Bm25Index::new();
+
+    // Short document with term
+    index.add_document("short", &["hello"]);
+    // Long document with same term but more other words
+    index.add_document(
+        "long",
+        &[
+            "hello", "other", "words", "here", "and", "even", "more", "words",
+        ],
+    );
+
+    // Both match, but shorter doc should score higher per-term
+    // (BM25 normalizes by document length)
+    let results = index.search(&["hello"], 10);
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].0, "short");
+}
+
+#[test]
+fn test_scoring_impact_tf() {
+    let mut index = Bm25Index::new();
+    // Same length docs
+    index.add_document("doc1", &["hello", "a", "b", "c"]);
+    index.add_document("doc2", &["hello", "hello", "a", "b"]);
+
+    let results = index.search(&["hello"], 10);
+    assert_eq!(results[0].0, "doc2");
+    assert!(results[0].1 > results[1].1);
+}
+
+#[test]
+fn test_clear() {
+    let mut index = Bm25Index::new();
+    index.add_document("doc1", &["hello", "world"]);
+    index.clear();
+    assert!(index.is_empty());
+    assert!(index.search(&["hello"], 10).is_empty());
+}
+
+#[test]
+fn test_avg_doc_length() {
+    let mut index = Bm25Index::new();
+    index.add_document("doc1", &["a", "b", "c"]);
+    index.add_document("doc2", &["x", "y"]);
+
+    assert!((index.avg_doc_length() - 2.5).abs() < 1e-6);
+}
+
+#[test]
+fn test_custom_config() {
+    let config = Bm25Config { k1: 2.0, b: 0.5 };
+    let index = Bm25Index::with_config(config);
+    assert!((index.config.k1 - 2.0).abs() < 1e-6);
+    assert!((index.config.b - 0.5).abs() < 1e-6);
+}
+
+#[test]
+fn test_zero_length_document() {
+    let mut index = Bm25Index::new();
+    index.add_document("empty", &[] as &[&str]);
+    index.add_document("doc1", &["hello"]);
+
+    let results = index.search(&["hello"], 10);
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].0, "doc1");
+}
+
+#[test]
+fn test_single_term_query() {
+    let mut index = Bm25Index::new();
+    index.add_document("doc1", &["hello", "world"]);
+    let results = index.search(&["hello"], 10);
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].0, "doc1");
+}
+
+#[test]
+fn test_no_matching_terms() {
+    let mut index = Bm25Index::new();
+    index.add_document("doc1", &["hello", "world"]);
+    assert!(index.search(&["rust"], 10).is_empty());
+}
+
+#[test]
+fn test_exact_score_calculation() {
+    let mut index = Bm25Index::new();
+    index.add_document("doc1", &["hello"]);
+
+    let results = index.search(&["hello"], 10);
+    assert_eq!(results.len(), 1);
+
+    // For N=1, df=1, tf=1, dl=avgdl:
+    // score = ln((N+1)/(df+0.5)) = ln(2/1.5)
+    let expected = (2.0f32 / 1.5f32).ln();
+    assert!((results[0].1 - expected).abs() < 1e-6);
+}
+
+#[test]
+fn test_internal_alignment() {
+    let mut index = Bm25Index::new();
+    index.add_document("doc1", &["a", "b"]);
+    index.add_document("doc2", &["a", "b", "c"]);
+    index.add_document("doc3", &["a"]);
+
+    assert_eq!(index.documents.len(), 3);
+    assert_eq!(index.doc_lengths.len(), 3);
+    assert!((index.doc_lengths[0] - 2.0).abs() < f32::EPSILON);
+    assert!((index.doc_lengths[1] - 3.0).abs() < f32::EPSILON);
+    assert!((index.doc_lengths[2] - 1.0).abs() < f32::EPSILON);
+
+    // Swap remove doc1 (index 0). doc3 (index 2) should move to index 0.
+    index.remove_document("doc1");
+    assert_eq!(index.documents.len(), 2);
+    assert_eq!(index.doc_lengths.len(), 2);
+    assert_eq!(index.documents[0].id, "doc3");
+    assert!((index.doc_lengths[0] - 1.0).abs() < f32::EPSILON);
+    assert_eq!(index.documents[1].id, "doc2");
+    assert!((index.doc_lengths[1] - 3.0).abs() < f32::EPSILON);
+
+    index.clear();
+    assert!(index.doc_lengths.is_empty());
+}
+
+#[test]
+fn test_cache_consistency() {
+    let mut index = Bm25Index::new();
+    index.add_document("doc1", &["hello"]);
+    index.add_document("doc2", &["hello", "hello"]);
+
+    // Initial search populates cache
+    let results = index.search(&["hello"], 10);
+    assert_eq!(results.len(), 2);
+    let score1_initial = results.iter().find(|(id, _)| id == "doc1").unwrap().1;
+
+    // Mutation invalidates cache
+    index.add_document("doc3", &["world"]);
+
+    // Second search recomputes cache
+    let results2 = index.search(&["hello"], 10);
+    let score1_after = results2.iter().find(|(id, _)| id == "doc1").unwrap().1;
+
+    // Scores should change because avgdl changed
+    assert!((score1_initial - score1_after).abs() > 1e-6);
+
+    // Identity check for cached search
+    let results3 = index.search(&["hello"], 10);
+    let score1_cached = results3.iter().find(|(id, _)| id == "doc1").unwrap().1;
+    assert!((score1_after - score1_cached).abs() < f32::EPSILON);
+}
+
+#[test]
+fn test_clone_preserves_state() {
+    let mut index = Bm25Index::new();
+    index.add_document("doc1", &["a"]);
+
+    let cloned = index.clone();
+    assert_eq!(cloned.len(), 1);
+    assert_eq!(cloned.search(&["a"], 10).len(), 1);
+
+    // Mutation on original doesn't affect clone
+    index.add_document("doc2", &["b"]);
+    assert_eq!(index.len(), 2);
+    assert_eq!(cloned.len(), 1);
+}
+
+#[test]
+fn test_scoring_math_general_case() {
+    let mut index = Bm25Index::new();
+    // doc1: "a" (tf=2), len=2
+    index.add_document("doc1", &["a", "a"]);
+    // doc2: "a" (tf=1), len=1
+    index.add_document("doc2", &["a"]);
+
+    let results = index.search(&["a"], 10);
+    assert_eq!(results.len(), 2);
+
+    let n = 2.0f32;
+    let df = 2.0f32;
+    let avgdl = 1.5f32;
+    let k1 = 1.2f32;
+    let b = 0.75f32;
+
+    let idf = ((n + 1.0) / (df + 0.5)).ln();
+    let weighted_idf = idf * (k1 + 1.0);
+
+    // doc2: tf=1, len=1
+    let b_doc2 = k1 * (1.0 - b) + (k1 * b / avgdl) * 1.0;
+    let expected_doc2 = weighted_idf / (1.0 + b_doc2);
+    let score_doc2 = results.iter().find(|(id, _)| id == "doc2").unwrap().1;
+    assert!((score_doc2 - expected_doc2).abs() < 1e-6);
+
+    // doc1: tf=2, len=2
+    let b_doc1 = k1 * (1.0 - b) + (k1 * b / avgdl) * 2.0;
+    let expected_doc1 = (2.0 * weighted_idf) / (2.0 + b_doc1);
+    let score_doc1 = results.iter().find(|(id, _)| id == "doc1").unwrap().1;
+    assert!((score_doc1 - expected_doc1).abs() < 1e-6);
+}
+
+#[test]
+fn test_search_mutant_prevention() {
+    let mut index = Bm25Index::new();
+    index.add_document("doc1", &["a"]);
+
+    // query_tokens is empty but index is NOT empty, top_k > 0
+    // If || was replaced with &&, this would NOT return empty
+    assert!(index.search::<&str>(&[], 10).is_empty());
+
+    // index is empty but query_tokens is NOT empty, top_k > 0
+    let index_empty = Bm25Index::new();
+    assert!(index_empty.search(&["a"], 10).is_empty());
+}
+
+#[test]
+fn test_oov_term_excluded_from_scoring() {
+    let mut index = Bm25Index::new();
+    index.add_document("doc1", &["hello", "world"]);
+    index.add_document("doc2", &["hello", "rust"]);
+
+    let results = index.search(&["hello", "nonexistent_term_xyz"], 10);
+    assert_eq!(results.len(), 2, "both docs with 'hello' must be returned");
+
+    let score_no_oov = index.search(&["hello"], 10);
+    for (id, score) in &results {
+        let expected = score_no_oov.iter().find(|(i, _)| i == id).unwrap().1;
+        assert!(
+            (*score - expected).abs() < 1e-6,
+            "OOV term must not affect score of '{id}': got {score}, expected {expected}"
+        );
+    }
+}
+
+#[test]
+fn test_idf_formula_positive_for_all_valid_inputs() {
+    let mut index = Bm25Index::new();
+    for i in 0..20 {
+        index.add_document(&format!("doc{i}"), &["term_a"]);
+    }
+
+    let results = index.search(&["term_a"], 20);
+    assert_eq!(results.len(), 20);
+
+    let n = 20.0f32;
+    let df = 20.0f32;
+    let expected_idf = ((n + 1.0) / (df + 0.5)).ln();
+    assert!(expected_idf > 0.0, "IDF must be positive for df=N case");
+
+    for (_, score) in &results {
+        assert!(*score > 0.0, "score must be positive when IDF > 0");
+    }
+}
+
+#[test]
+fn test_rare_term_scores_higher_than_common_term() {
+    let mut index = Bm25Index::new();
+    index.add_document("common-only", &["common"]);
+    index.add_document("rare-and-common", &["rare", "common"]);
+
+    let results_both = index.search(&["rare", "common"], 10);
+    let results_common = index.search(&["common"], 10);
+
+    let score_both = results_both
+        .iter()
+        .find(|(id, _)| id == "rare-and-common")
+        .unwrap()
+        .1;
+    let score_common = results_common
+        .iter()
+        .find(|(id, _)| id == "rare-and-common")
+        .unwrap()
+        .1;
+
+    assert!(
+        score_both > score_common,
+        "adding a rare term must increase score: both={score_both} > common={score_common}"
+    );
+}
+
+#[test]
+fn test_score_positive_for_single_doc_single_term() {
+    let mut index = Bm25Index::new();
+    index.add_document("solo", &["unique"]);
+
+    let results = index.search(&["unique"], 10);
+    assert_eq!(results.len(), 1);
+    assert!(
+        results[0].1 > 0.0,
+        "single doc with matching term must score > 0, got {}",
+        results[0].1
+    );
+}
+
+#[test]
+fn test_search_does_not_mutate_index() {
+    let mut index = Bm25Index::new();
+    index.add_document("d1", &["alpha", "beta"]);
+    index.add_document("d2", &["alpha", "gamma"]);
+
+    let before_len = index.len();
+    let _ = index.search(&["alpha"], 10);
+    let _ = index.search(&["beta"], 10);
+    assert_eq!(
+        index.len(),
+        before_len,
+        "search must not change document count"
+    );
+
+    let results_after = index.search(&["alpha"], 10);
+    assert_eq!(
+        results_after.len(),
+        2,
+        "index still queryable after searches"
+    );
+}
+
+// Regression: every distinct query term must contribute to scoring.
+//
+// Guards the short-query (<= 8 tokens) linear-scan deduplication added in
+// PR #363 (src/retrieval/bm25.rs:271-283). Kills the surviving mutant
+// `replace == with != in Bm25Index::search` (line 276): flipping the term
+// equality check marks every *distinct* term as a duplicate, so only the
+// first query term is scored. By isolating each query term to its own
+// document we make the dropped contribution observable.
+#[test]
+fn test_search_distinct_terms_each_contribute() {
+    let mut index = Bm25Index::new();
+    // Each document carries exactly one of the two query terms so that a
+    // term being dropped during dedup removes its document from the results.
+    index.add_document("doc_alpha", &["alpha", "alpha", "alpha"]);
+    index.add_document("doc_beta", &["beta", "beta", "beta"]);
+    // Two distinct tokens, length 2 (<= 8) -> exercises the linear-scan path.
+    let results = index.search(&["alpha", "beta"], 10);
+    assert_eq!(
+        results.len(),
+        2,
+        "both distinct query terms must score their respective document"
+    );
+    let ids: std::collections::HashSet<&str> = results.iter().map(|(id, _)| id.as_str()).collect();
+    assert!(ids.contains("doc_alpha"), "alpha term must contribute");
+    assert!(ids.contains("doc_beta"), "beta term must contribute");
+    assert!(
+        results.iter().all(|(_, score)| *score > 0.0),
+        "each contributing term must yield a positive score"
+    );
+}
+// Companion: the same distinct-term invariant on the HashSet dedup path
+// (> 8 unique tokens). Ensures both deduplication paths stay behaviourally
+// identical and that duplicate terms never inflate scores.
+#[test]
+fn test_search_dedup_hashset_path_distinct_terms() {
+    let mut index = Bm25Index::new();
+    index.add_document("doc_a", &["a"]);
+    index.add_document("doc_b", &["b"]);
+
+    // 10 tokens (> 8) forces the HashSet dedup branch. "a" is repeated to
+    // confirm duplicates are collapsed, not double-counted.
+    let query = ["a", "a", "c", "d", "e", "f", "g", "h", "i", "b"];
+    let results = index.search(&query, 10);
+
+    let ids: std::collections::HashSet<&str> = results.iter().map(|(id, _)| id.as_str()).collect();
+    assert!(
+        ids.contains("doc_a"),
+        "term 'a' must contribute via HashSet path"
+    );
+    assert!(
+        ids.contains("doc_b"),
+        "term 'b' must contribute via HashSet path"
+    );
+
+    // Querying "a" once must give doc_a the same score as querying it twice.
+    let once = index.search(&["a"], 10);
+    let twice = index.search(&["a", "a"], 10);
+    #[allow(clippy::float_cmp)]
+    let scores_match = once[0].1 == twice[0].1;
+    assert!(
+        scores_match,
+        "duplicate query terms must not inflate the score"
+    );
+}

--- a/crates/csm-retrieval/src/bridge_retrieval.rs
+++ b/crates/csm-retrieval/src/bridge_retrieval.rs
@@ -1,0 +1,469 @@
+//! Bridge retrieval pipeline for semantic expansion.
+//!
+//! Provides a query pipeline that expands queries through the concept graph
+//! and combines deterministic HDC recall with concept-expanded results.
+
+// Casts are intentional for bridge score math
+#![allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+
+use crate::retrieval::hybrid::normalize_scores;
+use crate::semantic_bridge::{
+    BridgeConfig, BridgeHit, ConceptGraph, MemoryPacket, ScoreBreakdown, SemanticReranker,
+};
+use crate::singularity::Singularity;
+use csm_core::encoder::TextEncoder;
+use csm_core::error::Result;
+use csm_core::hyperdim::HVec10240;
+
+/// Bridge retrieval orchestrator combining concept expansion with HDC recall.
+#[derive(Debug, Clone)]
+pub struct BridgeRetrieval {
+    /// Text encoder for query normalization.
+    encoder: TextEncoder,
+    /// Concept graph for semantic expansion.
+    concept_graph: ConceptGraph,
+    /// Configuration for retrieval behavior.
+    config: BridgeConfig,
+}
+
+impl BridgeRetrieval {
+    /// Create a new bridge retrieval pipeline.
+    pub const fn new(
+        encoder: TextEncoder,
+        concept_graph: ConceptGraph,
+        config: BridgeConfig,
+    ) -> Self {
+        Self {
+            encoder,
+            concept_graph,
+            config,
+        }
+    }
+
+    /// Create with default configuration.
+    pub fn with_defaults(encoder: TextEncoder, concept_graph: ConceptGraph) -> Self {
+        Self::new(encoder, concept_graph, BridgeConfig::default())
+    }
+
+    /// Execute the full bridge retrieval pipeline.
+    ///
+    /// Pipeline steps:
+    /// 1. Normalize and encode query
+    /// 2. First recall: deterministic HDC similarity
+    /// 3. Concept expansion via graph matching
+    /// 4. Second recall: expanded query vector
+    /// 5. Merge and score with breakdown
+    /// 6. Optional reranking
+    pub fn query(
+        &self,
+        ns: &str,
+        singularity: &Singularity,
+        query_text: &str,
+        top_k: usize,
+        reranker: Option<&dyn SemanticReranker>,
+    ) -> Result<Vec<BridgeHit>> {
+        if top_k == 0 || singularity.is_empty(ns) {
+            return Ok(Vec::new());
+        }
+
+        // Step 1: Normalize and encode primary query
+        let tokens = TextEncoder::tokenize(query_text, self.encoder.config().code_aware, true);
+        let query_hv = self.encoder.encode(query_text);
+
+        // Step 2: First recall - deterministic HDC scores
+        let primary_results = singularity.find_similar(ns, &query_hv, top_k);
+        let primary_normalized = normalize_scores(&primary_results);
+
+        // Step 3: Concept expansion
+        let matched_ids = self.concept_graph.match_tokens(&tokens);
+        let expanded_labels = self
+            .concept_graph
+            .expand(&matched_ids, self.config.max_expansion_depth);
+
+        // Step 4: Encode expanded labels for second recall (if any matches)
+        let expanded_results = if expanded_labels.is_empty() {
+            Vec::new()
+        } else {
+            // Bundle expanded label vectors
+            let label_hvs: Vec<HVec10240> = expanded_labels
+                .iter()
+                .map(|label| self.encoder.encode(label))
+                .collect();
+
+            let expanded_hv = HVec10240::bundle(&label_hvs).unwrap_or_else(|_| HVec10240::zero());
+            let results = singularity.find_similar(ns, &expanded_hv, top_k);
+            normalize_scores(&results)
+        };
+
+        // Step 5: Merge results with score breakdown
+        let mut hits = self.merge_with_breakdown(&primary_normalized, &expanded_results);
+
+        // Step 6: Optional reranking (never mutates deterministic scores)
+        if let Some(reranker) = reranker {
+            reranker.rerank(query_text, &mut hits);
+        }
+
+        // Compute final scores using configurable weights
+        for hit in &mut hits {
+            hit.scores.final_score = self.compute_final_score(&hit.scores);
+        }
+
+        // Sort by final score and truncate
+        hits.sort_by(|a, b| b.scores.final_score.total_cmp(&a.scores.final_score));
+        hits.truncate(top_k);
+
+        Ok(hits)
+    }
+
+    /// Compile a memory packet from query results.
+    ///
+    /// Calls `query()` then compiles hits into a compressed packet
+    /// suitable for LLM context injection.
+    pub fn memory_packet(
+        &self,
+        ns: &str,
+        singularity: &Singularity,
+        query_text: &str,
+        top_k: usize,
+        reranker: Option<&dyn SemanticReranker>,
+    ) -> Result<MemoryPacket> {
+        let hits = self.query(ns, singularity, query_text, top_k, reranker)?;
+        self.compile_packet(ns, query_text, &hits, singularity)
+    }
+
+    /// Merge primary and expanded results with score breakdown.
+    fn merge_with_breakdown(
+        &self,
+        primary: &[(String, f32)],
+        expanded: &[(String, f32)],
+    ) -> Vec<BridgeHit> {
+        use std::collections::HashMap;
+
+        let mut hit_map: HashMap<String, BridgeHit> = HashMap::new();
+
+        // Process primary results (deterministic scores)
+        for (id, score) in primary {
+            hit_map.insert(
+                id.clone(),
+                BridgeHit {
+                    id: id.clone(),
+                    text_preview: None,
+                    scores: ScoreBreakdown {
+                        deterministic: *score,
+                        concept: 0.0,
+                        semantic: 0.0,
+                        final_score: 0.0,
+                        evidence: vec!["deterministic_recall".to_string()],
+                    },
+                },
+            );
+        }
+
+        // Process expanded results (concept scores)
+        for (id, score) in expanded {
+            if let Some(hit) = hit_map.get_mut(id) {
+                // Boost existing hit's concept score
+                hit.scores.concept = hit.scores.concept.max(*score);
+                hit.scores.evidence.push("concept_expansion".to_string());
+            } else {
+                // New hit from expansion only
+                hit_map.insert(
+                    id.clone(),
+                    BridgeHit {
+                        id: id.clone(),
+                        text_preview: None,
+                        scores: ScoreBreakdown {
+                            deterministic: 0.0,
+                            concept: *score,
+                            semantic: 0.0,
+                            final_score: 0.0,
+                            evidence: vec!["concept_expansion".to_string()],
+                        },
+                    },
+                );
+            }
+        }
+
+        hit_map.into_values().collect()
+    }
+
+    /// Compute final score from breakdown using configurable weights.
+    fn compute_final_score(&self, scores: &ScoreBreakdown) -> f32 {
+        self.config.deterministic_weight * scores.deterministic
+            + self.config.concept_weight * scores.concept
+            + self.config.semantic_weight * scores.semantic
+    }
+
+    /// Compile hits into a memory packet with token budget.
+    fn compile_packet(
+        &self,
+        ns: &str,
+        query_text: &str,
+        hits: &[BridgeHit],
+        singularity: &Singularity,
+    ) -> Result<MemoryPacket> {
+        // Extract facts from hits
+        let mut facts: Vec<(String, f32)> = Vec::new();
+        let mut sources: Vec<String> = Vec::new();
+
+        for hit in hits {
+            // Get concept for text preview
+            if let Some(concept) = singularity.get(ns, &hit.id) {
+                // Extract text from metadata or use ID
+                let text = concept
+                    .metadata
+                    .get("_text")
+                    .and_then(|v| v.as_str())
+                    .map_or_else(|| hit.id.clone(), |s| s.to_string());
+
+                facts.push((text, hit.scores.final_score));
+                sources.push(hit.id.clone());
+            }
+        }
+
+        // Deduplicate facts (exact match)
+        let mut unique_facts: Vec<String> = Vec::new();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for (text, _score) in &facts {
+            if !seen.contains(text) {
+                seen.insert(text.clone());
+                unique_facts.push(text.clone());
+            }
+        }
+
+        // Truncate to max_packet_facts
+        unique_facts.truncate(self.config.max_packet_facts);
+
+        // Apply token budget (drop lowest-scored facts)
+        let mut budgeted_facts: Vec<String> = Vec::new();
+        let mut token_count = 0;
+        for text in unique_facts {
+            let estimated = (text.split_whitespace().count() as f32 / 0.75).ceil() as usize;
+            if token_count + estimated <= self.config.token_budget {
+                budgeted_facts.push(text);
+                token_count += estimated;
+            }
+        }
+
+        // Compute confidence from top-k final_scores
+        let confidence = if hits.is_empty() {
+            0.0
+        } else {
+            let top_scores: Vec<f32> = hits
+                .iter()
+                .take(self.config.max_packet_facts)
+                .map(|h| h.scores.final_score)
+                .collect();
+            top_scores.iter().sum::<f32>() / top_scores.len() as f32
+        };
+
+        Ok(MemoryPacket {
+            query_intent: query_text.to_string(),
+            facts: budgeted_facts,
+            sources,
+            confidence,
+        })
+    }
+
+    /// Get the underlying concept graph.
+    pub const fn concept_graph(&self) -> &ConceptGraph {
+        &self.concept_graph
+    }
+
+    /// Get the underlying encoder.
+    pub const fn encoder(&self) -> &TextEncoder {
+        &self.encoder
+    }
+
+    /// Get the configuration.
+    pub const fn config(&self) -> &BridgeConfig {
+        &self.config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Exact float comparisons for score test assertions
+
+    use super::*;
+    use crate::semantic_bridge::CanonicalConcept;
+    use crate::singularity::{Singularity, SingularityConfig};
+
+    #[test]
+    fn test_bridge_retrieval_empty_singularity() {
+        let encoder = TextEncoder::new();
+        let graph = ConceptGraph::new();
+        let bridge = BridgeRetrieval::with_defaults(encoder, graph);
+        let singularity = Singularity::new(SingularityConfig::default());
+
+        let results = bridge
+            .query("_default", &singularity, "test query", 10, None)
+            .unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_bridge_retrieval_empty_graph() {
+        let encoder = TextEncoder::new();
+        let graph = ConceptGraph::new();
+        let bridge = BridgeRetrieval::with_defaults(encoder.clone(), graph);
+
+        let mut singularity = Singularity::new(SingularityConfig::default());
+        let concept = crate::singularity::ConceptBuilder::new("test-concept")
+            .with_vector(encoder.encode("test content"))
+            .build()
+            .unwrap();
+        singularity.inject("_default", concept).unwrap();
+
+        let results = bridge
+            .query("_default", &singularity, "test query", 10, None)
+            .unwrap();
+        // Should return deterministic results even without graph expansion
+        assert!(!results.is_empty());
+        assert!(results[0].scores.deterministic > 0.0);
+        assert!((results[0].scores.concept).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_bridge_retrieval_with_expansion() {
+        let encoder = TextEncoder::new();
+        let mut graph = ConceptGraph::new();
+
+        // Add canonical concept with label matching query
+        graph.add_concept(
+            CanonicalConcept::new("c1")
+                .with_label("agent-memory")
+                .with_label("session-context"),
+        );
+
+        let bridge = BridgeRetrieval::with_defaults(encoder.clone(), graph);
+
+        let mut singularity = Singularity::new(SingularityConfig::default());
+        let concept = crate::singularity::ConceptBuilder::new("mem-1")
+            .with_vector(encoder.encode("session context for AI agent"))
+            .build()
+            .unwrap();
+        singularity.inject("_default", concept).unwrap();
+
+        let results = bridge
+            .query("_default", &singularity, "agent memory session", 10, None)
+            .unwrap();
+
+        assert!(!results.is_empty());
+        // Check that expansion added concept score evidence
+        assert!(
+            results[0]
+                .scores
+                .evidence
+                .contains(&"deterministic_recall".to_string())
+        );
+    }
+
+    #[test]
+    fn test_memory_packet_empty_hits() {
+        let encoder = TextEncoder::new();
+        let graph = ConceptGraph::new();
+        let bridge = BridgeRetrieval::with_defaults(encoder, graph);
+        let singularity = Singularity::new(SingularityConfig::default());
+
+        let packet = bridge
+            .memory_packet("_default", &singularity, "test query", 10, None)
+            .unwrap();
+        assert!(packet.facts.is_empty());
+        assert!(packet.sources.is_empty());
+        assert!((packet.confidence).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_final_score_weights() {
+        let config = BridgeConfig {
+            deterministic_weight: 0.6,
+            concept_weight: 0.3,
+            semantic_weight: 0.1,
+            ..Default::default()
+        };
+
+        let encoder = TextEncoder::new();
+        let graph = ConceptGraph::new();
+        let bridge = BridgeRetrieval::new(encoder, graph, config);
+
+        let scores = ScoreBreakdown {
+            deterministic: 1.0,
+            concept: 1.0,
+            semantic: 1.0,
+            final_score: 0.0,
+            evidence: vec!["test".to_string()],
+        };
+
+        let final_score = bridge.compute_final_score(&scores);
+        assert!((final_score - 1.0).abs() < 1e-6); // All weights sum to 1.0
+    }
+
+    /// Kills compute_final_score -> 1.0 mutant: partial scores must NOT yield 1.0.
+    #[test]
+    fn test_final_score_partial_deterministic_only() {
+        let config = BridgeConfig {
+            deterministic_weight: 0.6,
+            concept_weight: 0.3,
+            semantic_weight: 0.1,
+            ..Default::default()
+        };
+        let bridge = BridgeRetrieval::new(TextEncoder::new(), ConceptGraph::new(), config);
+        let scores = ScoreBreakdown {
+            deterministic: 0.5,
+            concept: 0.0,
+            semantic: 0.0,
+            final_score: 0.0,
+            evidence: vec![],
+        };
+        // 0.6 * 0.5 = 0.3, not 1.0
+        let final_score = bridge.compute_final_score(&scores);
+        assert!(
+            (final_score - 0.3).abs() < 1e-5,
+            "expected 0.3, got {final_score}"
+        );
+    }
+
+    /// Kills query `||` -> `&&` mutant: top_k == 0 with non-empty singularity must return empty.
+    #[test]
+    fn test_query_top_k_zero_returns_empty() {
+        let encoder = TextEncoder::new();
+        let bridge = BridgeRetrieval::with_defaults(encoder.clone(), ConceptGraph::new());
+        let mut singularity = Singularity::new(SingularityConfig::default());
+        let concept = crate::singularity::ConceptBuilder::new("c1")
+            .with_vector(encoder.encode("hello world"))
+            .build()
+            .unwrap();
+        singularity.inject("_default", concept).unwrap();
+        // top_k == 0 must short-circuit even when singularity is non-empty
+        let results = bridge
+            .query("_default", &singularity, "hello", 0, None)
+            .unwrap();
+        assert!(results.is_empty(), "top_k=0 must yield empty results");
+    }
+}
+
+#[cfg(test)]
+mod tests_v2 {
+    use super::*;
+    use crate::singularity::{ConceptBuilder, Singularity, SingularityConfig};
+    use csm_core::hyperdim::HVec10240;
+
+    #[test]
+    fn test_bridge_retrieval_query_v2() {
+        let mut singularity = Singularity::new(SingularityConfig::default());
+        let concept = ConceptBuilder::new("c1")
+            .with_vector(HVec10240::random())
+            .build()
+            .unwrap();
+        singularity.inject("_default", concept).unwrap();
+
+        let bridge = BridgeRetrieval::new(
+            TextEncoder::new(),
+            ConceptGraph::new(),
+            BridgeConfig::default(),
+        );
+        let results = bridge.query("_default", &singularity, "test", 10, None);
+        assert!(results.is_ok());
+    }
+}

--- a/crates/csm-retrieval/src/framework_graph_rag.rs
+++ b/crates/csm-retrieval/src/framework_graph_rag.rs
@@ -1,0 +1,80 @@
+//! GraphRAG retrieval extension for framework.
+
+use crate::framework::ChaoticSemanticFramework;
+use crate::retrieval::{GraphRagConfig, GraphRagResult, graph_rag_retrieve};
+use csm_core::error::Result;
+use csm_core::hyperdim::HVec10240;
+use tracing::instrument;
+
+impl ChaoticSemanticFramework {
+    /// GraphRAG retrieval: similarity + graph traversal hybrid.
+    ///
+    /// Combines vector similarity with graph traversal for unified retrieval:
+    /// 1. Anchor: probe(query, anchor_top_k) → seed set
+    /// 2. Expand: traverse from each anchor
+    /// 3. Score: similarity_weight * cosine + graph_weight * (1/(1+hops)) * strength
+    /// 4. Dedupe + rank by score
+    #[instrument(err, skip(self, query, config))]
+    // Lock needed for concept and association access
+    pub async fn probe_with_graph(
+        &self,
+        query: HVec10240,
+        config: GraphRagConfig,
+    ) -> Result<Vec<GraphRagResult>> {
+        self.validate_top_k(config.anchor_top_k)?;
+        self.validate_top_k(config.final_top_k)?;
+
+        let (concepts, associations) = {
+            let sing = self.singularity.read().await;
+            let ns = self.namespace.read().await;
+            (sing.all_concepts(&ns), sing.all_associations(&ns))
+        };
+
+        graph_rag_retrieve(&query, &concepts, &associations, &config)
+    }
+
+    /// GraphRAG retrieval using configured embedding provider for text query.
+    #[instrument(err, skip(self, text, config))]
+    pub async fn probe_text_with_graph(
+        &self,
+        text: &str,
+        config: GraphRagConfig,
+    ) -> Result<Vec<GraphRagResult>> {
+        let embedding = self.embedding_provider.embed(text).await?;
+        let query = self
+            .embedding_provider
+            .project(&embedding, &self.projection);
+        self.probe_with_graph(query, config).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn probe_with_graph_returns_relevant_results() {
+        let fw = ChaoticSemanticFramework::builder()
+            .without_persistence()
+            .build()
+            .await
+            .unwrap();
+        let vector = HVec10240::random();
+        fw.inject_concept("graph".to_string(), vector)
+            .await
+            .unwrap();
+        let config = GraphRagConfig {
+            anchor_top_k: 5,
+            max_hops: 2,
+            min_assoc_strength: 0.1,
+            similarity_weight: 0.7,
+            graph_weight: 0.3,
+            final_top_k: 5,
+        };
+        let results = fw.probe_with_graph(vector, config).await.unwrap();
+        assert!(
+            !results.is_empty(),
+            "probe_with_graph must return at least one result"
+        );
+    }
+}

--- a/crates/csm-retrieval/src/framework_rerank.rs
+++ b/crates/csm-retrieval/src/framework_rerank.rs
@@ -1,0 +1,62 @@
+//! Framework extensions for reranking retrieval results.
+
+use csm_core::error::Result;
+use crate::framework::ChaoticSemanticFramework;
+use csm_core::hyperdim::HVec10240;
+use crate::retrieval::rerank::{RerankCandidate, Reranker};
+use std::sync::Arc;
+use tracing::instrument;
+
+impl ChaoticSemanticFramework {
+    /// Query for similar concepts and apply a pipeline of rerankers.
+    #[instrument(err, skip(self, query, rerankers))]
+    pub async fn probe_with_rerankers(
+        &self,
+        query: HVec10240,
+        initial_top_k: usize,
+        rerankers: &[Box<dyn Reranker>],
+        final_top_k: usize,
+    ) -> Result<Vec<(String, f32)>> {
+        self.validate_top_k(initial_top_k)?;
+        self.validate_top_k(final_top_k)?;
+
+        // ADR-0071: initial_top_k must not be smaller than final_top_k to avoid under-fetching
+        let actual_initial_k = initial_top_k.max(final_top_k);
+
+        // 1. Initial probe
+        let initial_results = self.probe(query, actual_initial_k).await?;
+
+        if rerankers.is_empty() {
+            let mut results = initial_results;
+            results.truncate(final_top_k);
+            return Ok(results);
+        }
+
+        // 2. Fetch full concept data for reranking
+        let mut candidates = Vec::with_capacity(initial_results.len());
+        {
+            let sing = self.singularity.read().await;
+            let ns = self.namespace.read().await;
+            for (id, score) in initial_results {
+                if let Some(concept) = sing.get(&ns, &id) {
+                    candidates.push(RerankCandidate {
+                        id: concept.id.clone(),
+                        vector: Arc::new(concept.vector),
+                        metadata: concept.metadata.clone(),
+                        score,
+                        created_at_unix: concept.created_at,
+                    });
+                }
+            }
+        }
+
+        // 3. Apply rerankers in sequence
+        for reranker in rerankers {
+            candidates = reranker.rerank(&query, candidates, actual_initial_k);
+        }
+
+        // 4. Truncate and format final results
+        candidates.truncate(final_top_k);
+        Ok(candidates.into_iter().map(|c| (c.id, c.score)).collect())
+    }
+}

--- a/crates/csm-retrieval/src/graph_rag.rs
+++ b/crates/csm-retrieval/src/graph_rag.rs
@@ -1,0 +1,237 @@
+#![allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+//! GraphRAG Hybrid Retrieval (ADR-0070)
+//!
+//! Combines vector similarity with graph traversal for unified retrieval.
+
+// Casts are intentional for scoring formula
+
+use csm_core::error::Result;
+use csm_core::hyperdim::HVec10240;
+use csm_memory::{Concept, TraversalConfig};
+use std::collections::{HashMap, HashSet, VecDeque};
+
+/// Configuration for GraphRAG retrieval.
+#[derive(Debug, Clone)]
+pub struct GraphRagConfig {
+    /// Number of anchor concepts from initial probe.
+    pub anchor_top_k: usize,
+    /// Maximum hops to traverse from each anchor.
+    pub max_hops: usize,
+    /// Minimum association strength to follow.
+    pub min_assoc_strength: f32,
+    /// Weight for similarity score component (0.0-1.0).
+    pub similarity_weight: f32,
+    /// Weight for graph distance component (0.0-1.0).
+    pub graph_weight: f32,
+    /// Final top-K results to return.
+    pub final_top_k: usize,
+}
+
+impl Default for GraphRagConfig {
+    fn default() -> Self {
+        Self {
+            anchor_top_k: 5,
+            max_hops: 2,
+            min_assoc_strength: 0.0,
+            similarity_weight: 0.6,
+            graph_weight: 0.4,
+            final_top_k: 20,
+        }
+    }
+}
+
+/// Result from GraphRAG retrieval.
+#[derive(Debug, Clone)]
+pub struct GraphRagResult {
+    /// Concept ID.
+    pub id: String,
+    /// Combined score (similarity + graph).
+    pub score: f32,
+    /// Raw cosine similarity to query.
+    pub similarity: f32,
+    /// Anchor concept that reached this result.
+    pub anchor_id: Option<String>,
+    /// Hop distance from anchor (0 = anchor itself).
+    pub hop_distance: usize,
+    /// Association strength along path.
+    pub assoc_strength: f32,
+}
+
+/// Internal candidate during GraphRAG expansion.
+#[derive(Debug, Clone)]
+struct Candidate {
+    id: String,
+    anchor_id: String,
+    hop_distance: usize,
+    path_strength: f32,
+}
+
+/// Execute GraphRAG retrieval.
+pub fn graph_rag_retrieve(
+    query: &HVec10240,
+    concepts: &[Concept],
+    associations: &[(String, String, f32)],
+    config: &GraphRagConfig,
+) -> Result<Vec<GraphRagResult>> {
+    if concepts.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let concept_map: HashMap<String, &Concept> =
+        concepts.iter().map(|c| (c.id.clone(), c)).collect();
+
+    let assoc_map: HashMap<String, Vec<(String, f32)>> = {
+        let mut map: HashMap<String, Vec<(String, f32)>> = HashMap::new();
+        for (from, to, strength) in associations {
+            map.entry(from.clone())
+                .or_default()
+                .push((to.clone(), *strength));
+        }
+        map
+    };
+
+    let anchors = find_anchors(query, &concept_map, config.anchor_top_k);
+    let mut candidates: Vec<Candidate> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+
+    for (anchor_id, _anchor_sim) in &anchors {
+        seen.insert(anchor_id.clone());
+        candidates.push(Candidate {
+            id: anchor_id.clone(),
+            anchor_id: anchor_id.clone(),
+            hop_distance: 0,
+            path_strength: 1.0,
+        });
+
+        let traversal_config = TraversalConfig {
+            max_depth: config.max_hops,
+            min_strength: config.min_assoc_strength,
+            max_results: 1000,
+        };
+
+        let traversed = traverse_from(anchor_id, &assoc_map, &traversal_config);
+
+        for (node_id, hop, path_strength) in traversed {
+            if seen.contains(&node_id) {
+                continue;
+            }
+            seen.insert(node_id.clone());
+
+            candidates.push(Candidate {
+                id: node_id,
+                anchor_id: anchor_id.clone(),
+                hop_distance: hop,
+                path_strength,
+            });
+        }
+    }
+
+    let mut best_by_id: HashMap<String, GraphRagResult> = HashMap::new();
+
+    for candidate in &candidates {
+        let concept = match concept_map.get(&candidate.id) {
+            Some(c) => c,
+            None => continue,
+        };
+
+        let similarity = query.cosine_similarity(&concept.vector);
+        let graph_score = config.graph_weight
+            * (1.0 / (1.0 + candidate.hop_distance as f32))
+            * candidate.path_strength;
+        let sim_score = config.similarity_weight * similarity;
+        let combined = sim_score + graph_score;
+
+        let result = GraphRagResult {
+            id: candidate.id.clone(),
+            score: combined,
+            similarity,
+            anchor_id: Some(candidate.anchor_id.clone()),
+            hop_distance: candidate.hop_distance,
+            assoc_strength: candidate.path_strength,
+        };
+        if best_by_id
+            .get(&candidate.id)
+            .is_none_or(|e| e.score < combined)
+        {
+            best_by_id.insert(candidate.id.clone(), result);
+        }
+    }
+
+    let mut results: Vec<GraphRagResult> = best_by_id.values().cloned().collect();
+    results.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    results.truncate(config.final_top_k);
+
+    Ok(results)
+}
+
+/// Find anchor concepts via brute-force similarity.
+fn find_anchors(
+    query: &HVec10240,
+    concepts: &HashMap<String, &Concept>,
+    top_k: usize,
+) -> Vec<(String, f32)> {
+    let mut scored: Vec<(String, f32)> = concepts
+        .iter()
+        .map(|(id, c)| (id.clone(), query.cosine_similarity(&c.vector)))
+        .collect();
+
+    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    scored.truncate(top_k);
+    scored
+}
+
+/// BFS traverse from a starting concept.
+///
+/// Re-visits nodes if a path with a higher graph score (strength / (1 + hops)) is found.
+fn traverse_from(
+    start: &str,
+    associations: &HashMap<String, Vec<(String, f32)>>,
+    config: &TraversalConfig,
+) -> Vec<(String, usize, f32)> {
+    // Map of node_id -> (depth, path_strength, graph_score)
+    let mut best_paths: HashMap<String, (usize, f32, f32)> = HashMap::new();
+    let mut queue: VecDeque<(String, usize, f32)> = VecDeque::new();
+
+    queue.push_back((start.to_string(), 0, 1.0));
+    best_paths.insert(start.to_string(), (0, 1.0, 1.0));
+
+    while let Some((current, depth, path_strength)) = queue.pop_front() {
+        if depth >= config.max_depth {
+            continue;
+        }
+
+        if let Some(edges) = associations.get(&current) {
+            for (neighbor, strength) in edges {
+                if *strength < config.min_strength {
+                    continue;
+                }
+
+                let new_depth = depth + 1;
+                let new_strength = path_strength.min(*strength);
+                let new_graph_score = new_strength / (1.0 + new_depth as f32);
+
+                let is_better = if let Some(&(_, _, prev_score)) = best_paths.get(neighbor) {
+                    new_graph_score > prev_score
+                } else {
+                    // Start node is in best_paths but not in results
+                    (best_paths.len() - 1) < config.max_results
+                };
+
+                if is_better {
+                    best_paths.insert(neighbor.clone(), (new_depth, new_strength, new_graph_score));
+                    queue.push_back((neighbor.clone(), new_depth, new_strength));
+                }
+            }
+        }
+    }
+
+    best_paths
+        .into_iter()
+        .filter(|(id, _)| id != start)
+        .map(|(id, (depth, strength, _))| (id, depth, strength))
+        .collect()
+}

--- a/crates/csm-retrieval/src/hybrid.rs
+++ b/crates/csm-retrieval/src/hybrid.rs
@@ -1,0 +1,245 @@
+//! Hybrid retrieval combining BM25 and HDC scores.
+//!
+//! Provides query-length-dependent weighting between keyword (BM25) and
+//! semantic (HDC) search results.
+
+use std::collections::HashMap;
+
+/// Compute query-length-dependent weights for hybrid retrieval.
+///
+/// Returns (keyword_weight, semantic_weight) based on token count.
+///
+/// | Query Tokens | Keyword | Semantic | Rationale |
+/// |-------------|---------|----------|-----------|
+/// | 1-2 | 0.9 | 0.1 | Exact match dominates |
+/// | 3-4 | 0.7 | 0.3 | Keyword still strong |
+/// | 5-8 | 0.4 | 0.6 | Semantic takes over |
+/// | 9+ | 0.2 | 0.8 | Full semantic mode |
+#[allow(dead_code)]
+pub const fn compute_weights(token_count: usize) -> (f32, f32) {
+    match token_count {
+        1..=2 => (0.9, 0.1),
+        3..=4 => (0.7, 0.3),
+        5..=8 => (0.4, 0.6),
+        _ => (0.2, 0.8),
+    }
+}
+
+/// Normalize scores to [0, 1] range using min-max normalization.
+///
+/// If all scores are equal, returns 0.5 for all.
+pub fn normalize_scores(scores: &[(String, f32)]) -> Vec<(String, f32)> {
+    if scores.is_empty() {
+        return Vec::new();
+    }
+
+    let min = scores.iter().map(|(_, s)| *s).fold(f32::INFINITY, f32::min);
+    let max = scores
+        .iter()
+        .map(|(_, s)| *s)
+        .fold(f32::NEG_INFINITY, f32::max);
+
+    let range = max - min;
+    let epsilon = 1e-10;
+
+    if range < epsilon {
+        return scores.iter().map(|(id, _)| (id.clone(), 1.0)).collect();
+    }
+
+    scores
+        .iter()
+        .map(|(id, score)| {
+            let normalized = (score - min) / range;
+            (id.clone(), normalized)
+        })
+        .collect()
+}
+
+/// Merge BM25 and HDC results with given weights.
+///
+/// Takes two result sets (from BM25 and HDC), normalizes scores,
+/// and combines them using weighted sum.
+///
+/// Duplicate IDs are merged by taking the maximum combined score.
+pub fn merge_results(
+    bm25_results: &[(String, f32)],
+    hdc_results: &[(String, f32)],
+    weights: (f32, f32),
+) -> Vec<(String, f32)> {
+    let (kw_weight, sem_weight) = weights;
+
+    // Normalize both result sets
+    let bm25_normalized = normalize_scores(bm25_results);
+    let hdc_normalized = normalize_scores(hdc_results);
+
+    // Build score map
+    let mut combined: HashMap<String, f32> = HashMap::new();
+
+    for (id, score) in &bm25_normalized {
+        let entry = combined.entry(id.clone()).or_insert(0.0);
+        *entry += kw_weight * score;
+    }
+
+    for (id, score) in &hdc_normalized {
+        let entry = combined.entry(id.clone()).or_insert(0.0);
+        *entry += sem_weight * score;
+    }
+
+    // Sort by combined score descending
+    let mut results: Vec<(String, f32)> = combined.into_iter().collect();
+    results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    results
+}
+
+/// Hybrid retrieval mode.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum HybridMode {
+    /// Auto-weight by query length (default).
+    #[default]
+    Auto,
+    /// Force semantic-only (HDC).
+    SemanticOnly,
+    /// Force keyword-only (BM25).
+    KeywordOnly,
+    /// Custom weight override.
+    Custom(f32),
+}
+
+/// Configuration for hybrid retrieval.
+#[derive(Debug, Clone)]
+pub struct HybridConfig {
+    /// Hybrid mode.
+    pub mode: HybridMode,
+    /// Minimum score threshold (0.0-1.0).
+    pub min_score: f32,
+}
+
+impl Default for HybridConfig {
+    fn default() -> Self {
+        Self {
+            mode: HybridMode::Auto,
+            min_score: 0.0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Exact float comparisons for weight test assertions
+
+    use super::*;
+
+    #[test]
+    fn test_compute_weights_short_query() {
+        let (kw, sem) = compute_weights(1);
+        assert!((kw - (0.9)).abs() < 1e-6);
+        assert!((sem - (0.1)).abs() < 1e-6);
+
+        let (kw, sem) = compute_weights(2);
+        assert!((kw - (0.9)).abs() < 1e-6);
+        assert!((sem - (0.1)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_compute_weights_medium_query() {
+        let (kw, sem) = compute_weights(3);
+        assert!((kw - (0.7)).abs() < 1e-6);
+        assert!((sem - (0.3)).abs() < 1e-6);
+
+        let (kw, sem) = compute_weights(4);
+        assert!((kw - (0.7)).abs() < 1e-6);
+        assert!((sem - (0.3)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_compute_weights_long_query() {
+        let (kw, sem) = compute_weights(5);
+        assert!((kw - (0.4)).abs() < 1e-6);
+        assert!((sem - (0.6)).abs() < 1e-6);
+
+        let (kw, sem) = compute_weights(8);
+        assert!((kw - (0.4)).abs() < 1e-6);
+        assert!((sem - (0.6)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_compute_weights_very_long_query() {
+        let (kw, sem) = compute_weights(9);
+        assert!((kw - (0.2)).abs() < 1e-6);
+        assert!((sem - (0.8)).abs() < 1e-6);
+
+        let (kw, sem) = compute_weights(100);
+        assert!((kw - (0.2)).abs() < 1e-6);
+        assert!((sem - (0.8)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_normalize_scores_basic() {
+        let scores = vec![
+            ("a".to_string(), 0.0),
+            ("b".to_string(), 0.5),
+            ("c".to_string(), 1.0),
+        ];
+        let normalized = normalize_scores(&scores);
+
+        assert!((normalized[0].1 - 0.0).abs() < 1e-6);
+        assert!((normalized[1].1 - 0.5).abs() < 1e-6);
+        assert!((normalized[2].1 - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_normalize_scores_empty() {
+        let normalized = normalize_scores(&[]);
+        assert!(normalized.is_empty());
+    }
+
+    #[test]
+    fn test_normalize_scores_equal() {
+        let scores = vec![("a".to_string(), 5.0), ("b".to_string(), 5.0)];
+        let normalized = normalize_scores(&scores);
+
+        // All equal scores should normalize to 1.0
+        assert!((normalized[0].1 - 1.0).abs() < 1e-6);
+        assert!((normalized[1].1 - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_merge_results_basic() {
+        let bm25 = vec![("doc1".to_string(), 1.0), ("doc2".to_string(), 0.5)];
+        let hdc = vec![("doc1".to_string(), 0.5), ("doc3".to_string(), 1.0)];
+
+        let merged = merge_results(&bm25, &hdc, (0.5, 0.5));
+
+        // doc1 appears in both
+        assert!(merged.iter().any(|(id, _)| id == "doc1"));
+        // doc2 only in BM25
+        assert!(merged.iter().any(|(id, _)| id == "doc2"));
+        // doc3 only in HDC
+        assert!(merged.iter().any(|(id, _)| id == "doc3"));
+    }
+
+    #[test]
+    fn test_merge_results_weighted() {
+        let bm25 = vec![("doc1".to_string(), 1.0)];
+        let hdc = vec![("doc1".to_string(), 1.0)];
+
+        // With heavy keyword weight, BM25 should dominate
+        let merged = merge_results(&bm25, &hdc, (0.9, 0.1));
+
+        // doc1 should have combined score
+        assert!(merged.iter().any(|(id, s)| id == "doc1" && *s > 0.0));
+    }
+
+    #[test]
+    fn test_merge_results_empty() {
+        let merged = merge_results(&[], &[], (0.5, 0.5));
+        assert!(merged.is_empty());
+
+        let merged = merge_results(&[("a".to_string(), 1.0)], &[], (0.5, 0.5));
+        assert_eq!(merged.len(), 1);
+
+        let merged = merge_results(&[], &[("a".to_string(), 1.0)], (0.5, 0.5));
+        assert_eq!(merged.len(), 1);
+    }
+}

--- a/crates/csm-retrieval/src/lib.rs
+++ b/crates/csm-retrieval/src/lib.rs
@@ -1,0 +1,20 @@
+//! Retrieval backends for chaotic_semantic_memory.
+//!
+//! This crate provides:
+//! - BM25 keyword search
+//! - Hybrid retrieval (combining semantic and keyword)
+//! - GraphRAG retrieval
+//! - Reranking with MMR and recency decay
+
+mod bm25;
+mod graph_rag;
+mod hybrid;
+mod rerank;
+
+pub use bm25::{Bm25Config, Bm25Index};
+pub use graph_rag::{GraphRagConfig, GraphRagResult, graph_rag_retrieve};
+pub use hybrid::{HybridConfig, HybridMode, merge_results, normalize_scores};
+pub use rerank::{MmrReranker, RecencyDecayReranker, RerankCandidate, Reranker, parse_rerankers};
+
+#[cfg(feature = "rerank-cross")]
+pub use rerank::CrossEncoderReranker;

--- a/crates/csm-retrieval/src/mod.rs
+++ b/crates/csm-retrieval/src/mod.rs
@@ -1,0 +1,18 @@
+//! Retrieval modules for hybrid search.
+//!
+//! This crate supports hybrid retrieval combining:
+//! - **BM25**: Keyword/exact matching for short queries
+//! - **HDC**: Semantic similarity for natural language queries
+//! - **GraphRAG**: Graph traversal + similarity for graph-heavy memory
+//!
+//! The hybrid approach uses query-length-dependent weighting:
+//! - Short queries (1-2 tokens): 90% keyword, 10% semantic
+//! - Long queries (9+ tokens): 20% keyword, 80% semantic
+
+pub mod bm25;
+pub mod graph_rag;
+pub mod hybrid;
+
+pub use bm25::{Bm25Config, Bm25Index};
+pub use graph_rag::{GraphRagConfig, GraphRagResult, graph_rag_retrieve};
+pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores};

--- a/crates/csm-retrieval/src/rerank.rs
+++ b/crates/csm-retrieval/src/rerank.rs
@@ -1,0 +1,375 @@
+#![allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+use csm_core::hyperdim::HVec10240;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// A candidate for reranking.
+#[derive(Debug, Clone)]
+pub struct RerankCandidate {
+    /// Unique identifier for the concept.
+    pub id: String,
+    /// Hypervector representation.
+    pub vector: Arc<HVec10240>,
+    /// Associated metadata.
+    pub metadata: HashMap<String, serde_json::Value>,
+    /// Retrieval score (initially cosine similarity).
+    pub score: f32,
+    /// Creation timestamp in Unix seconds.
+    pub created_at_unix: u64,
+}
+
+/// Trait for reranking retrieval results.
+pub trait Reranker: Send + Sync + std::fmt::Debug {
+    /// Returns the name of the reranker.
+    fn name(&self) -> &str;
+
+    /// Reranks the candidates based on the query and existing scores.
+    fn rerank(
+        &self,
+        query: &HVec10240,
+        candidates: Vec<RerankCandidate>,
+        top_k: usize,
+    ) -> Vec<RerankCandidate>;
+}
+
+/// Maximal Marginal Relevance (MMR) reranker for diversity.
+#[derive(Debug)]
+pub struct MmrReranker {
+    /// Diversity vs similarity trade-off (0.0 = full diversity, 1.0 = pure similarity).
+    pub lambda: f32,
+}
+
+impl Reranker for MmrReranker {
+    fn name(&self) -> &str {
+        "mmr"
+    }
+
+    fn rerank(
+        &self,
+        query: &HVec10240,
+        mut candidates: Vec<RerankCandidate>,
+        top_k: usize,
+    ) -> Vec<RerankCandidate> {
+        if candidates.is_empty() || top_k == 0 {
+            return Vec::new();
+        }
+
+        let mut selected: Vec<RerankCandidate> = Vec::with_capacity(top_k);
+
+        // Greedily select candidates
+        while selected.len() < top_k && !candidates.is_empty() {
+            let mut best_idx = 0;
+            let mut max_mmr = f32::NEG_INFINITY;
+
+            for (idx, cand) in candidates.iter().enumerate() {
+                let mut max_sim_to_selected = 0.0f32;
+                for sel in &selected {
+                    let sim = cand.vector.cosine_similarity(&sel.vector);
+                    if sim > max_sim_to_selected {
+                        max_sim_to_selected = sim;
+                    }
+                }
+
+                // MMR Formula: lambda * sim(query, cand) - (1 - lambda) * max_sim(cand, selected)
+                let similarity = query.cosine_similarity(&cand.vector);
+                let mmr_score =
+                    self.lambda * similarity - (1.0 - self.lambda) * max_sim_to_selected;
+                if mmr_score > max_mmr {
+                    max_mmr = mmr_score;
+                    best_idx = idx;
+                }
+            }
+
+            let mut best_cand = candidates.remove(best_idx);
+            best_cand.score = max_mmr;
+            selected.push(best_cand);
+        }
+
+        selected
+    }
+}
+
+/// Recency decay reranker to favor newer concepts.
+#[derive(Debug)]
+pub struct RecencyDecayReranker {
+    /// Time period after which weight is halved (in days).
+    pub half_life_days: f32,
+    /// Balance between similarity and recency (0.0 = pure recency, 1.0 = pure similarity).
+    pub blend: f32,
+}
+
+impl Reranker for RecencyDecayReranker {
+    fn name(&self) -> &str {
+        "recency"
+    }
+
+    fn rerank(
+        &self,
+        _query: &HVec10240,
+        mut candidates: Vec<RerankCandidate>,
+        top_k: usize,
+    ) -> Vec<RerankCandidate> {
+        let now = csm_memory::unix_now_secs();
+        let half_life_secs = self.half_life_days * 86400.0;
+
+        for cand in &mut candidates {
+            let age_secs = now.saturating_sub(cand.created_at_unix) as f32;
+            let recency = 0.5f32.powf(age_secs / half_life_secs);
+
+            // blended_score = blend * original_score + (1 - blend) * recency
+            cand.score = self.blend * cand.score + (1.0 - self.blend) * recency;
+        }
+
+        candidates.sort_by(|a, b| b.score.total_cmp(&a.score));
+        candidates.truncate(top_k);
+        candidates
+    }
+}
+
+/// Cross-encoder reranker using ONNX (opt-in).
+#[cfg(feature = "rerank-cross")]
+#[derive(Debug)]
+pub struct CrossEncoderReranker {
+    pub model: Arc<candle_onnx::onnx::ModelProto>,
+    pub model_path: String,
+}
+
+#[cfg(feature = "rerank-cross")]
+impl Reranker for CrossEncoderReranker {
+    fn name(&self) -> &str {
+        "cross-encoder"
+    }
+
+    fn rerank(
+        &self,
+        _query: &HVec10240,
+        candidates: Vec<RerankCandidate>,
+        top_k: usize,
+    ) -> Vec<RerankCandidate> {
+        // Implementation would load and run ONNX model
+        // For now, it's a skeleton that returns candidates as-is
+        let mut results = candidates;
+        results.truncate(top_k);
+        results
+    }
+}
+
+/// Parses a list of rerankers from a string flag (e.g., "mmr:0.7,recency:30d").
+pub fn parse_rerankers(s: &str) -> csm_core::error::Result<Vec<Box<dyn Reranker>>> {
+    let mut rerankers: Vec<Box<dyn Reranker>> = Vec::new();
+    for part in s.split(',') {
+        if part.is_empty() {
+            continue;
+        }
+        let (name, value) = part.split_once(':').unwrap_or((part, ""));
+
+        match name {
+            "mmr" => {
+                let lambda = value.parse::<f32>().map_err(|_| {
+                    csm_core::error::MemoryError::InvalidInput {
+                        field: "rerank".to_string(),
+                        reason: format!("invalid MMR lambda: {}", value),
+                    }
+                })?;
+
+                if !(0.0..=1.0).contains(&lambda) {
+                    return Err(csm_core::error::MemoryError::InvalidInput {
+                        field: "rerank".to_string(),
+                        reason: format!("MMR lambda must be between 0.0 and 1.0: {}", lambda),
+                    });
+                }
+
+                rerankers.push(Box::new(MmrReranker { lambda }));
+            }
+            "recency" => {
+                let mut recency_split = value.split(':');
+                let half_life_str = recency_split.next().unwrap_or("");
+                let val_str = if let Some(stripped) = half_life_str.strip_suffix('d') {
+                    stripped
+                } else {
+                    half_life_str
+                };
+                let half_life = val_str.parse::<f32>().map_err(|_| {
+                    csm_core::error::MemoryError::InvalidInput {
+                        field: "rerank".to_string(),
+                        reason: format!("invalid recency half-life: {}", half_life_str),
+                    }
+                })?;
+
+                if half_life <= 0.0 {
+                    return Err(csm_core::error::MemoryError::InvalidInput {
+                        field: "rerank".to_string(),
+                        reason: format!("recency half-life must be positive: {}", half_life),
+                    });
+                }
+
+                let blend = if let Some(blend_str) = recency_split.next() {
+                    let b = blend_str.parse::<f32>().map_err(|_| {
+                        csm_core::error::MemoryError::InvalidInput {
+                            field: "rerank".to_string(),
+                            reason: format!("invalid recency blend: {}", blend_str),
+                        }
+                    })?;
+                    if !(0.0..=1.0).contains(&b) {
+                        return Err(csm_core::error::MemoryError::InvalidInput {
+                            field: "rerank".to_string(),
+                            reason: format!("recency blend must be between 0.0 and 1.0: {}", b),
+                        });
+                    }
+                    b
+                } else {
+                    0.5
+                };
+
+                if recency_split.next().is_some() {
+                    return Err(csm_core::error::MemoryError::InvalidInput {
+                        field: "rerank".to_string(),
+                        reason: format!("extra segments in recency reranker: {}", value),
+                    });
+                }
+
+                rerankers.push(Box::new(RecencyDecayReranker {
+                    half_life_days: half_life,
+                    blend,
+                }));
+            }
+            #[cfg(feature = "rerank-cross")]
+            "cross" => {
+                let model = candle_onnx::read_file(value).map_err(|e| {
+                    csm_core::error::MemoryError::InvalidInput {
+                        field: "rerank".to_string(),
+                        reason: format!("failed to load ONNX model {}: {}", value, e),
+                    }
+                })?;
+                rerankers.push(Box::new(CrossEncoderReranker {
+                    model: Arc::new(model),
+                    model_path: value.to_string(),
+                }));
+            }
+            _ => {
+                return Err(csm_core::error::MemoryError::InvalidInput {
+                    field: "rerank".to_string(),
+                    reason: format!("unknown reranker: {}", name),
+                });
+            }
+        }
+    }
+    Ok(rerankers)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn create_candidate(id: &str, score: f32, age_days: f32) -> RerankCandidate {
+        let now = csm_memory::unix_now_secs();
+        let created_at_unix = now - (age_days * 86400.0) as u64;
+        RerankCandidate {
+            id: id.to_string(),
+            vector: Arc::new(HVec10240::random()),
+            metadata: HashMap::new(),
+            score,
+            created_at_unix,
+        }
+    }
+
+    #[test]
+    fn test_mmr_reranker() {
+        // Use a zero vector as query for deterministic (and low) similarity
+        let query = HVec10240::zero();
+        // Use seeded vectors for deterministic similarity
+        // v1 will be the anchor
+        let v1 = Arc::new(HVec10240::new_seeded(1));
+        // v2 is identical to v1
+        let v2 = Arc::new(HVec10240::new_seeded(1));
+        // v3 is different
+        let v3 = Arc::new(HVec10240::new_seeded(2));
+
+        let c1 = RerankCandidate {
+            id: "c1".into(),
+            vector: v1,
+            metadata: HashMap::new(),
+            score: 0.9, // Higher initial score
+            created_at_unix: 0,
+        };
+        let c2 = RerankCandidate {
+            id: "c2".into(),
+            vector: v2,
+            metadata: HashMap::new(),
+            score: 0.85,
+            created_at_unix: 0,
+        };
+        let c3 = RerankCandidate {
+            id: "c3".into(),
+            vector: v3,
+            metadata: HashMap::new(),
+            score: 0.7,
+            created_at_unix: 0,
+        };
+
+        // If lambda is 1.0, it should be pure similarity: c1, c2
+        let reranker_sim = MmrReranker { lambda: 1.0 };
+        let results_sim = reranker_sim.rerank(&query, vec![c1.clone(), c2.clone(), c3.clone()], 2);
+        assert_eq!(results_sim[0].id, "c1");
+        assert_eq!(results_sim[1].id, "c2");
+
+        // If lambda is 0.5, diversity should kick in.
+        // Step 1: Selection.
+        // MMR(c1) = 0.5 * sim(query, c1) - 0.5 * 0.0 = 0.5 * sim(query, c1)
+        // MMR(c2) = 0.5 * sim(query, c2)
+        // MMR(c3) = 0.5 * sim(query, c3)
+        // Since sim(query, c1) is highest (initially we use query.cosine_similarity), c1 is selected.
+
+        // Step 2:
+        // MMR(c2) = 0.5 * sim(query, c2) - 0.5 * sim(c2, c1) = 0.5 * sim(query, c2) - 0.5 * 1.0
+        // MMR(c3) = 0.5 * sim(query, c3) - 0.5 * sim(c3, c1)
+        // Since sim(c3, c1) < 1.0, MMR(c3) will be greater than MMR(c2).
+        let reranker = MmrReranker { lambda: 0.5 };
+        let results = reranker.rerank(&query, vec![c1, c2, c3], 2);
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].id, "c1");
+        assert_eq!(results[1].id, "c3");
+    }
+
+    #[test]
+    fn test_recency_reranker() {
+        let query = HVec10240::zero();
+        let c1 = create_candidate("old", 0.9, 10.0); // 10 days old
+        let c2 = create_candidate("new", 0.8, 0.0); // 0 days old
+
+        let reranker = RecencyDecayReranker {
+            half_life_days: 5.0,
+            blend: 0.5,
+        };
+
+        let results = reranker.rerank(&query, vec![c1, c2], 2);
+        assert_eq!(results[0].id, "new");
+    }
+
+    #[test]
+    fn test_parse_rerankers() {
+        let rers = parse_rerankers("mmr:0.7,recency:30d:0.8").unwrap();
+        assert_eq!(rers.len(), 2);
+        assert_eq!(rers[0].name(), "mmr");
+        assert_eq!(rers[1].name(), "recency");
+    }
+
+    #[test]
+    #[cfg(feature = "rerank-cross")]
+    fn test_parse_rerankers_windows_path() {
+        let err = parse_rerankers(r"cross:C:\nonexistent\model.onnx").unwrap_err();
+        if let csm_core::error::MemoryError::InvalidInput { reason, .. } = err {
+            assert!(reason.contains(r"C:\nonexistent\model.onnx"));
+        } else {
+            panic!("Expected InvalidInput error with the full path");
+        }
+    }
+
+    #[test]
+    fn test_parse_rerankers_invalid_blend() {
+        let err = parse_rerankers("recency:30d:not-a-number").unwrap_err();
+        assert!(format!("{}", err).contains("invalid recency blend"));
+    }
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -19,6 +19,7 @@
 - csm-core
 - csm-embedding
 - csm-memory
+- csm-retrieval
 - fastembed (4)
 - glob (0.3.2)
 - hnsw_rs (0.3.4)

--- a/llms.txt
+++ b/llms.txt
@@ -19,6 +19,7 @@
 - csm-core
 - csm-embedding
 - csm-memory
+- csm-retrieval
 - fastembed (4)
 - glob (0.3.2)
 - hnsw_rs (0.3.4)
@@ -1291,6 +1292,7 @@ members = [
     "crates/csm-core",
     "crates/csm-embedding",
     "crates/csm-memory",
+    "crates/csm-retrieval",
     ".",
     "benchmarks",
     "crates/chaotic_semantic_memory_duckdb",
@@ -1346,6 +1348,7 @@ include = [
 csm-core = { path = "crates/csm-core" }
 csm-embedding = { path = "crates/csm-embedding" }
 csm-memory = { path = "crates/csm-memory" }
+csm-retrieval = { path = "crates/csm-retrieval" }
 tempfile = { workspace = true }
 # Serialization
 serde = { workspace = true }


### PR DESCRIPTION
## Summary

- Extract retrieval backends into standalone `csm-retrieval` workspace crate
- Move BM25, hybrid, GraphRAG, and reranking modules
- Update imports to use csm-memory types
- Add csm-retrieval as dependency to main crate

## Changes

- Created `crates/csm-retrieval/` with retrieval backends
- Moved BM25 index, hybrid retrieval, GraphRAG, and reranking
- Updated imports to use `csm_memory` types (Concept, TraversalConfig, unix_now_secs)
- Added `rerank-cross` feature for CrossEncoderReranker
- Added csm-retrieval to workspace members and as dependency to main crate

## Testing

- `cargo test -p csm-retrieval` passes (46 tests)
- `cargo test --quiet` passes (all tests)
- `cargo check --all-features` passes
- `cargo clippy -- -D warnings` passes
- `cargo fmt --check` passes

## Related Issues

- Closes #366