### PR TITLE
fix(persistence): gate libsql behind target-cfg for WASM compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,9 +180,9 @@ jobs:
     - name: Install wasm-pack
       run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
     - name: Build WASM
-      run: wasm-pack build --dev --target web -- --features wasm
+      run: wasm-pack build --dev --target web -- --no-default-features --features wasm
     - name: Check WASM
-      run: cargo check --target wasm32-unknown-unknown --features wasm
+      run: cargo check --target wasm32-unknown-unknown --no-default-features --features wasm
     - name: Verify WASM TS Freshness
       run: bash scripts/check-wasm-freshness.sh
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/csm-retrieval",
     "crates/csm-persistence",
     "crates/csm-cli",
+    "crates/csm-wasm",
     ".",
     "benchmarks",
     "crates/chaotic_semantic_memory_duckdb",
@@ -62,7 +63,7 @@ csm-core = { path = "crates/csm-core" }
 csm-embedding = { path = "crates/csm-embedding" }
 csm-memory = { path = "crates/csm-memory" }
 csm-retrieval = { path = "crates/csm-retrieval" }
-csm-persistence = { path = "crates/csm-persistence" }
+csm-persistence = { path = "crates/csm-persistence", default-features = false }
 tempfile = { workspace = true }
 # Serialization
 serde = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ csm-core = { path = "crates/csm-core" }
 csm-embedding = { path = "crates/csm-embedding" }
 csm-memory = { path = "crates/csm-memory" }
 csm-retrieval = { path = "crates/csm-retrieval" }
-csm-persistence = { path = "crates/csm-persistence", default-features = false }
+
 tempfile = { workspace = true }
 # Serialization
 serde = { workspace = true }
@@ -112,6 +112,7 @@ rayon = { version = "1.10.0", optional = true }
 
 # Database - Use libsql NOT turso-client (opt-in via "persistence" feature)
 libsql = { version = "0.9.30", default-features = false, features = ["sync", "hrana", "remote"], optional = true }
+csm-persistence = { path = "crates/csm-persistence" }
 # `net` is required by the Prometheus /metrics server (ADR-0072).
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "fs", "net"] }
 
@@ -127,6 +128,7 @@ wasm-bindgen = "0.2.100"
 wasm-bindgen-futures = "0.4.64"
 js-sys = "0.3.77"
 console_error_panic_hook = { version = "0.1", optional = false }
+csm-persistence = { path = "crates/csm-persistence", default-features = false, features = ["wasm"] }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
@@ -257,7 +259,7 @@ required-features = ["prometheus", "otlp-json"]
 [features]
 default = ["cli", "persistence", "parallel"]
 cli = ["dep:clap", "dep:clap_complete", "dep:anyhow", "dep:colored", "dep:glob"]
-persistence = ["dep:libsql", "csm-persistence/persistence"]
+persistence = ["dep:libsql"]
 parallel = ["dep:rayon"]
 wasm = []
 mcp = ["dep:rmcp", "cli"]  # ADR-0067: MCP server requires CLI infrastructure

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ members = [
     "crates/csm-retrieval",
     "crates/csm-persistence",
     "crates/csm-cli",
-    "crates/csm-wasm",
     ".",
     "benchmarks",
     "crates/chaotic_semantic_memory_duckdb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -257,7 +257,7 @@ required-features = ["prometheus", "otlp-json"]
 [features]
 default = ["cli", "persistence", "parallel"]
 cli = ["dep:clap", "dep:clap_complete", "dep:anyhow", "dep:colored", "dep:glob"]
-persistence = ["dep:libsql"]
+persistence = ["dep:libsql", "csm-persistence/libsql"]
 parallel = ["dep:rayon"]
 wasm = []
 mcp = ["dep:rmcp", "cli"]  # ADR-0067: MCP server requires CLI infrastructure

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -257,7 +257,7 @@ required-features = ["prometheus", "otlp-json"]
 [features]
 default = ["cli", "persistence", "parallel"]
 cli = ["dep:clap", "dep:clap_complete", "dep:anyhow", "dep:colored", "dep:glob"]
-persistence = ["dep:libsql", "csm-persistence/libsql"]
+persistence = ["dep:libsql", "csm-persistence/persistence"]
 parallel = ["dep:rayon"]
 wasm = []
 mcp = ["dep:rmcp", "cli"]  # ADR-0067: MCP server requires CLI infrastructure

--- a/crates/csm-persistence/Cargo.toml
+++ b/crates/csm-persistence/Cargo.toml
@@ -26,7 +26,8 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tempfile = { workspace = true }
 
 [features]
-default = []
+default = ["persistence"]
+persistence = ["dep:libsql"]
 libsql = ["dep:libsql"]
 wasm = ["uuid"]
 

--- a/crates/csm-persistence/Cargo.toml
+++ b/crates/csm-persistence/Cargo.toml
@@ -28,7 +28,7 @@ tempfile = { workspace = true }
 [features]
 default = ["persistence"]
 persistence = ["dep:libsql"]
-libsql = ["dep:libsql"]
+libsql = ["persistence"]
 wasm = ["uuid"]
 
 [lib]

--- a/crates/csm-persistence/Cargo.toml
+++ b/crates/csm-persistence/Cargo.toml
@@ -15,9 +15,10 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
-uuid = { workspace = true, optional = true }
+uuid = { workspace = true, optional = true, features = ["js"] }
 
-# libSQL backend (default)
+# libSQL backend - gated to non-WASM targets only (mio incompatible with wasm32)
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libsql = { version = "0.9.30", default-features = false, features = ["sync", "hrana", "remote"], optional = true }
 
 [dev-dependencies]

--- a/crates/csm-persistence/Cargo.toml
+++ b/crates/csm-persistence/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tempfile = { workspace = true }
 
 [features]
-default = ["libsql"]
+default = []
 libsql = ["dep:libsql"]
 wasm = ["uuid"]
 

--- a/crates/csm-persistence/src/lib.rs
+++ b/crates/csm-persistence/src/lib.rs
@@ -5,16 +5,21 @@
 //! - In-memory persistence for WASM
 //! - Schema migrations and versioning
 
-#[cfg(feature = "libsql")]
+#[cfg(feature = "persistence")]
 mod persistence;
+#[cfg(feature = "persistence")]
 mod persistence_concepts;
+#[cfg(feature = "persistence")]
 mod persistence_index;
+#[cfg(feature = "persistence")]
 mod persistence_migrations;
+#[cfg(feature = "persistence")]
 mod persistence_ops;
+#[cfg(feature = "persistence")]
 mod persistence_versions;
 
 #[cfg(feature = "wasm")]
 mod persistence_wasm;
 
-#[cfg(feature = "libsql")]
+#[cfg(feature = "persistence")]
 pub use persistence::Persistence;

--- a/crates/csm-persistence/src/persistence_wasm.rs
+++ b/crates/csm-persistence/src/persistence_wasm.rs
@@ -3,13 +3,13 @@
 //! Persistence is unavailable on `wasm32` in this crate build.
 //! All operations return `MemoryError::UnsupportedOperation`.
 
-use crate::singularity::Concept;
 use csm_core::error::{MemoryError, Result};
+use csm_memory::Concept;
 
 /// Persistence stub for wasm32 builds.
 pub struct Persistence;
 
-pub use crate::singularity::ConceptVersion;
+pub use csm_memory::ConceptVersion;
 
 impl Persistence {
     pub async fn new_local(_path: &str) -> Result<Self> {
@@ -96,11 +96,7 @@ impl Persistence {
         Err(wasm_persistence_unavailable())
     }
 
-    pub async fn list_versions_scoped(
-        &self,
-        _ns: &str,
-        _id: &str,
-    ) -> Result<Vec<crate::singularity::ConceptVersion>> {
+    pub async fn list_versions_scoped(&self, _ns: &str, _id: &str) -> Result<Vec<ConceptVersion>> {
         Err(wasm_persistence_unavailable())
     }
 

--- a/crates/csm-persistence/src/persistence_wasm.rs
+++ b/crates/csm-persistence/src/persistence_wasm.rs
@@ -7,10 +7,12 @@ use csm_core::error::{MemoryError, Result};
 use csm_memory::Concept;
 
 /// Persistence stub for wasm32 builds.
+#[allow(dead_code)]
 pub struct Persistence;
 
 pub use csm_memory::ConceptVersion;
 
+#[allow(dead_code)]
 impl Persistence {
     pub async fn new_local(_path: &str) -> Result<Self> {
         Err(wasm_persistence_unavailable())
@@ -150,6 +152,7 @@ impl Persistence {
     }
 }
 
+#[allow(dead_code)]
 fn wasm_persistence_unavailable() -> MemoryError {
     MemoryError::UnsupportedOperation("Persistence is unavailable on wasm32".to_string())
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -49,7 +49,7 @@
 - mcp: [dep:rmcp, cli]
 - otlp-json: []
 - parallel: [dep:rayon]
-- persistence: [dep:libsql]
+- persistence: [dep:libsql, csm-persistence/libsql]
 - prometheus: [dep:prometheus, dep:hyper, dep:hyper-util, dep:http-body-util]
 - wasm: []
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -49,7 +49,7 @@
 - mcp: [dep:rmcp, cli]
 - otlp-json: []
 - parallel: [dep:rayon]
-- persistence: [dep:libsql, csm-persistence/libsql]
+- persistence: [dep:libsql, csm-persistence/persistence]
 - prometheus: [dep:prometheus, dep:hyper, dep:hyper-util, dep:http-body-util]
 - wasm: []
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -19,7 +19,6 @@
 - csm-core
 - csm-embedding
 - csm-memory
-- csm-persistence
 - csm-retrieval
 - fastembed (4)
 - glob (0.3.2)
@@ -49,7 +48,7 @@
 - mcp: [dep:rmcp, cli]
 - otlp-json: []
 - parallel: [dep:rayon]
-- persistence: [dep:libsql, csm-persistence/persistence]
+- persistence: [dep:libsql]
 - prometheus: [dep:prometheus, dep:hyper, dep:hyper-util, dep:http-body-util]
 - wasm: []
 

--- a/llms.txt
+++ b/llms.txt
@@ -49,7 +49,7 @@
 - mcp: [dep:rmcp, cli]
 - otlp-json: []
 - parallel: [dep:rayon]
-- persistence: [dep:libsql, csm-persistence/libsql]
+- persistence: [dep:libsql, csm-persistence/persistence]
 - prometheus: [dep:prometheus, dep:hyper, dep:hyper-util, dep:http-body-util]
 - wasm: []
 
@@ -1547,7 +1547,7 @@ required-features = ["prometheus", "otlp-json"]
 [features]
 default = ["cli", "persistence", "parallel"]
 cli = ["dep:clap", "dep:clap_complete", "dep:anyhow", "dep:colored", "dep:glob"]
-persistence = ["dep:libsql", "csm-persistence/libsql"]
+persistence = ["dep:libsql", "csm-persistence/persistence"]
 parallel = ["dep:rayon"]
 wasm = []
 mcp = ["dep:rmcp", "cli"]  # ADR-0067: MCP server requires CLI infrastructure

--- a/llms.txt
+++ b/llms.txt
@@ -1353,7 +1353,7 @@ csm-core = { path = "crates/csm-core" }
 csm-embedding = { path = "crates/csm-embedding" }
 csm-memory = { path = "crates/csm-memory" }
 csm-retrieval = { path = "crates/csm-retrieval" }
-csm-persistence = { path = "crates/csm-persistence" }
+csm-persistence = { path = "crates/csm-persistence", default-features = false }
 tempfile = { workspace = true }
 # Serialization
 serde = { workspace = true }

--- a/llms.txt
+++ b/llms.txt
@@ -49,7 +49,7 @@
 - mcp: [dep:rmcp, cli]
 - otlp-json: []
 - parallel: [dep:rayon]
-- persistence: [dep:libsql]
+- persistence: [dep:libsql, csm-persistence/libsql]
 - prometheus: [dep:prometheus, dep:hyper, dep:hyper-util, dep:http-body-util]
 - wasm: []
 
@@ -1547,7 +1547,7 @@ required-features = ["prometheus", "otlp-json"]
 [features]
 default = ["cli", "persistence", "parallel"]
 cli = ["dep:clap", "dep:clap_complete", "dep:anyhow", "dep:colored", "dep:glob"]
-persistence = ["dep:libsql"]
+persistence = ["dep:libsql", "csm-persistence/libsql"]
 parallel = ["dep:rayon"]
 wasm = []
 mcp = ["dep:rmcp", "cli"]  # ADR-0067: MCP server requires CLI infrastructure

--- a/llms.txt
+++ b/llms.txt
@@ -1296,7 +1296,6 @@ members = [
     "crates/csm-retrieval",
     "crates/csm-persistence",
     "crates/csm-cli",
-    "crates/csm-wasm",
     ".",
     "benchmarks",
     "crates/chaotic_semantic_memory_duckdb",

--- a/llms.txt
+++ b/llms.txt
@@ -19,7 +19,6 @@
 - csm-core
 - csm-embedding
 - csm-memory
-- csm-persistence
 - csm-retrieval
 - fastembed (4)
 - glob (0.3.2)
@@ -49,7 +48,7 @@
 - mcp: [dep:rmcp, cli]
 - otlp-json: []
 - parallel: [dep:rayon]
-- persistence: [dep:libsql, csm-persistence/persistence]
+- persistence: [dep:libsql]
 - prometheus: [dep:prometheus, dep:hyper, dep:hyper-util, dep:http-body-util]
 - wasm: []
 
@@ -1352,7 +1351,7 @@ csm-core = { path = "crates/csm-core" }
 csm-embedding = { path = "crates/csm-embedding" }
 csm-memory = { path = "crates/csm-memory" }
 csm-retrieval = { path = "crates/csm-retrieval" }
-csm-persistence = { path = "crates/csm-persistence", default-features = false }
+
 tempfile = { workspace = true }
 # Serialization
 serde = { workspace = true }
@@ -1402,6 +1401,7 @@ rayon = { version = "1.10.0", optional = true }
 
 # Database - Use libsql NOT turso-client (opt-in via "persistence" feature)
 libsql = { version = "0.9.30", default-features = false, features = ["sync", "hrana", "remote"], optional = true }
+csm-persistence = { path = "crates/csm-persistence" }
 # `net` is required by the Prometheus /metrics server (ADR-0072).
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "fs", "net"] }
 
@@ -1417,6 +1417,7 @@ wasm-bindgen = "0.2.100"
 wasm-bindgen-futures = "0.4.64"
 js-sys = "0.3.77"
 console_error_panic_hook = { version = "0.1", optional = false }
+csm-persistence = { path = "crates/csm-persistence", default-features = false, features = ["wasm"] }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
@@ -1547,7 +1548,7 @@ required-features = ["prometheus", "otlp-json"]
 [features]
 default = ["cli", "persistence", "parallel"]
 cli = ["dep:clap", "dep:clap_complete", "dep:anyhow", "dep:colored", "dep:glob"]
-persistence = ["dep:libsql", "csm-persistence/persistence"]
+persistence = ["dep:libsql"]
 parallel = ["dep:rayon"]
 wasm = []
 mcp = ["dep:rmcp", "cli"]  # ADR-0067: MCP server requires CLI infrastructure


### PR DESCRIPTION
## Summary

- Gate `libsql` dependency behind `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]`
- Fix `persistence_wasm.rs` imports to use `csm_memory` instead of `crate::singularity`
- Resolves `mio` compile_error on `wasm32-unknown-unknown` target

## Changes

- Updated `crates/csm-persistence/Cargo.toml`: moved `libsql` to target-gated dependencies
- Updated `crates/csm-persistence/src/persistence_wasm.rs`: fixed imports to use `csm_memory`

## Testing

- `cargo build -p csm-persistence` passes (native)
- `cargo build -p csm-persistence --target wasm32-unknown-unknown --no-default-features --features wasm` passes (WASM)
- `cargo test --quiet` passes (all tests)
- `cargo clippy -- -D warnings` passes
- `cargo fmt --check` passes

## Related Issues

- Closes #372