### PR TITLE
refactor(persistence): extract csm-persistence into standalone workspace crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,6 +854,7 @@ dependencies = [
  "csm-core",
  "csm-embedding",
  "csm-memory",
+ "csm-persistence",
  "csm-retrieval",
  "fastembed",
  "getrandom 0.4.2",
@@ -1349,6 +1350,22 @@ dependencies = [
  "hnsw_rs",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "csm-persistence"
+version = "0.1.0"
+dependencies = [
+ "csm-core",
+ "csm-memory",
+ "libsql",
+ "serde",
+ "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/csm-embedding",
     "crates/csm-memory",
     "crates/csm-retrieval",
+    "crates/csm-persistence",
     ".",
     "benchmarks",
     "crates/chaotic_semantic_memory_duckdb",
@@ -60,6 +61,7 @@ csm-core = { path = "crates/csm-core" }
 csm-embedding = { path = "crates/csm-embedding" }
 csm-memory = { path = "crates/csm-memory" }
 csm-retrieval = { path = "crates/csm-retrieval" }
+csm-persistence = { path = "crates/csm-persistence" }
 tempfile = { workspace = true }
 # Serialization
 serde = { workspace = true }

--- a/crates/csm-persistence/Cargo.toml
+++ b/crates/csm-persistence/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "csm-persistence"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+description = "Persistence backends for chaotic_semantic_memory"
+license = "MIT"
+repository = "https://github.com/d-o-hub/chaotic_semantic_memory"
+
+[dependencies]
+csm-core = { path = "../csm-core" }
+csm-memory = { path = "../csm-memory" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true }
+uuid = { workspace = true, optional = true }
+
+# libSQL backend (default)
+libsql = { version = "0.9.30", default-features = false, features = ["sync", "hrana", "remote"], optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tempfile = { workspace = true }
+
+[features]
+default = ["libsql"]
+libsql = ["dep:libsql"]
+wasm = ["uuid"]
+
+[lib]
+crate-type = ["lib"]

--- a/crates/csm-persistence/src/bridge_persistence.rs
+++ b/crates/csm-persistence/src/bridge_persistence.rs
@@ -1,0 +1,317 @@
+//! Persistence for canonical concept graph.
+//!
+//! Feature-gated persistence layer for storing the symbolic semantic graph
+//! used by the bridge retrieval pipeline.
+
+// Casts are intentional for version serialization
+
+use crate::persistence::Persistence;
+use crate::semantic_bridge::{CanonicalConcept, ConceptGraph};
+use csm_core::error::{MemoryError, Result};
+use libsql::params;
+
+impl Persistence {
+    /// Save a canonical concept to the database.
+    pub async fn save_canonical_concept(&self, ns: &str, concept: &CanonicalConcept) -> Result<()> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+
+        let labels_json = serde_json::to_string(&concept.labels)?;
+        let related_json = serde_json::to_string(&concept.related)?;
+
+        conn.execute(
+            "INSERT INTO csm_canonical (namespace, id, version, labels_json, related_json)
+             VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT(namespace, id) DO UPDATE SET
+             version = excluded.version,
+             labels_json = excluded.labels_json,
+             related_json = excluded.related_json",
+            params![
+                ns.to_string(),
+                concept.id.clone(),
+                concept.version as i64,
+                labels_json,
+                related_json
+            ],
+        )
+        .await
+        .map_err(|e| MemoryError::database(format!("Failed to save canonical concept: {e}")))?;
+
+        Ok(())
+    }
+
+    /// Delete a canonical concept from the database.
+    pub async fn delete_canonical_concept(&self, ns: &str, id: &str) -> Result<()> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+
+        conn.execute(
+            "DELETE FROM csm_canonical WHERE namespace = ?1 AND id = ?2",
+            params![ns.to_string(), id],
+        )
+        .await
+        .map_err(|e| MemoryError::database(format!("Failed to delete canonical concept: {e}")))?;
+
+        Ok(())
+    }
+
+    /// Load a canonical concept by namespace and ID.
+    pub async fn load_canonical_concept(
+        &self,
+        ns: &str,
+        id: &str,
+    ) -> Result<Option<CanonicalConcept>> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+
+        let mut rows = conn
+            .query(
+                "SELECT id, version, labels_json, related_json FROM csm_canonical WHERE namespace = ?1 AND id = ?2",
+                params![ns.to_string(), id],
+            )
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to load canonical concept: {e}")))?;
+
+        if let Some(row) = rows.next().await.map_err(|e| {
+            MemoryError::database(format!("Failed to read canonical concept row: {e}"))
+        })? {
+            let id: String = row.get(0).map_err(|e| {
+                MemoryError::database(format!("Failed to read canonical concept id: {e}"))
+            })?;
+            let version: i64 = row.get(1).map_err(|e| {
+                MemoryError::database(format!("Failed to read canonical concept version: {e}"))
+            })?;
+            let labels_json: String = row.get(2).map_err(|e| {
+                MemoryError::database(format!("Failed to read canonical concept labels: {e}"))
+            })?;
+            let related_json: String = row.get(3).map_err(|e| {
+                MemoryError::database(format!("Failed to read canonical concept related: {e}"))
+            })?;
+
+            let labels: Vec<String> = serde_json::from_str(&labels_json)?;
+            let related: Vec<String> = serde_json::from_str(&related_json)?;
+
+            Ok(Some(CanonicalConcept {
+                id,
+                version: u32::try_from(version).unwrap_or(0),
+                labels,
+                related,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Load all canonical concepts for a namespace from the database.
+    pub async fn load_all_canonical_concepts(&self, ns: &str) -> Result<Vec<CanonicalConcept>> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+
+        let mut rows = conn
+            .query(
+                "SELECT id, version, labels_json, related_json FROM csm_canonical WHERE namespace = ?1",
+                params![ns.to_string()],
+            )
+            .await
+            .map_err(|e| {
+                MemoryError::database(format!("Failed to load canonical concepts: {e}"))
+            })?;
+
+        let mut concepts = Vec::new();
+        while let Some(row) = rows.next().await.map_err(|e| {
+            MemoryError::database(format!("Failed to read canonical concept row: {e}"))
+        })? {
+            let id: String = row.get(0).map_err(|e| {
+                MemoryError::database(format!("Failed to read canonical concept id: {e}"))
+            })?;
+            let version: i64 = row.get(1).map_err(|e| {
+                MemoryError::database(format!("Failed to read canonical concept version: {e}"))
+            })?;
+            let labels_json: String = row.get(2).map_err(|e| {
+                MemoryError::database(format!("Failed to read canonical concept labels: {e}"))
+            })?;
+            let related_json: String = row.get(3).map_err(|e| {
+                MemoryError::database(format!("Failed to read canonical concept related: {e}"))
+            })?;
+
+            let labels: Vec<String> = serde_json::from_str(&labels_json)?;
+            let related: Vec<String> = serde_json::from_str(&related_json)?;
+
+            concepts.push(CanonicalConcept {
+                id,
+                version: u32::try_from(version).unwrap_or(0),
+                labels,
+                related,
+            });
+        }
+
+        Ok(concepts)
+    }
+
+    /// Save an entire concept graph to the database for a namespace.
+    pub async fn save_concept_graph(&self, ns: &str, graph: &ConceptGraph) -> Result<()> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to begin transaction: {e}")))?;
+
+        // Clear existing concepts for this namespace
+        if let Err(e) = conn
+            .execute(
+                "DELETE FROM csm_canonical WHERE namespace = ?1",
+                params![ns.to_string()],
+            )
+            .await
+        {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(MemoryError::database(format!(
+                "Failed to clear canonical concepts: {e}"
+            )));
+        }
+
+        // Insert all concepts
+        let mut first_error: Option<MemoryError> = None;
+        for concept in graph.all_concepts() {
+            let labels_json = match serde_json::to_string(&concept.labels) {
+                Ok(j) => j,
+                Err(e) => {
+                    first_error = Some(MemoryError::Serialization(e));
+                    break;
+                }
+            };
+            let related_json = match serde_json::to_string(&concept.related) {
+                Ok(j) => j,
+                Err(e) => {
+                    first_error = Some(MemoryError::Serialization(e));
+                    break;
+                }
+            };
+
+            if let Err(e) = conn
+                .execute(
+                    "INSERT INTO csm_canonical (namespace, id, version, labels_json, related_json)
+                     VALUES (?1, ?2, ?3, ?4, ?5)",
+                    params![
+                        ns.to_string(),
+                        concept.id.clone(),
+                        concept.version as i64,
+                        labels_json,
+                        related_json
+                    ],
+                )
+                .await
+            {
+                first_error = Some(MemoryError::database(format!(
+                    "Failed to save canonical concept: {e}"
+                )));
+                break;
+            }
+        }
+
+        if let Some(error) = first_error {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(error);
+        }
+
+        conn.execute("COMMIT", ())
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to commit transaction: {e}")))?;
+
+        Ok(())
+    }
+
+    /// Load an entire concept graph from the database for a namespace.
+    pub async fn load_concept_graph(&self, ns: &str) -> Result<ConceptGraph> {
+        let concepts = self.load_all_canonical_concepts(ns).await?;
+        let mut graph = ConceptGraph::new();
+        for concept in concepts {
+            graph.add_concept(concept);
+        }
+        Ok(graph)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::semantic_bridge::CanonicalConcept;
+    use tempfile::NamedTempFile;
+
+    #[tokio::test]
+    async fn test_save_and_load_canonical_concept() {
+        let temp = NamedTempFile::new().unwrap();
+        let path = temp.path().to_str().unwrap();
+        let persistence = Persistence::new_local(path).await.unwrap();
+
+        let concept = CanonicalConcept::new("test-concept")
+            .with_label("label1")
+            .with_label("label2")
+            .with_related("related-concept");
+
+        persistence
+            .save_canonical_concept("_default", &concept)
+            .await
+            .unwrap();
+
+        let loaded = persistence
+            .load_canonical_concept("_default", "test-concept")
+            .await
+            .unwrap();
+        assert!(loaded.is_some());
+
+        let loaded = loaded.unwrap();
+        assert_eq!(loaded.id, "test-concept");
+        assert_eq!(loaded.labels, vec!["label1", "label2"]);
+        assert_eq!(loaded.related, vec!["related-concept"]);
+    }
+
+    #[tokio::test]
+    async fn test_delete_canonical_concept() {
+        let temp = NamedTempFile::new().unwrap();
+        let path = temp.path().to_str().unwrap();
+        let persistence = Persistence::new_local(path).await.unwrap();
+
+        let concept = CanonicalConcept::new("to-delete");
+        persistence
+            .save_canonical_concept("_default", &concept)
+            .await
+            .unwrap();
+
+        persistence
+            .delete_canonical_concept("_default", "to-delete")
+            .await
+            .unwrap();
+
+        let loaded = persistence
+            .load_canonical_concept("_default", "to-delete")
+            .await
+            .unwrap();
+        assert!(loaded.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_save_and_load_concept_graph() {
+        let temp = NamedTempFile::new().unwrap();
+        let path = temp.path().to_str().unwrap();
+        let persistence = Persistence::new_local(path).await.unwrap();
+
+        let mut graph = ConceptGraph::new();
+        graph.add_concept(
+            CanonicalConcept::new("c1")
+                .with_label("label1")
+                .with_related("c2"),
+        );
+        graph.add_concept(CanonicalConcept::new("c2").with_label("label2"));
+
+        persistence
+            .save_concept_graph("_default", &graph)
+            .await
+            .unwrap();
+
+        let loaded = persistence.load_concept_graph("_default").await.unwrap();
+        assert_eq!(loaded.concept_count(), 2);
+        assert_eq!(loaded.label_count(), 2);
+    }
+}

--- a/crates/csm-persistence/src/lib.rs
+++ b/crates/csm-persistence/src/lib.rs
@@ -1,0 +1,20 @@
+//! Persistence backends for chaotic_semantic_memory.
+//!
+//! This crate provides:
+//! - libSQL/Turso storage backend
+//! - In-memory persistence for WASM
+//! - Schema migrations and versioning
+
+#[cfg(feature = "libsql")]
+mod persistence;
+mod persistence_concepts;
+mod persistence_index;
+mod persistence_migrations;
+mod persistence_ops;
+mod persistence_versions;
+
+#[cfg(feature = "wasm")]
+mod persistence_wasm;
+
+#[cfg(feature = "libsql")]
+pub use persistence::Persistence;

--- a/crates/csm-persistence/src/persistence.rs
+++ b/crates/csm-persistence/src/persistence.rs
@@ -1,0 +1,282 @@
+//! Persistence layer using libSQL (SQLite/Turso). Auto-migrations, version retention, FK enabled.
+
+// Casts are intentional for schema version math
+#![allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+
+use csm_core::error::{MemoryError, Result};
+use libsql::{Builder, Connection, Database, params};
+use std::sync::Arc;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+pub(crate) const LATEST_SCHEMA_VERSION: i64 = 8;
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct Persistence {
+    pub(crate) db: Arc<Database>,
+    pub(crate) local_path: Option<String>,
+    pub(crate) remote_limit: Option<Arc<Semaphore>>,
+    pub(crate) version_retention: usize,
+}
+
+pub use csm_memory::ConceptVersion;
+
+impl Persistence {
+    /// Create new persistence layer with local SQLite
+    pub async fn new_local(path: &str) -> Result<Self> {
+        Self::new_local_with_retention(path, 10).await
+    }
+
+    pub async fn new_local_with_retention(path: &str, version_retention: usize) -> Result<Self> {
+        let db = Builder::new_local(path)
+            .build()
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to open database: {e}")))?;
+
+        let persistence = Self {
+            db: Arc::new(db),
+            local_path: Some(path.to_string()),
+            remote_limit: None,
+            version_retention: version_retention.max(1),
+        };
+        persistence.init_schema().await?;
+        Ok(persistence)
+    }
+
+    /// Create new persistence layer with remote Turso
+    pub async fn new_turso(url: &str, token: &str) -> Result<Self> {
+        Self::new_turso_with_pool(url, token, 10).await
+    }
+
+    pub async fn new_turso_with_pool(url: &str, token: &str, pool_size: usize) -> Result<Self> {
+        Self::new_turso_with_pool_and_retention(url, token, pool_size, 10).await
+    }
+
+    pub async fn new_turso_with_pool_and_retention(
+        url: &str,
+        token: &str,
+        pool_size: usize,
+        version_retention: usize,
+    ) -> Result<Self> {
+        let db = Builder::new_remote(url.to_string(), token.to_string())
+            .build()
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to open remote database: {e}")))?;
+
+        let persistence = Self {
+            db: Arc::new(db),
+            local_path: None,
+            remote_limit: Some(Arc::new(Semaphore::new(pool_size.max(1)))),
+            version_retention: version_retention.max(1),
+        };
+        persistence.init_schema().await?;
+        Ok(persistence)
+    }
+
+    pub(crate) async fn connect(&self) -> Result<Connection> {
+        let conn = self
+            .db
+            .connect()
+            .map_err(|e| MemoryError::database(format!("Failed to connect: {e}")))?;
+
+        if self.local_path.is_some() {
+            let _ = conn
+                .query("PRAGMA journal_mode=WAL;", ())
+                .await
+                .map_err(|e| MemoryError::database(format!("Failed to enable WAL mode: {e}")))?;
+        }
+        conn.execute("PRAGMA foreign_keys=ON;", ())
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to enable foreign keys: {e}")))?;
+        Ok(conn)
+    }
+
+    pub(crate) async fn acquire_remote_slot(&self) -> Result<Option<OwnedSemaphorePermit>> {
+        match &self.remote_limit {
+            Some(limit) => limit
+                .clone()
+                .acquire_owned()
+                .await
+                .map(Some)
+                .map_err(|e| MemoryError::database(format!("Failed to acquire pool slot: {e}"))),
+            None => Ok(None),
+        }
+    }
+
+    /// Initialize database schema
+    pub(crate) async fn init_schema(&self) -> Result<()> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+        conn.execute_batch(
+            "BEGIN;
+            CREATE TABLE IF NOT EXISTS csm_concepts (
+                id TEXT PRIMARY KEY,
+                vector BLOB NOT NULL,
+                metadata TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                modified_at INTEGER NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS csm_associations (
+                from_id TEXT NOT NULL,
+                to_id TEXT NOT NULL,
+                strength REAL NOT NULL,
+                PRIMARY KEY (from_id, to_id),
+                FOREIGN KEY (from_id) REFERENCES csm_concepts(id),
+                FOREIGN KEY (to_id) REFERENCES csm_concepts(id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_csm_associations_from ON csm_associations(from_id);
+            CREATE TABLE IF NOT EXISTS csm_versions (
+                concept_id TEXT NOT NULL,
+                version INTEGER NOT NULL,
+                vector BLOB NOT NULL,
+                metadata TEXT NOT NULL,
+                modified_at INTEGER NOT NULL,
+                PRIMARY KEY (concept_id, version),
+                FOREIGN KEY (concept_id) REFERENCES csm_concepts(id)
+            );
+            CREATE TABLE IF NOT EXISTS csm_schema_version (
+                version INTEGER PRIMARY KEY
+            );
+            INSERT OR IGNORE INTO csm_schema_version(version) VALUES (1);
+            COMMIT;",
+        )
+        .await
+        .map_err(|e| MemoryError::database(format!("Failed to initialize schema: {e}")))?;
+        // Use internal method that reuses the connection to avoid semaphore deadlock
+        self.apply_migrations_with_conn(&conn, LATEST_SCHEMA_VERSION)
+            .await?;
+        Ok(())
+    }
+
+    /// Save an association
+    pub async fn save_association(
+        &self,
+        ns: &str,
+        from: &str,
+        to: &str,
+        strength: f32,
+    ) -> Result<()> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+
+        conn.execute(
+            "INSERT INTO csm_associations (namespace, from_id, to_id, strength)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(namespace, from_id, to_id) DO UPDATE SET strength = excluded.strength",
+            params![ns, from, to, strength],
+        )
+        .await
+        .map_err(|e| MemoryError::database(format!("Failed to save association: {e}")))?;
+
+        Ok(())
+    }
+
+    /// Load associations for a concept
+    pub async fn load_associations(&self, ns: &str, id: &str) -> Result<Vec<(String, f32)>> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+
+        let mut rows = conn
+            .query(
+                "SELECT to_id, strength FROM csm_associations WHERE namespace = ?1 AND from_id = ?2",
+                params![ns, id],
+            )
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to load associations: {e}")))?;
+
+        let mut associations = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to fetch row: {e}")))?
+        {
+            let to_id: String = row
+                .get(0)
+                .map_err(|e| MemoryError::database(format!("Failed to get to_id: {e}")))?;
+            let strength: f64 = row
+                .get(1)
+                .map_err(|e| MemoryError::database(format!("Failed to get strength: {e}")))?;
+            associations.push((to_id, strength as f32));
+        }
+
+        Ok(associations)
+    }
+
+    /// Perform database checkpoint (optimize)
+    pub async fn checkpoint(&self) -> Result<()> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+
+        let mut rows = conn
+            .query("PRAGMA wal_checkpoint(TRUNCATE);", ())
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to checkpoint: {e}")))?;
+        let _ = rows
+            .next()
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to read checkpoint row: {e}")))?;
+
+        Ok(())
+    }
+
+    /// List all distinct namespaces present in the database.
+    pub async fn list_namespaces(&self) -> Result<Vec<String>> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+
+        let mut rows = conn
+            .query(
+                "SELECT DISTINCT namespace FROM csm_concepts
+                 UNION
+                 SELECT DISTINCT namespace FROM csm_canonical
+                 ORDER BY namespace",
+                params![],
+            )
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to list namespaces: {e}")))?;
+
+        let mut namespaces = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to fetch namespace row: {e}")))?
+        {
+            let ns: String = row
+                .get(0)
+                .map_err(|e| MemoryError::database(format!("Failed to get namespace: {e}")))?;
+            namespaces.push(ns);
+        }
+
+        if namespaces.is_empty() {
+            namespaces.push("_default".to_string());
+        }
+
+        Ok(namespaces)
+    }
+
+    /// Get database size in bytes
+    pub async fn size(&self) -> Result<u64> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+
+        let mut rows = conn
+            .query(
+                "SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()",
+                (),
+            )
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to get size: {e}")))?;
+
+        if let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to fetch row: {e}")))?
+        {
+            let size: i64 = row
+                .get(0)
+                .map_err(|e| MemoryError::database(format!("Failed to get size value: {e}")))?;
+            Ok(size as u64)
+        } else {
+            Ok(0)
+        }
+    }
+}

--- a/crates/csm-persistence/src/persistence_concepts.rs
+++ b/crates/csm-persistence/src/persistence_concepts.rs
@@ -1,0 +1,301 @@
+#![cfg(all(not(target_arch = "wasm32"), feature = "libsql"))]
+use crate::persistence::Persistence;
+use csm_core::error::{MemoryError, Result};
+use csm_core::hyperdim::HVec10240;
+use csm_memory::Concept;
+use libsql::params;
+
+impl Persistence {
+    /// Save a concept to the database
+    pub async fn save_concept(&self, ns: &str, concept: &Concept) -> Result<()> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+        let vector_bytes = concept.vector.to_bytes();
+        let metadata_json = serde_json::to_string(&concept.metadata)?;
+        let expires_at: Option<i64> = concept.expires_at.map(|t| t as i64);
+        let canonical_concept_ids_json = serde_json::to_string(&concept.canonical_concept_ids)?;
+
+        conn.execute(
+            "INSERT INTO csm_concepts
+             (namespace, id, vector, metadata, created_at, modified_at, expires_at, canonical_concept_ids_json)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             ON CONFLICT(namespace, id) DO UPDATE SET
+             vector = excluded.vector,
+             metadata = excluded.metadata,
+             modified_at = excluded.modified_at,
+             expires_at = excluded.expires_at,
+             canonical_concept_ids_json = excluded.canonical_concept_ids_json",
+            params![
+                ns,
+                concept.id.as_str(),
+                vector_bytes.as_slice(),
+                metadata_json.as_str(),
+                concept.created_at as i64,
+                concept.modified_at as i64,
+                expires_at,
+                canonical_concept_ids_json.as_str()
+            ],
+        )
+        .await
+        .map_err(|e| MemoryError::database(format!("Failed to save concept: {e}")))?;
+
+        self.record_concept_version_scoped(
+            &conn,
+            ns,
+            concept,
+            Some(&vector_bytes),
+            Some(&metadata_json),
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Save concepts in a single transaction
+    pub async fn save_concepts(&self, ns: &str, concepts: &[Concept]) -> Result<()> {
+        if concepts.is_empty() {
+            return Ok(());
+        }
+
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to begin transaction: {e}")))?;
+
+        let mut first_error: Option<MemoryError> = None;
+        for concept in concepts {
+            let vector_bytes = concept.vector.to_bytes();
+            let metadata_json = serde_json::to_string(&concept.metadata)?;
+            let expires_at: Option<i64> = concept.expires_at.map(|t| t as i64);
+            let canonical_concept_ids_json = serde_json::to_string(&concept.canonical_concept_ids)?;
+
+            if let Err(e) = conn
+                .execute(
+                    "INSERT INTO csm_concepts
+                     (namespace, id, vector, metadata, created_at, modified_at, expires_at, canonical_concept_ids_json)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                     ON CONFLICT(namespace, id) DO UPDATE SET
+                     vector = excluded.vector,
+                     metadata = excluded.metadata,
+                     modified_at = excluded.modified_at,
+                     expires_at = excluded.expires_at,
+                     canonical_concept_ids_json = excluded.canonical_concept_ids_json",
+                    params![
+                        ns,
+                        concept.id.as_str(),
+                        vector_bytes.as_slice(),
+                        metadata_json.as_str(),
+                        concept.created_at as i64,
+                        concept.modified_at as i64,
+                        expires_at,
+                        canonical_concept_ids_json.as_str()
+                    ],
+                )
+                .await
+            {
+                first_error = Some(MemoryError::database(format!(
+                    "Failed to batch save concept: {e}"
+                )));
+                break;
+            }
+
+            if let Err(e) = self
+                .record_concept_version_scoped(
+                    &conn,
+                    ns,
+                    concept,
+                    Some(&vector_bytes),
+                    Some(&metadata_json),
+                )
+                .await
+            {
+                first_error = Some(e);
+                break;
+            }
+        }
+
+        if let Some(error) = first_error {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(error);
+        }
+
+        conn.execute("COMMIT", ())
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to commit transaction: {e}")))?;
+
+        Ok(())
+    }
+
+    /// Load a concept from the database
+    pub async fn load_concept(&self, ns: &str, id: &str) -> Result<Option<Concept>> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+
+        let mut rows = conn
+            .query(
+                "SELECT vector, metadata, created_at, modified_at, expires_at, canonical_concept_ids_json
+                 FROM csm_concepts WHERE namespace = ?1 AND id = ?2",
+                params![ns, id],
+            )
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to load concept: {e}")))?;
+
+        if let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to fetch row: {e}")))?
+        {
+            let vector_bytes: Vec<u8> = row
+                .get(0)
+                .map_err(|e| MemoryError::database(format!("Failed to get vector: {e}")))?;
+            let metadata_json: String = row
+                .get(1)
+                .map_err(|e| MemoryError::database(format!("Failed to get metadata: {e}")))?;
+            let created_at: i64 = row
+                .get(2)
+                .map_err(|e| MemoryError::database(format!("Failed to get created_at: {e}")))?;
+            let modified_at: i64 = row
+                .get(3)
+                .map_err(|e| MemoryError::database(format!("Failed to get modified_at: {e}")))?;
+            let expires_at: Option<i64> = row.get(4).ok();
+            let canonical_concept_ids_json: Option<String> = row.get(5).ok();
+
+            let vector = HVec10240::from_bytes(&vector_bytes)?;
+            let metadata = serde_json::from_str(&metadata_json)?;
+            let canonical_concept_ids = canonical_concept_ids_json
+                .as_deref()
+                .map(serde_json::from_str)
+                .transpose()?
+                .unwrap_or_default();
+
+            Ok(Some(Concept {
+                id: id.to_string(),
+                vector,
+                metadata,
+                created_at: created_at as u64,
+                modified_at: modified_at as u64,
+                expires_at: expires_at.map(|t| t as u64),
+                canonical_concept_ids,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Load all concepts from the database for a specific namespace
+    pub async fn load_all_concepts(&self, ns: &str) -> Result<Vec<Concept>> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+
+        let mut rows = conn
+            .query(
+                "SELECT id, vector, metadata, created_at, modified_at, expires_at, canonical_concept_ids_json
+                 FROM csm_concepts WHERE namespace = ?1",
+                params![ns],
+            )
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to load concepts: {e}")))?;
+
+        let mut concepts = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to fetch row: {e}")))?
+        {
+            let id: String = row
+                .get(0)
+                .map_err(|e| MemoryError::database(format!("Failed to get id: {e}")))?;
+            let vector_bytes: Vec<u8> = row
+                .get(1)
+                .map_err(|e| MemoryError::database(format!("Failed to get vector: {e}")))?;
+            let metadata_json: String = row
+                .get(2)
+                .map_err(|e| MemoryError::database(format!("Failed to get metadata: {e}")))?;
+            let created_at: i64 = row
+                .get(3)
+                .map_err(|e| MemoryError::database(format!("Failed to get created_at: {e}")))?;
+            let modified_at: i64 = row
+                .get(4)
+                .map_err(|e| MemoryError::database(format!("Failed to get modified_at: {e}")))?;
+            let expires_at: Option<i64> = row.get(5).ok();
+            let canonical_concept_ids_json: Option<String> = row.get(6).ok();
+
+            let vector = HVec10240::from_bytes(&vector_bytes)?;
+            let metadata = serde_json::from_str(&metadata_json)?;
+            let canonical_concept_ids = canonical_concept_ids_json
+                .as_deref()
+                .map(serde_json::from_str)
+                .transpose()?
+                .unwrap_or_default();
+
+            concepts.push(Concept {
+                id,
+                vector,
+                metadata,
+                created_at: created_at as u64,
+                modified_at: modified_at as u64,
+                expires_at: expires_at.map(|t| t as u64),
+                canonical_concept_ids,
+            });
+        }
+
+        Ok(concepts)
+    }
+
+    /// Delete a concept from the database
+    pub async fn delete_concept(&self, ns: &str, id: &str) -> Result<()> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to begin transaction: {e}")))?;
+
+        // Delete in FK order: versions first (FK → concepts), then associations (FK → concepts),
+        // then the concept itself
+        if let Err(e) = conn
+            .execute(
+                "DELETE FROM csm_versions WHERE namespace = ?1 AND concept_id = ?2",
+                params![ns, id],
+            )
+            .await
+        {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(MemoryError::database(format!(
+                "Failed to delete concept versions: {e}"
+            )));
+        }
+
+        if let Err(e) = conn
+            .execute(
+                "DELETE FROM csm_associations WHERE namespace = ?1 AND (from_id = ?2 OR to_id = ?2)",
+                params![ns, id],
+            )
+            .await
+        {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(MemoryError::database(format!(
+                "Failed to delete associations: {e}"
+            )));
+        }
+
+        if let Err(e) = conn
+            .execute(
+                "DELETE FROM csm_concepts WHERE namespace = ?1 AND id = ?2",
+                params![ns, id],
+            )
+            .await
+        {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(MemoryError::database(format!(
+                "Failed to delete concept: {e}"
+            )));
+        }
+
+        conn.execute("COMMIT", ())
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to commit transaction: {e}")))?;
+
+        Ok(())
+    }
+}

--- a/crates/csm-persistence/src/persistence_index.rs
+++ b/crates/csm-persistence/src/persistence_index.rs
@@ -1,0 +1,49 @@
+//! ANN index persistence operations.
+//!
+//! Extracted from persistence.rs to satisfy the 500 LOC gate.
+
+use crate::persistence::Persistence;
+use csm_core::error::{MemoryError, Result};
+use libsql::params;
+
+impl Persistence {
+    /// Save the serialized index state to the database.
+    pub async fn save_index(&self, ns: &str, id: &str, data: &[u8]) -> Result<()> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+        conn.execute(
+            "INSERT OR REPLACE INTO csm_hnsw_graph (namespace, id, data, modified_at)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![ns.to_string(), id, data, csm_memory::unix_now_secs() as i64],
+        )
+        .await
+        .map_err(|e| MemoryError::database(format!("Failed to save index: {}", e)))?;
+        Ok(())
+    }
+
+    /// Load the serialized index state from the database.
+    pub async fn load_index(&self, ns: &str, id: &str) -> Result<Option<Vec<u8>>> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                "SELECT data FROM csm_hnsw_graph WHERE namespace = ?1 AND id = ?2",
+                params![ns.to_string(), id],
+            )
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to load index: {}", e)))?;
+
+        if let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to fetch index row: {}", e)))?
+        {
+            let data: Vec<u8> = row
+                .get(0)
+                .map_err(|e| MemoryError::database(format!("Failed to get index data: {}", e)))?;
+            Ok(Some(data))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/crates/csm-persistence/src/persistence_migrations.rs
+++ b/crates/csm-persistence/src/persistence_migrations.rs
@@ -1,0 +1,380 @@
+use crate::persistence::Persistence;
+use csm_core::error::{MemoryError, Result};
+use libsql::params;
+use tracing::info;
+
+impl Persistence {
+    pub(crate) async fn table_exists(
+        &self,
+        conn: &libsql::Connection,
+        table_name: &str,
+    ) -> Result<bool> {
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?1",
+                params![table_name],
+            )
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to check table existence: {e}")))?;
+
+        if let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to fetch table existence: {e}")))?
+        {
+            let count: i64 = row
+                .get(0)
+                .map_err(|e| MemoryError::database(format!("Failed to parse table count: {e}")))?;
+            Ok(count > 0)
+        } else {
+            Ok(false)
+        }
+    }
+
+    pub(crate) async fn column_exists(
+        &self,
+        conn: &libsql::Connection,
+        table_name: &str,
+        column_name: &str,
+    ) -> Result<bool> {
+        // Validate table_name to prevent potential issues in pragma_table_info (CWE-89)
+        if table_name.is_empty() {
+            return Err(MemoryError::InvalidInput {
+                field: "table_name".to_string(),
+                reason: "Table name cannot be empty".to_string(),
+            });
+        }
+
+        // Use parameter binding for both the table name and the column name.
+        // pragma_table_info supports parameter binding for its argument.
+        let sql = "SELECT COUNT(*) FROM pragma_table_info(?1) WHERE name = ?2";
+
+        let mut rows = conn
+            .query(sql, params![table_name, column_name])
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to check column existence: {e}")))?;
+
+        if let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to fetch column existence: {e}")))?
+        {
+            let count: i64 = row
+                .get(0)
+                .map_err(|e| MemoryError::database(format!("Failed to parse column count: {e}")))?;
+            Ok(count > 0)
+        } else {
+            Ok(false)
+        }
+    }
+
+    pub(crate) async fn apply_v5_namespace_migration(
+        &self,
+        conn: &libsql::Connection,
+    ) -> Result<()> {
+        if self.table_exists(conn, "concepts").await? {
+            if self.table_exists(conn, "csm_concepts").await? {
+                conn.execute_batch(
+                    "INSERT OR IGNORE INTO csm_concepts (id, vector, metadata, created_at, modified_at)
+                     SELECT id, vector, metadata, created_at, modified_at FROM concepts;
+                     DROP TABLE concepts;",
+                )
+                .await
+                .map_err(|e| {
+                    MemoryError::database(format!("Failed migration v5 concepts merge: {e}"))
+                })?;
+            } else {
+                conn.execute_batch("ALTER TABLE concepts RENAME TO csm_concepts;")
+                    .await
+                    .map_err(|e| {
+                        MemoryError::database(format!("Failed migration v5 concepts rename: {e}"))
+                    })?;
+            }
+        }
+
+        if self.table_exists(conn, "associations").await? {
+            if self.table_exists(conn, "csm_associations").await? {
+                conn.execute_batch(
+                    "INSERT OR IGNORE INTO csm_associations (from_id, to_id, strength)
+                     SELECT from_id, to_id, strength FROM associations;
+                     DROP TABLE associations;",
+                )
+                .await
+                .map_err(|e| {
+                    MemoryError::database(format!("Failed migration v5 associations merge: {e}"))
+                })?;
+            } else {
+                conn.execute_batch("ALTER TABLE associations RENAME TO csm_associations;")
+                    .await
+                    .map_err(|e| {
+                        MemoryError::database(format!(
+                            "Failed migration v5 associations rename: {e}"
+                        ))
+                    })?;
+            }
+        }
+
+        if self.table_exists(conn, "concept_versions").await? {
+            if self.table_exists(conn, "csm_versions").await? {
+                conn.execute_batch(
+                    "INSERT OR IGNORE INTO csm_versions (concept_id, version, vector, metadata, modified_at)
+                     SELECT concept_id, version, vector, metadata, modified_at FROM concept_versions;
+                     DROP TABLE concept_versions;",
+                )
+                .await
+                .map_err(|e| {
+                    MemoryError::database(format!("Failed migration v5 versions merge: {e}"))
+                })?;
+            } else {
+                conn.execute_batch("ALTER TABLE concept_versions RENAME TO csm_versions;")
+                    .await
+                    .map_err(|e| {
+                        MemoryError::database(format!("Failed migration v5 versions rename: {e}"))
+                    })?;
+            }
+        }
+
+        if self.table_exists(conn, "canonical_concepts").await? {
+            if self.table_exists(conn, "csm_canonical").await? {
+                conn.execute_batch(
+                    "INSERT OR IGNORE INTO csm_canonical (id, version, labels_json, related_json)
+                     SELECT id, version, labels_json, related_json FROM canonical_concepts;
+                     DROP TABLE canonical_concepts;",
+                )
+                .await
+                .map_err(|e| {
+                    MemoryError::database(format!("Failed migration v5 canonical merge: {e}"))
+                })?;
+            } else {
+                conn.execute_batch("ALTER TABLE canonical_concepts RENAME TO csm_canonical;")
+                    .await
+                    .map_err(|e| {
+                        MemoryError::database(format!("Failed migration v5 canonical rename: {e}"))
+                    })?;
+            }
+        }
+
+        if self.table_exists(conn, "__schema_version").await? {
+            conn.execute_batch("DROP TABLE __schema_version;")
+                .await
+                .map_err(|e| {
+                    MemoryError::database(format!("Failed migration v5 schema cleanup: {e}"))
+                })?;
+        }
+
+        Ok(())
+    }
+
+    pub(crate) async fn apply_v8_namespace_migration(
+        &self,
+        conn: &libsql::Connection,
+    ) -> Result<()> {
+        // v8: Namespace isolation. Update PKs and FKs to include namespace.
+        conn.execute_batch(
+            "-- 1. Concepts
+             ALTER TABLE csm_concepts RENAME TO csm_concepts_old;
+             CREATE TABLE csm_concepts (
+                 namespace TEXT NOT NULL DEFAULT '_default',
+                 id TEXT NOT NULL,
+                 vector BLOB NOT NULL,
+                 metadata TEXT NOT NULL,
+                 created_at INTEGER NOT NULL,
+                 modified_at INTEGER NOT NULL,
+                 expires_at INTEGER,
+                 canonical_concept_ids_json TEXT,
+                 PRIMARY KEY (namespace, id)
+             );
+             INSERT INTO csm_concepts (id, vector, metadata, created_at, modified_at, expires_at, canonical_concept_ids_json)
+             SELECT id, vector, metadata, created_at, modified_at, expires_at, canonical_concept_ids_json FROM csm_concepts_old;
+             DROP TABLE csm_concepts_old;
+             CREATE INDEX idx_csm_concepts_namespace ON csm_concepts(namespace);
+
+             -- 2. Associations
+             ALTER TABLE csm_associations RENAME TO csm_associations_old;
+             CREATE TABLE csm_associations (
+                 namespace TEXT NOT NULL DEFAULT '_default',
+                 from_id TEXT NOT NULL,
+                 to_id TEXT NOT NULL,
+                 strength REAL NOT NULL,
+                 PRIMARY KEY (namespace, from_id, to_id),
+                 FOREIGN KEY (namespace, from_id) REFERENCES csm_concepts(namespace, id),
+                 FOREIGN KEY (namespace, to_id) REFERENCES csm_concepts(namespace, id)
+             );
+             INSERT INTO csm_associations (from_id, to_id, strength)
+             SELECT from_id, to_id, strength FROM csm_associations_old;
+             DROP TABLE csm_associations_old;
+             CREATE INDEX idx_csm_associations_namespace ON csm_associations(namespace);
+             CREATE INDEX idx_csm_associations_from ON csm_associations(namespace, from_id);
+
+             -- 3. Versions
+             ALTER TABLE csm_versions RENAME TO csm_versions_old;
+             CREATE TABLE csm_versions (
+                 namespace TEXT NOT NULL DEFAULT '_default',
+                 concept_id TEXT NOT NULL,
+                 version INTEGER NOT NULL,
+                 vector BLOB NOT NULL,
+                 metadata TEXT NOT NULL,
+                 modified_at INTEGER NOT NULL,
+                 PRIMARY KEY (namespace, concept_id, version),
+                 FOREIGN KEY (namespace, concept_id) REFERENCES csm_concepts(namespace, id)
+             );
+             INSERT INTO csm_versions (concept_id, version, vector, metadata, modified_at)
+             SELECT concept_id, version, vector, metadata, modified_at FROM csm_versions_old;
+             DROP TABLE csm_versions_old;
+             CREATE INDEX idx_csm_versions_namespace ON csm_versions(namespace);
+             CREATE INDEX idx_csm_versions_modified_at ON csm_versions(namespace, modified_at);
+
+             -- 4. HNSW Graph
+             ALTER TABLE csm_hnsw_graph RENAME TO csm_hnsw_graph_old;
+             CREATE TABLE csm_hnsw_graph (
+                 namespace TEXT NOT NULL DEFAULT '_default',
+                 id TEXT NOT NULL,
+                 data BLOB NOT NULL,
+                 modified_at INTEGER NOT NULL,
+                 PRIMARY KEY (namespace, id)
+             );
+             INSERT INTO csm_hnsw_graph (id, data, modified_at)
+             SELECT id, data, modified_at FROM csm_hnsw_graph_old;
+             DROP TABLE csm_hnsw_graph_old;
+             CREATE INDEX idx_csm_hnsw_graph_namespace ON csm_hnsw_graph(namespace);
+
+             -- 5. Canonical Concepts
+             ALTER TABLE csm_canonical RENAME TO csm_canonical_old;
+             CREATE TABLE csm_canonical (
+                 namespace TEXT NOT NULL DEFAULT '_default',
+                 id TEXT NOT NULL,
+                 version INTEGER NOT NULL,
+                 labels_json TEXT NOT NULL,
+                 related_json TEXT NOT NULL,
+                 PRIMARY KEY (namespace, id)
+             );
+             INSERT INTO csm_canonical (id, version, labels_json, related_json)
+             SELECT id, version, labels_json, related_json FROM csm_canonical_old;
+             DROP TABLE csm_canonical_old;
+             CREATE INDEX idx_csm_canonical_namespace ON csm_canonical(namespace);",
+        )
+        .await
+        .map_err(|e| MemoryError::database(format!("Failed migration v8 namespace isolation: {e}")))?;
+
+        Ok(())
+    }
+
+    /// Internal migration method that reuses an existing connection.
+    /// Used by init_schema() to avoid semaphore deadlock from nested permit acquisition.
+    pub(crate) async fn apply_migrations_with_conn(
+        &self,
+        conn: &libsql::Connection,
+        target_version: i64,
+    ) -> Result<()> {
+        let current = self.schema_version_with_conn(conn).await?;
+        if target_version <= current {
+            return Ok(());
+        }
+
+        conn.execute("BEGIN", ()).await.map_err(|e| {
+            MemoryError::database(format!("Failed to begin migration transaction: {e}"))
+        })?;
+
+        for version in (current + 1)..=target_version {
+            info!(version, "applying schema migration");
+            if version == 2 {
+                conn.execute_batch(
+                    "CREATE INDEX IF NOT EXISTS idx_csm_versions_modified_at
+                     ON csm_versions(modified_at);",
+                )
+                .await
+                .map_err(|e| MemoryError::database(format!("Failed migration v2: {e}")))?;
+            }
+
+            if version == 3
+                && !self
+                    .column_exists(conn, "csm_concepts", "expires_at")
+                    .await?
+            {
+                conn.execute_batch("ALTER TABLE csm_concepts ADD COLUMN expires_at INTEGER;")
+                    .await
+                    .map_err(|e| MemoryError::database(format!("Failed migration v3: {e}")))?;
+            }
+
+            if version == 4 {
+                conn.execute_batch(
+                    "CREATE TABLE IF NOT EXISTS csm_canonical (
+                        id TEXT PRIMARY KEY,
+                        version INTEGER NOT NULL,
+                        labels_json TEXT NOT NULL,
+                        related_json TEXT NOT NULL
+                    );",
+                )
+                .await
+                .map_err(|e| MemoryError::database(format!("Failed migration v4: {e}")))?;
+            }
+
+            if version == 5 {
+                self.apply_v5_namespace_migration(conn).await?;
+            }
+
+            if version == 6
+                && !self
+                    .column_exists(conn, "csm_concepts", "canonical_concept_ids_json")
+                    .await?
+            {
+                conn.execute_batch(
+                    "ALTER TABLE csm_concepts ADD COLUMN canonical_concept_ids_json TEXT;",
+                )
+                .await
+                .map_err(|e| MemoryError::database(format!("Failed migration v6: {e}")))?;
+            }
+
+            if version == 7 {
+                conn.execute_batch(
+                    "CREATE TABLE IF NOT EXISTS csm_hnsw_graph (
+                        id TEXT PRIMARY KEY,
+                        data BLOB NOT NULL,
+                        modified_at INTEGER NOT NULL
+                    );",
+                )
+                .await
+                .map_err(|e| MemoryError::database(format!("Failed migration v7: {}", e)))?;
+            }
+
+            if version == 8 {
+                self.apply_v8_namespace_migration(conn).await?;
+            }
+
+            conn.execute(
+                "INSERT INTO csm_schema_version(version) VALUES (?1)",
+                libsql::params![version],
+            )
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to record schema version: {e}")))?;
+        }
+
+        conn.execute("COMMIT", ())
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to commit migrations: {e}")))?;
+
+        Ok(())
+    }
+
+    /// Internal schema version query that reuses an existing connection.
+    async fn schema_version_with_conn(&self, conn: &libsql::Connection) -> Result<i64> {
+        let mut rows = conn
+            .query(
+                "SELECT COALESCE(MAX(version), 0) FROM csm_schema_version",
+                (),
+            )
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to get schema version: {e}")))?;
+
+        if let Some(row) = rows.next().await.map_err(|e| {
+            MemoryError::database(format!("Failed to fetch schema version row: {e}"))
+        })? {
+            let version: i64 = row.get(0).map_err(|e| {
+                MemoryError::database(format!("Failed to parse schema version: {e}"))
+            })?;
+            Ok(version)
+        } else {
+            Ok(0)
+        }
+    }
+}

--- a/crates/csm-persistence/src/persistence_ops.rs
+++ b/crates/csm-persistence/src/persistence_ops.rs
@@ -1,0 +1,394 @@
+use libsql::params;
+use tokio::fs;
+use tracing::warn;
+
+use crate::persistence::{ConceptVersion, Persistence};
+use csm_core::error::{MemoryError, Result};
+
+impl Persistence {
+    pub async fn save_associations(
+        &self,
+        ns: &str,
+        associations: &[(String, String, f32)],
+    ) -> Result<()> {
+        if associations.is_empty() {
+            return Ok(());
+        }
+
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to begin transaction: {e}")))?;
+
+        let stmt = conn
+            .prepare(
+                "INSERT INTO csm_associations (namespace, from_id, to_id, strength)
+                 VALUES (?1, ?2, ?3, ?4)
+                 ON CONFLICT(namespace, from_id, to_id) DO UPDATE SET strength = excluded.strength",
+            )
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to prepare statement: {e}")))?;
+
+        let mut first_error: Option<MemoryError> = None;
+        for (from, to, strength) in associations {
+            stmt.reset();
+            if let Err(e) = stmt
+                .execute(params![ns, from.as_str(), to.as_str(), *strength])
+                .await
+            {
+                first_error = Some(MemoryError::database(format!(
+                    "Failed to batch save association: {e}"
+                )));
+                break;
+            }
+        }
+
+        if let Some(error) = first_error {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(error);
+        }
+
+        conn.execute("COMMIT", ())
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to commit transaction: {e}")))?;
+
+        Ok(())
+    }
+
+    pub async fn clear_namespace(&self, ns: &str) -> Result<()> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to begin transaction: {e}")))?;
+
+        let tables = [
+            "DELETE FROM csm_associations WHERE namespace = ?1",
+            "DELETE FROM csm_versions WHERE namespace = ?1",
+            "DELETE FROM csm_concepts WHERE namespace = ?1",
+            "DELETE FROM csm_hnsw_graph WHERE namespace = ?1",
+            "DELETE FROM csm_canonical WHERE namespace = ?1",
+        ];
+
+        for sql in &tables {
+            if let Err(e) = conn.execute(sql, params![ns]).await {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                return Err(MemoryError::database(format!(
+                    "Failed to clear namespace data: {e}"
+                )));
+            }
+        }
+
+        conn.execute("COMMIT", ())
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to commit namespace clear: {e}")))?;
+        Ok(())
+    }
+
+    pub async fn clear_all(&self) -> Result<()> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+        conn.execute_batch(
+            "BEGIN;
+             DELETE FROM csm_associations;
+             DELETE FROM csm_versions;
+             DELETE FROM csm_concepts;
+             DELETE FROM csm_hnsw_graph;
+             DELETE FROM csm_canonical;
+             COMMIT;",
+        )
+        .await
+        .map_err(|e| MemoryError::database(format!("Failed to clear all data: {e}")))?;
+        Ok(())
+    }
+
+    pub async fn get_concept_history(
+        &self,
+        ns: &str,
+        id: &str,
+        limit: usize,
+    ) -> Result<Vec<ConceptVersion>> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+
+        let mut rows = conn
+            .query(
+                "SELECT concept_id, version, vector, metadata, modified_at
+                 FROM csm_versions
+                 WHERE namespace = ?1 AND concept_id = ?2
+                 ORDER BY version DESC
+                 LIMIT ?3",
+                libsql::params![ns, id, limit as i64],
+            )
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to load concept history: {e}")))?;
+
+        let mut history = Vec::new();
+        while let Some(row) = rows.next().await.map_err(|e| {
+            MemoryError::database(format!("Failed to fetch concept history row: {e}"))
+        })? {
+            let concept_id: String = row
+                .get(0)
+                .map_err(|e| MemoryError::database(format!("Failed to get concept_id: {e}")))?;
+            let version: i64 = row
+                .get(1)
+                .map_err(|e| MemoryError::database(format!("Failed to get version: {e}")))?;
+            let vector_bytes: Vec<u8> = row
+                .get(2)
+                .map_err(|e| MemoryError::database(format!("Failed to get vector: {e}")))?;
+            let metadata_json: String = row
+                .get(3)
+                .map_err(|e| MemoryError::database(format!("Failed to get metadata: {e}")))?;
+            let modified_at: i64 = row
+                .get(4)
+                .map_err(|e| MemoryError::database(format!("Failed to get modified_at: {e}")))?;
+
+            history.push(ConceptVersion {
+                concept_id,
+                version: version as u64,
+                timestamp_unix: modified_at as u64,
+                vector: Some(csm_core::hyperdim::HVec10240::from_bytes(&vector_bytes)?),
+                metadata: Some(serde_json::from_str(&metadata_json)?),
+                vector_changed: None,
+                metadata_changed: None,
+            });
+        }
+
+        Ok(history)
+    }
+
+    pub async fn schema_version(&self) -> Result<i64> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                "SELECT COALESCE(MAX(version), 0) FROM csm_schema_version",
+                (),
+            )
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to get schema version: {e}")))?;
+
+        if let Some(row) = rows.next().await.map_err(|e| {
+            MemoryError::database(format!("Failed to fetch schema version row: {e}"))
+        })? {
+            let version: i64 = row.get(0).map_err(|e| {
+                MemoryError::database(format!("Failed to parse schema version: {e}"))
+            })?;
+            Ok(version)
+        } else {
+            Ok(0)
+        }
+    }
+
+    pub async fn apply_migrations(&self, target_version: i64) -> Result<()> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+        self.apply_migrations_with_conn(&conn, target_version).await
+    }
+
+    pub async fn backup(&self, path: &str) -> Result<()> {
+        let Some(_local_path) = &self.local_path else {
+            return Err(MemoryError::UnsupportedOperation(
+                "backup is only supported for local SQLite databases".to_string(),
+            ));
+        };
+
+        self.checkpoint().await?;
+        if fs::metadata(path).await.is_ok() {
+            fs::remove_file(path).await.map_err(MemoryError::Io)?;
+        }
+
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+        conn.execute("VACUUM INTO ?1", params![path])
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to create backup: {e}")))?;
+        Ok(())
+    }
+
+    pub async fn restore(&self, path: &str) -> Result<()> {
+        let Some(_local_path) = &self.local_path else {
+            return Err(MemoryError::UnsupportedOperation(
+                "restore is only supported for local SQLite databases".to_string(),
+            ));
+        };
+
+        fs::metadata(path).await.map_err(MemoryError::Io)?;
+
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+        conn.execute("BEGIN IMMEDIATE", ()).await.map_err(|e| {
+            MemoryError::database(format!("Failed to begin restore transaction: {e}"))
+        })?;
+
+        if let Err(error) = async {
+            conn.execute("ATTACH DATABASE ?1 AS restore_db", params![path])
+                .await
+                .map_err(|e| MemoryError::database(format!("Failed to attach backup DB: {e}")))?;
+
+            conn.execute_batch(
+                "DELETE FROM csm_associations;
+                 DELETE FROM csm_versions;
+                 DELETE FROM csm_concepts;
+                 DELETE FROM csm_hnsw_graph;
+                 DELETE FROM csm_canonical;
+                 DELETE FROM csm_schema_version;",
+            )
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to clear current database: {e}")))?;
+
+            conn.execute_batch(
+                "INSERT INTO csm_concepts (namespace, id, vector, metadata, created_at, modified_at, expires_at, canonical_concept_ids_json)
+                 SELECT namespace, id, vector, metadata, created_at, modified_at, expires_at, canonical_concept_ids_json FROM restore_db.csm_concepts;
+                 INSERT INTO csm_associations (namespace, from_id, to_id, strength)
+                 SELECT namespace, from_id, to_id, strength FROM restore_db.csm_associations;
+                 INSERT INTO csm_versions (namespace, concept_id, version, vector, metadata, modified_at)
+                 SELECT namespace, concept_id, version, vector, metadata, modified_at FROM restore_db.csm_versions;
+                 INSERT INTO csm_hnsw_graph (namespace, id, data, modified_at)
+                 SELECT namespace, id, data, modified_at FROM restore_db.csm_hnsw_graph;
+                 INSERT INTO csm_canonical (namespace, id, version, labels_json, related_json)
+                 SELECT namespace, id, version, labels_json, related_json FROM restore_db.csm_canonical;
+                 INSERT INTO csm_schema_version(version)
+                 SELECT version FROM restore_db.csm_schema_version;",
+            )
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to import backup data: {e}")))?;
+
+            Ok::<(), MemoryError>(())
+        }
+        .await
+        {
+            let _ = conn.execute_batch("ROLLBACK;").await;
+            return Err(error);
+        }
+
+        conn.execute("COMMIT", ())
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to commit restore: {e}")))?;
+        if let Err(error) = conn.execute_batch("DETACH DATABASE restore_db;").await {
+            warn!(error = %error, "failed to detach restore_db after restore");
+        }
+
+        self.init_schema().await?;
+        Ok(())
+    }
+
+    pub async fn health_check(&self) -> Result<()> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+        conn.query("SELECT 1", ())
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed persistence health check: {e}")))?;
+        Ok(())
+    }
+
+    /// Delete a single association between two concepts.
+    pub async fn delete_association(&self, ns: &str, from: &str, to: &str) -> Result<()> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+        conn.execute(
+            "DELETE FROM csm_associations WHERE namespace = ?1 AND from_id = ?2 AND to_id = ?3",
+            params![ns, from, to],
+        )
+        .await
+        .map_err(|e| MemoryError::database(format!("Failed to delete association: {e}")))?;
+        Ok(())
+    }
+
+    /// Clear all outbound associations for a concept.
+    pub async fn clear_concept_associations(&self, ns: &str, id: &str) -> Result<()> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+        conn.execute(
+            "DELETE FROM csm_associations WHERE namespace = ?1 AND from_id = ?2",
+            params![ns, id],
+        )
+        .await
+        .map_err(|e| MemoryError::database(format!("Failed to clear concept associations: {e}")))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "persistence")]
+mod tests {
+    use crate::persistence::Persistence;
+    use crate::singularity::Concept;
+    use csm_core::hyperdim::HVec10240;
+    use std::collections::HashMap;
+    use tempfile::NamedTempFile;
+
+    fn make_concept(id: &str) -> Concept {
+        Concept {
+            id: id.to_string(),
+            vector: HVec10240::random(),
+            metadata: HashMap::new(),
+            created_at: 0,
+            modified_at: 0,
+            expires_at: None,
+            canonical_concept_ids: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn save_and_load_concept_roundtrip() {
+        let temp = NamedTempFile::new().expect("Failed to create temp file");
+        let path = temp.path().to_str().expect("Invalid path");
+        let persistence = Persistence::new_local(path)
+            .await
+            .expect("Failed to create persistence");
+
+        let ns = "_default";
+        let concept = make_concept("test-concept");
+
+        persistence
+            .save_concept(ns, &concept)
+            .await
+            .expect("Failed to save");
+        let loaded = persistence
+            .load_concept(ns, "test-concept")
+            .await
+            .expect("Failed to load")
+            .expect("Concept not found");
+        assert_eq!(loaded.id, concept.id);
+    }
+
+    #[tokio::test]
+    async fn delete_concept_removes_from_db() {
+        let temp = NamedTempFile::new().expect("Failed to create temp file");
+        let path = temp.path().to_str().expect("Invalid path");
+        let persistence = Persistence::new_local(path)
+            .await
+            .expect("Failed to create persistence");
+
+        let ns = "_default";
+        let concept = make_concept("delete-test");
+
+        persistence
+            .save_concept(ns, &concept)
+            .await
+            .expect("Failed to save");
+        persistence
+            .delete_concept(ns, "delete-test")
+            .await
+            .expect("Failed to delete");
+        let result = persistence.load_concept(ns, "delete-test").await;
+        assert!(result.expect("Query failed").is_none());
+    }
+
+    #[tokio::test]
+    async fn schema_version_initialized() {
+        let temp = NamedTempFile::new().expect("Failed to create temp file");
+        let path = temp.path().to_str().expect("Invalid path");
+        let persistence = Persistence::new_local(path)
+            .await
+            .expect("Failed to create persistence");
+
+        let version = persistence
+            .schema_version()
+            .await
+            .expect("Failed to get version");
+        assert!(version > 0);
+    }
+}

--- a/crates/csm-persistence/src/persistence_versions.rs
+++ b/crates/csm-persistence/src/persistence_versions.rs
@@ -1,0 +1,220 @@
+use crate::persistence::Persistence;
+use csm_core::error::{MemoryError, Result};
+use csm_memory::{Concept, ConceptVersion};
+use libsql::{Connection, params};
+
+#[allow(dead_code)]
+impl Persistence {
+    pub(crate) async fn record_concept_version(
+        &self,
+        conn: &Connection,
+        concept: &Concept,
+    ) -> Result<()> {
+        self.record_concept_version_scoped(conn, "_default", concept, None, None)
+            .await
+    }
+
+    /// Records a new concept version, optionally using pre-computed vector bytes and metadata JSON.
+    /// Performance Optimization: Accepting pre-computed values avoids redundant serialization and
+    /// allocations when this is called from batch operations or normal save paths.
+    pub(crate) async fn record_concept_version_scoped(
+        &self,
+        conn: &Connection,
+        ns: &str,
+        concept: &Concept,
+        vector_bytes: Option<&[u8]>,
+        metadata_json: Option<&str>,
+    ) -> Result<()> {
+        let mut rows = conn
+            .query(
+                "SELECT COALESCE(MAX(version), 0) FROM csm_versions WHERE namespace = ?1 AND concept_id = ?2",
+                params![ns, concept.id.as_str()],
+            )
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to query concept version: {e}")))?;
+
+        let current = if let Some(row) = rows.next().await.map_err(|e| {
+            MemoryError::database(format!("Failed to fetch concept version row: {e}"))
+        })? {
+            row.get::<i64>(0).map_err(|e| {
+                MemoryError::database(format!("Failed to read version from row: {e}"))
+            })?
+        } else {
+            0
+        };
+        let next_version = current + 1;
+        let vector_bytes_owned: Vec<u8>;
+        let vector_ref = if let Some(v) = vector_bytes {
+            v
+        } else {
+            vector_bytes_owned = concept.vector.to_bytes();
+            &vector_bytes_owned
+        };
+
+        let metadata_owned: String;
+        let metadata_ref = if let Some(m) = metadata_json {
+            m
+        } else {
+            metadata_owned = serde_json::to_string(&concept.metadata)?;
+            &metadata_owned
+        };
+
+        conn.execute(
+            "INSERT INTO csm_versions (namespace, concept_id, version, vector, metadata, modified_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                ns,
+                concept.id.as_str(),
+                next_version,
+                vector_ref,
+                metadata_ref,
+                concept.modified_at as i64
+            ],
+        )
+        .await
+        .map_err(|e| MemoryError::database(format!("Failed to save concept version: {e}")))?;
+
+        conn.execute(
+            "DELETE FROM csm_versions
+             WHERE namespace = ?1 AND concept_id = ?2
+             AND version <= (
+                SELECT MAX(version) - ?3 FROM csm_versions WHERE namespace = ?1 AND concept_id = ?2
+             )",
+            params![ns, concept.id.as_str(), self.version_retention as i64],
+        )
+        .await
+        .map_err(|e| MemoryError::database(format!("Failed to prune concept versions: {e}")))?;
+
+        Ok(())
+    }
+
+    /// Load a specific concept version from the database.
+    pub async fn get_version_scoped(
+        &self,
+        ns: &str,
+        id: &str,
+        version: u64,
+    ) -> Result<Option<Concept>> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+
+        let mut rows = conn
+            .query(
+                "SELECT v.vector, v.metadata, v.modified_at, c.created_at, c.expires_at, c.canonical_concept_ids_json
+                 FROM csm_versions v
+                 LEFT JOIN csm_concepts c ON v.namespace = c.namespace AND v.concept_id = c.id
+                 WHERE v.namespace = ?1 AND v.concept_id = ?2 AND v.version = ?3",
+                params![ns, id, version as i64],
+            )
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to load concept version: {e}")))?;
+
+        if let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to fetch row: {e}")))?
+        {
+            let vector_bytes: Vec<u8> = row
+                .get(0)
+                .map_err(|e| MemoryError::database(format!("Failed to get vector bytes: {e}")))?;
+            let metadata_json: String = row
+                .get(1)
+                .map_err(|e| MemoryError::database(format!("Failed to get metadata JSON: {e}")))?;
+            let modified_at: i64 = row
+                .get(2)
+                .map_err(|e| MemoryError::database(format!("Failed to get modified_at: {e}")))?;
+
+            let created_at: i64 = row.get(3).unwrap_or(modified_at);
+            let expires_at: Option<i64> = row.get::<Option<i64>>(4).ok().flatten();
+            let canonical_concept_ids_json: Option<String> =
+                row.get::<Option<String>>(5).ok().flatten();
+
+            let vector = csm_core::hyperdim::HVec10240::from_bytes(&vector_bytes)?;
+            let metadata = serde_json::from_str(&metadata_json)?;
+            let canonical_concept_ids = canonical_concept_ids_json
+                .as_deref()
+                .map(serde_json::from_str)
+                .transpose()?
+                .unwrap_or_default();
+
+            Ok(Some(Concept {
+                id: id.to_string(),
+                vector,
+                metadata,
+                created_at: created_at as u64,
+                modified_at: modified_at as u64,
+                expires_at: expires_at.map(|t| t as u64),
+                canonical_concept_ids,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// List all versions of a concept in a namespace.
+    pub async fn list_versions_scoped(&self, ns: &str, id: &str) -> Result<Vec<ConceptVersion>> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+
+        let mut rows = conn
+            .query(
+                "SELECT version, vector, metadata, modified_at
+                 FROM csm_versions
+                 WHERE namespace = ?1 AND concept_id = ?2
+                 ORDER BY version ASC",
+                params![ns, id],
+            )
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to list concept versions: {e}")))?;
+
+        let mut list = Vec::new();
+        let mut prev_vector: Option<Vec<u8>> = None;
+        let mut prev_metadata: Option<String> = None;
+
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to fetch row: {e}")))?
+        {
+            let version: i64 = row
+                .get(0)
+                .map_err(|e| MemoryError::database(format!("Failed to get version: {e}")))?;
+            let vector_bytes: Vec<u8> = row
+                .get(1)
+                .map_err(|e| MemoryError::database(format!("Failed to get vector bytes: {e}")))?;
+            let metadata_json: String = row
+                .get(2)
+                .map_err(|e| MemoryError::database(format!("Failed to get metadata JSON: {e}")))?;
+            let modified_at: i64 = row
+                .get(3)
+                .map_err(|e| MemoryError::database(format!("Failed to get modified_at: {e}")))?;
+
+            let vector_changed = if let Some(ref prev_v) = prev_vector {
+                *prev_v != vector_bytes
+            } else {
+                true
+            };
+
+            let metadata_changed = if let Some(ref prev_m) = prev_metadata {
+                *prev_m != metadata_json
+            } else {
+                true
+            };
+
+            prev_vector = Some(vector_bytes);
+            prev_metadata = Some(metadata_json);
+
+            list.push(ConceptVersion {
+                concept_id: id.to_string(),
+                version: version as u64,
+                timestamp_unix: modified_at as u64,
+                vector: None,
+                metadata: None,
+                vector_changed: Some(vector_changed),
+                metadata_changed: Some(metadata_changed),
+            });
+        }
+
+        Ok(list)
+    }
+}

--- a/crates/csm-persistence/src/persistence_wasm.rs
+++ b/crates/csm-persistence/src/persistence_wasm.rs
@@ -1,0 +1,223 @@
+//! WASM persistence stubs.
+//!
+//! Persistence is unavailable on `wasm32` in this crate build.
+//! All operations return `MemoryError::UnsupportedOperation`.
+
+use crate::singularity::Concept;
+use csm_core::error::{MemoryError, Result};
+
+/// Persistence stub for wasm32 builds.
+pub struct Persistence;
+
+pub use crate::singularity::ConceptVersion;
+
+impl Persistence {
+    pub async fn new_local(_path: &str) -> Result<Self> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn new_local_with_retention(_path: &str, _retention: usize) -> Result<Self> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn new_turso(_url: &str, _token: &str) -> Result<Self> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn new_turso_with_pool(_url: &str, _token: &str, _pool_size: usize) -> Result<Self> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn new_turso_with_pool_and_retention(
+        _url: &str,
+        _token: &str,
+        _pool_size: usize,
+        _retention: usize,
+    ) -> Result<Self> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn save_concept(&self, _ns: &str, _concept: &Concept) -> Result<()> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn save_concepts(&self, _ns: &str, _concepts: &[Concept]) -> Result<()> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn load_concept(&self, _ns: &str, _id: &str) -> Result<Option<Concept>> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn load_all_concepts(&self, _ns: &str) -> Result<Vec<Concept>> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn delete_concept(&self, _ns: &str, _id: &str) -> Result<()> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn save_association(
+        &self,
+        _ns: &str,
+        _from: &str,
+        _to: &str,
+        _strength: f32,
+    ) -> Result<()> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn save_associations(
+        &self,
+        _ns: &str,
+        _associations: &[(String, String, f32)],
+    ) -> Result<()> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn load_associations(&self, _ns: &str, _id: &str) -> Result<Vec<(String, f32)>> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn clear_namespace(&self, _ns: &str) -> Result<()> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn clear_all(&self) -> Result<()> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn get_version_scoped(
+        &self,
+        _ns: &str,
+        _id: &str,
+        _version: u64,
+    ) -> Result<Option<Concept>> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn list_versions_scoped(
+        &self,
+        _ns: &str,
+        _id: &str,
+    ) -> Result<Vec<crate::singularity::ConceptVersion>> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn get_concept_history(
+        &self,
+        _ns: &str,
+        _id: &str,
+        _limit: usize,
+    ) -> Result<Vec<ConceptVersion>> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn schema_version(&self) -> Result<i64> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn apply_migrations(&self, _target_version: i64) -> Result<()> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn backup(&self, _path: &str) -> Result<()> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn restore(&self, _path: &str) -> Result<()> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn checkpoint(&self) -> Result<()> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn health_check(&self) -> Result<()> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn size(&self) -> Result<u64> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn save_index(&self, _ns: &str, _id: &str, _data: &[u8]) -> Result<()> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn list_namespaces(&self) -> Result<Vec<String>> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn load_index(&self, _ns: &str, _id: &str) -> Result<Option<Vec<u8>>> {
+        Err(wasm_persistence_unavailable())
+    }
+}
+
+fn wasm_persistence_unavailable() -> MemoryError {
+    MemoryError::UnsupportedOperation("Persistence is unavailable on wasm32".to_string())
+}
+
+// ============================================================================
+// TESTS
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use csm_core::hyperdim::HVec10240;
+
+    #[tokio::test]
+    async fn new_local_returns_unsupported() {
+        let result = Persistence::new_local("test.db").await;
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        assert!(matches!(err, MemoryError::UnsupportedOperation(_)));
+    }
+
+    #[tokio::test]
+    async fn new_turso_returns_unsupported() {
+        let result = Persistence::new_turso("https://example.com", "token").await;
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        assert!(matches!(err, MemoryError::UnsupportedOperation(_)));
+    }
+
+    #[tokio::test]
+    async fn all_operations_return_unsupported() {
+        // Persistence struct cannot be created (constructor fails),
+        // but we can verify the error function behavior
+        let err = wasm_persistence_unavailable();
+
+        assert!(matches!(err, MemoryError::UnsupportedOperation(_)));
+
+        // Verify error message contains expected text
+        let msg = err.to_string();
+        assert!(msg.contains("wasm32"));
+        assert!(msg.contains("unavailable"));
+    }
+
+    #[test]
+    fn concept_version_serialization_roundtrip() {
+        // ConceptVersion is used in WASM builds for version serialization
+        let version = ConceptVersion {
+            concept_id: "test-id".to_string(),
+            version: 1,
+            timestamp_unix: 12345,
+            vector: Some(HVec10240::zero()),
+            metadata: Some(serde_json::json!({"key": "value"})),
+            vector_changed: None,
+            metadata_changed: None,
+        };
+
+        // Serialize to JSON
+        let json = serde_json::to_string(&version).unwrap();
+
+        // Deserialize back
+        let recovered: ConceptVersion = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(recovered, version);
+    }
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -19,6 +19,7 @@
 - csm-core
 - csm-embedding
 - csm-memory
+- csm-persistence
 - csm-retrieval
 - fastembed (4)
 - glob (0.3.2)

--- a/llms.txt
+++ b/llms.txt
@@ -19,6 +19,7 @@
 - csm-core
 - csm-embedding
 - csm-memory
+- csm-persistence
 - csm-retrieval
 - fastembed (4)
 - glob (0.3.2)
@@ -1293,6 +1294,7 @@ members = [
     "crates/csm-embedding",
     "crates/csm-memory",
     "crates/csm-retrieval",
+    "crates/csm-persistence",
     ".",
     "benchmarks",
     "crates/chaotic_semantic_memory_duckdb",
@@ -1349,6 +1351,7 @@ csm-core = { path = "crates/csm-core" }
 csm-embedding = { path = "crates/csm-embedding" }
 csm-memory = { path = "crates/csm-memory" }
 csm-retrieval = { path = "crates/csm-retrieval" }
+csm-persistence = { path = "crates/csm-persistence" }
 tempfile = { workspace = true }
 # Serialization
 serde = { workspace = true }


### PR DESCRIPTION
## Summary

- Extract persistence backends into standalone `csm-persistence` workspace crate
- Move libSQL backend and schema migrations
- Update imports to use csm-memory types
- Add csm-persistence as dependency to main crate

## Changes

- Created `crates/csm-persistence/` with libSQL backend
- Moved persistence modules from main crate
- Updated imports to use `csm_memory` types (Concept, ConceptVersion, unix_now_secs)
- Added `libsql` feature (default) and `wasm` feature
- Added csm-persistence to workspace members and as dependency to main crate

## Testing

- `cargo test -p csm-persistence` passes
- `cargo test --quiet` passes (all tests)
- `cargo check --all-features` passes
- `cargo clippy -- -D warnings` passes
- `cargo fmt --check` passes

## Related Issues

- Closes #367