### PR TITLE
feat(wasm): create csm-wasm crate and fix WASM-incompatible functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,6 +1379,7 @@ version = "0.1.0"
 dependencies = [
  "csm-core",
  "hnsw_rs",
+ "js-sys",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1423,8 +1424,28 @@ name = "csm-traits"
 version = "0.1.0"
 dependencies = [
  "csm-core",
+ "js-sys",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "csm-wasm"
+version = "0.1.0"
+dependencies = [
+ "chaotic_semantic_memory",
+ "console_error_panic_hook",
+ "csm-core",
+ "csm-memory",
+ "csm-retrieval",
+ "csm-traits",
+ "getrandom 0.4.2",
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+ "web-sys",
 ]
 
 [[package]]
@@ -3267,6 +3288,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -6121,6 +6152,45 @@ checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28a0782b173cf2e98f62aacb487c5c021b7c5925df46098675f28e1fa85e159"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee997551ce1ad5adda03f7ce37ec34b4140fe9f547fd07b46d55901d1ba1a06b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae0f005eb61f765eff31a79ef71df7e21819731268a868df41192c1e41d6d3e5"
 
 [[package]]
 name = "wasm-encoder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/csm-persistence",
     "crates/csm-cli",
     "crates/csm-traits",
+    "crates/csm-wasm",
     ".",
     "benchmarks",
     "crates/chaotic_semantic_memory_duckdb",

--- a/crates/csm-memory/Cargo.toml
+++ b/crates/csm-memory/Cargo.toml
@@ -19,6 +19,9 @@ uuid = { workspace = true, optional = true }
 # ANN backends (opt-in)
 hnsw_rs = { version = "0.3.4", optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = "0.3.77"
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 

--- a/crates/csm-memory/src/singularity.rs
+++ b/crates/csm-memory/src/singularity.rs
@@ -470,6 +470,8 @@ impl Singularity {
     }
 }
 
+/// Get current time in Unix seconds.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn unix_now_secs() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -477,12 +479,26 @@ pub fn unix_now_secs() -> u64 {
         .as_secs()
 }
 
+/// Get current time in Unix seconds (WASM version).
+#[cfg(target_arch = "wasm32")]
+pub fn unix_now_secs() -> u64 {
+    (js_sys::Date::new_0().get_time() / 1000.0) as u64
+}
+
+/// Get current time in Unix nanoseconds.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn unix_now_ns() -> u64 {
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos();
     u64::try_from(nanos).unwrap_or(u64::MAX)
+}
+
+/// Get current time in Unix nanoseconds (WASM version).
+#[cfg(target_arch = "wasm32")]
+pub fn unix_now_ns() -> u64 {
+    (js_sys::Date::new_0().get_time() * 1_000_000.0) as u64
 }
 
 pub(crate) fn similarity_cache_key(query: &HVec10240, top_k: usize) -> u64 {

--- a/crates/csm-traits/Cargo.toml
+++ b/crates/csm-traits/Cargo.toml
@@ -12,6 +12,9 @@ csm-core = { path = "../csm-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = "0.3.77"
+
 [features]
 default = []
 parallel = ["csm-core/parallel"]

--- a/crates/csm-traits/src/lib.rs
+++ b/crates/csm-traits/src/lib.rs
@@ -201,6 +201,7 @@ impl BinaryExportPayload {
 // ============================================================================
 
 /// Get current time in Unix seconds.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn unix_now_secs() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -208,13 +209,26 @@ pub fn unix_now_secs() -> u64 {
         .as_secs()
 }
 
+/// Get current time in Unix seconds (WASM version).
+#[cfg(target_arch = "wasm32")]
+pub fn unix_now_secs() -> u64 {
+    (js_sys::Date::new_0().get_time() / 1000.0) as u64
+}
+
 /// Get current time in Unix nanoseconds.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn unix_now_ns() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos()
         .min(u128::from(u64::MAX)) as u64
+}
+
+/// Get current time in Unix nanoseconds (WASM version).
+#[cfg(target_arch = "wasm32")]
+pub fn unix_now_ns() -> u64 {
+    (js_sys::Date::new_0().get_time() * 1_000_000.0) as u64
 }
 
 #[cfg(test)]

--- a/crates/csm-wasm/Cargo.toml
+++ b/crates/csm-wasm/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "csm-wasm"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+description = "WASM bindings for chaotic_semantic_memory"
+license = "MIT"
+repository = "https://github.com/d-o-hub/chaotic_semantic_memory"
+
+[dependencies]
+chaotic_semantic_memory = { path = "../..", default-features = false, features = ["wasm"] }
+csm-core = { path = "../csm-core" }
+csm-memory = { path = "../csm-memory" }
+csm-retrieval = { path = "../csm-retrieval", default-features = false }
+csm-traits = { path = "../csm-traits" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+wasm-bindgen = "0.2.100"
+js-sys = "0.3.77"
+web-sys = { version = "0.3.77", features = ["console"] }
+console_error_panic_hook = { version = "0.1", optional = true }
+getrandom = { version = "0.4.2", features = ["wasm_js"] }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.50"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["console_error_panic_hook"]

--- a/crates/csm-wasm/src/lib.rs
+++ b/crates/csm-wasm/src/lib.rs
@@ -1,0 +1,14 @@
+//! WASM bindings for chaotic_semantic_memory.
+//!
+//! This crate provides JavaScript/WASM bindings for the core memory engine.
+//! It re-exports WASM-compatible types from the main crate and extracted crates.
+
+// Re-export WASM bindings from main crate
+pub use chaotic_semantic_memory::wasm::*;
+
+// Re-export useful types from extracted crates
+pub use csm_core::error::{MemoryError, Result};
+pub use csm_core::hyperdim::HVec10240;
+pub use csm_memory::{Concept, MetadataFilter, TraversalConfig};
+pub use csm_retrieval::GraphRagConfig;
+pub use csm_traits::{MAX_IMPORT_SIZE, MemoryEvent, unix_now_ns, unix_now_secs};

--- a/crates/csm-wasm/src/wasm.rs
+++ b/crates/csm-wasm/src/wasm.rs
@@ -1,0 +1,446 @@
+//! WASM bindings for chaotic semantic memory
+
+use bincode::Options;
+use js_sys::{Array, Float32Array, Uint8Array};
+use tracing::warn;
+use wasm_bindgen::JsCast;
+use wasm_bindgen::prelude::*;
+
+pub(crate) use crate::export_payload::{BinaryExportPayload, ExportPayload, unix_now_secs};
+pub(crate) use crate::framework::ChaoticSemanticFramework;
+pub(crate) use crate::framework_validation::MAX_IMPORT_SIZE;
+pub(crate) use crate::wasm_ext::{concept_to_js_value, to_js_error};
+pub(crate) use csm_core::hyperdim::HVec10240;
+
+#[wasm_bindgen(start)]
+pub fn initialize_wasm() {
+    console_error_panic_hook::set_once();
+}
+
+/// WASM-friendly wrapper for the framework
+#[wasm_bindgen]
+pub struct WasmFramework {
+    pub(crate) framework: ChaoticSemanticFramework,
+}
+
+#[wasm_bindgen]
+impl WasmFramework {
+    /// Create a new framework instance (no persistence in WASM)
+    pub async fn new() -> Result<WasmFramework, JsValue> {
+        let framework = ChaoticSemanticFramework::builder()
+            .without_persistence()
+            .build()
+            .await
+            .map_err(to_js_error)?;
+
+        Ok(WasmFramework { framework })
+    }
+
+    /// Set the current namespace
+    #[wasm_bindgen(js_name = setNamespace)]
+    pub async fn set_namespace(&self, ns: String) -> Result<(), JsValue> {
+        self.framework.set_namespace(ns).await.map_err(to_js_error)
+    }
+
+    /// Get the current namespace
+    #[wasm_bindgen(js_name = getNamespace)]
+    pub async fn get_namespace(&self) -> String {
+        self.framework.namespace().await
+    }
+
+    /// Inject a concept
+    pub async fn inject_concept(&self, id: String, vector: &[u8]) -> Result<(), JsValue> {
+        let hvec = HVec10240::from_bytes(vector).map_err(to_js_error)?;
+
+        self.framework
+            .inject_concept(id, hvec)
+            .await
+            .map_err(to_js_error)
+    }
+
+    /// Query for similar concepts
+    pub async fn probe(&self, vector: &[u8], top_k: usize) -> Result<Array, JsValue> {
+        let hvec = HVec10240::from_bytes(vector).map_err(to_js_error)?;
+
+        let results = self
+            .framework
+            .probe(hvec, top_k)
+            .await
+            .map_err(to_js_error)?;
+
+        let array = Array::new();
+        for (id, score) in results {
+            let obj = js_sys::Object::new();
+            js_sys::Reflect::set(&obj, &"id".into(), &id.into())
+                .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            js_sys::Reflect::set(&obj, &"score".into(), &score.into())
+                .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            array.push(&obj);
+        }
+
+        Ok(array)
+    }
+
+    /// Associate two concepts
+    pub async fn associate(&self, from: String, to: String, strength: f32) -> Result<(), JsValue> {
+        self.framework
+            .associate(&from, &to, strength)
+            .await
+            .map_err(to_js_error)
+    }
+
+    /// Delete concept by ID
+    pub async fn delete_concept(&self, id: String) -> Result<(), JsValue> {
+        self.framework
+            .delete_concept(&id)
+            .await
+            .map_err(to_js_error)
+    }
+
+    /// Update a concept's vector
+    pub async fn update_concept(&self, id: String, vector: &[u8]) -> Result<(), JsValue> {
+        let hvec = HVec10240::from_bytes(vector).map_err(to_js_error)?;
+        self.framework
+            .update_concept_vector(&id, hvec)
+            .await
+            .map_err(to_js_error)
+    }
+
+    /// Remove an association between two concepts
+    pub async fn disassociate(&self, from: String, to: String) -> Result<(), JsValue> {
+        self.framework
+            .disassociate(&from, &to)
+            .await
+            .map_err(to_js_error)
+    }
+
+    /// Get associations for a concept
+    pub async fn get_associations(&self, id: String) -> Result<Array, JsValue> {
+        let associations = self
+            .framework
+            .get_associations(&id)
+            .await
+            .map_err(to_js_error)?;
+
+        let array = Array::new();
+        for (to, strength) in associations {
+            let obj = js_sys::Object::new();
+            js_sys::Reflect::set(&obj, &"to".into(), &to.into())
+                .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            js_sys::Reflect::set(&obj, &"strength".into(), &strength.into())
+                .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            array.push(&obj);
+        }
+        Ok(array)
+    }
+
+    /// Get a concept by ID
+    pub async fn get_concept(&self, id: String) -> Result<JsValue, JsValue> {
+        let concept_opt = self.framework.get_concept(&id).await.map_err(to_js_error)?;
+
+        match concept_opt {
+            Some(concept) => concept_to_js_value(&concept),
+            None => Ok(JsValue::NULL),
+        }
+    }
+
+    /// Inject multiple concepts in batch
+    pub async fn inject_concepts(&self, ids: Array, vectors: Array) -> Result<(), JsValue> {
+        self.framework
+            .validate_batch_size(ids.length() as usize)
+            .map_err(to_js_error)?;
+
+        if ids.length() != vectors.length() {
+            return Err(JsValue::from_str(
+                "ids and vectors arrays must have the same length",
+            ));
+        }
+
+        for i in 0..ids.length() {
+            let id = ids
+                .get(i)
+                .as_string()
+                .ok_or_else(|| JsValue::from_str("id must be a string"))?;
+            let vector_bytes = vectors
+                .get(i)
+                .dyn_into::<Uint8Array>()
+                .map_err(|_| JsValue::from_str("vector must be Uint8Array"))?
+                .to_vec();
+            let hvec = HVec10240::from_bytes(&vector_bytes).map_err(to_js_error)?;
+
+            self.framework
+                .inject_concept(id, hvec)
+                .await
+                .map_err(to_js_error)?;
+        }
+
+        Ok(())
+    }
+
+    /// Create multiple associations in batch
+    pub async fn associate_many(&self, associations: Array) -> Result<(), JsValue> {
+        self.framework
+            .validate_batch_size(associations.length() as usize)
+            .map_err(to_js_error)?;
+
+        for i in 0..associations.length() {
+            let assoc = associations.get(i);
+            let from = js_sys::Reflect::get(&assoc, &"from".into())
+                .map_err(|_| JsValue::from_str("association must have 'from' field"))?
+                .as_string()
+                .ok_or_else(|| JsValue::from_str("'from' must be a string"))?;
+            let to = js_sys::Reflect::get(&assoc, &"to".into())
+                .map_err(|_| JsValue::from_str("association must have 'to' field"))?
+                .as_string()
+                .ok_or_else(|| JsValue::from_str("'to' must be a string"))?;
+            let strength = js_sys::Reflect::get(&assoc, &"strength".into())
+                .map_err(|_| JsValue::from_str("association must have 'strength' field"))?
+                .as_f64()
+                .ok_or_else(|| JsValue::from_str("'strength' must be a number"))?
+                as f32;
+
+            self.framework
+                .associate(&from, &to, strength)
+                .await
+                .map_err(to_js_error)?;
+        }
+
+        Ok(())
+    }
+
+    /// Probe for similar concepts with multiple queries in batch
+    pub async fn probe_batch(&self, vectors: Array, top_k: usize) -> Result<Array, JsValue> {
+        self.framework
+            .validate_batch_size(vectors.length() as usize)
+            .map_err(to_js_error)?;
+
+        let results = Array::new();
+
+        for i in 0..vectors.length() {
+            let vector_bytes = vectors
+                .get(i)
+                .dyn_into::<Uint8Array>()
+                .map_err(|_| JsValue::from_str("vector must be Uint8Array"))?
+                .to_vec();
+            let hvec = HVec10240::from_bytes(&vector_bytes).map_err(to_js_error)?;
+
+            let query_results = self
+                .framework
+                .probe(hvec, top_k)
+                .await
+                .map_err(to_js_error)?;
+
+            let query_array = Array::new();
+            for (id, score) in query_results {
+                let obj = js_sys::Object::new();
+                js_sys::Reflect::set(&obj, &"id".into(), &id.into())
+                    .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+                js_sys::Reflect::set(&obj, &"score".into(), &score.into())
+                    .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+                query_array.push(&obj);
+            }
+            results.push(&query_array);
+        }
+
+        Ok(results)
+    }
+
+    /// Get framework metrics snapshot
+    pub async fn metrics_snapshot(&self) -> Result<JsValue, JsValue> {
+        let metrics = self.framework.metrics_snapshot().await;
+        let obj = js_sys::Object::new();
+        js_sys::Reflect::set(
+            &obj,
+            &"concepts_injected_total".into(),
+            &(metrics.concepts_injected_total as f64).into(),
+        )
+        .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+        js_sys::Reflect::set(
+            &obj,
+            &"associations_created_total".into(),
+            &(metrics.associations_created_total as f64).into(),
+        )
+        .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+        js_sys::Reflect::set(
+            &obj,
+            &"probes_total".into(),
+            &(metrics.probes_total as f64).into(),
+        )
+        .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+        js_sys::Reflect::set(
+            &obj,
+            &"avg_probe_latency_ms".into(),
+            &metrics.avg_probe_latency_ms.into(),
+        )
+        .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+        js_sys::Reflect::set(
+            &obj,
+            &"cache_hits_total".into(),
+            &(metrics.cache_hits_total as f64).into(),
+        )
+        .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+        js_sys::Reflect::set(
+            &obj,
+            &"cache_misses_total".into(),
+            &(metrics.cache_misses_total as f64).into(),
+        )
+        .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+        js_sys::Reflect::set(
+            &obj,
+            &"cache_evictions_total".into(),
+            &(metrics.cache_evictions_total as f64).into(),
+        )
+        .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+        js_sys::Reflect::set(
+            &obj,
+            &"reservoir_steps_total".into(),
+            &(metrics.reservoir_steps_total as f64).into(),
+        )
+        .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+        js_sys::Reflect::set(
+            &obj,
+            &"avg_reservoir_step_latency_us".into(),
+            &metrics.avg_reservoir_step_latency_us.into(),
+        )
+        .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+        js_sys::Reflect::set(
+            &obj,
+            &"reservoir_nodes_active".into(),
+            &(metrics.reservoir_nodes_active as f64).into(),
+        )
+        .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+        js_sys::Reflect::set(
+            &obj,
+            &"persist_ops_total".into(),
+            &(metrics.persist_ops_total as f64).into(),
+        )
+        .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+        js_sys::Reflect::set(
+            &obj,
+            &"avg_persist_latency_ms".into(),
+            &metrics.avg_persist_latency_ms.into(),
+        )
+        .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+        Ok(obj.into())
+    }
+
+    /// Process a temporal sequence and return the resulting hypervector bytes.
+    #[wasm_bindgen(js_name = processSequence)]
+    pub async fn process_sequence(&self, sequence: Array) -> Result<Box<[u8]>, JsValue> {
+        self.framework
+            .validate_sequence_length(sequence.length() as usize)
+            .map_err(to_js_error)?;
+
+        let mut parsed_sequence = Vec::with_capacity(sequence.length() as usize);
+        for item in sequence.iter() {
+            let step = item
+                .dyn_into::<Float32Array>()
+                .map_err(|_| JsValue::from_str("processSequence expects Float32Array items"))?;
+            parsed_sequence.push(step.to_vec());
+        }
+
+        let output = self
+            .framework
+            .process_sequence(&parsed_sequence)
+            .await
+            .map_err(to_js_error)?;
+        Ok(output.to_bytes().into_boxed_slice())
+    }
+
+    /// Export all concepts and associations to bytes for in-browser storage.
+    #[wasm_bindgen(js_name = exportToBytes)]
+    pub async fn export_to_bytes(&self) -> Result<Uint8Array, JsValue> {
+        let payload = {
+            let singularity = self.framework.singularity.read().await;
+            let ns = self.framework.namespace().await;
+            ExportPayload {
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                exported_at: unix_now_secs(),
+                concepts: singularity.all_concepts(&ns),
+                associations: singularity.all_associations(&ns),
+            }
+        };
+
+        // Use BinaryExportPayload for bincode compatibility (serde_json::Value is incompatible with bincode)
+        let binary_payload = BinaryExportPayload::from(payload);
+        let data = bincode::serialize(&binary_payload).map_err(to_js_error)?;
+        Ok(Uint8Array::from(data.as_slice()))
+    }
+
+    /// Import state from bytes previously produced by .
+    #[wasm_bindgen(js_name = importFromBytes)]
+    pub async fn import_from_bytes(&self, data: Uint8Array, merge: bool) -> Result<usize, JsValue> {
+        let bytes = data.to_vec();
+
+        if bytes.len() > MAX_IMPORT_SIZE as usize {
+            return Err(JsValue::from_str(&format!(
+                "Import data size {} exceeds maximum allowed size {}",
+                bytes.len(),
+                MAX_IMPORT_SIZE
+            )));
+        }
+
+        // Deserialize as BinaryExportPayload (bincode-compatible), then convert to ExportPayload
+        let options = bincode::DefaultOptions::new().with_limit(MAX_IMPORT_SIZE);
+        let binary_payload: BinaryExportPayload =
+            options.deserialize(&bytes).map_err(to_js_error)?;
+        let payload = binary_payload.to_export_payload().map_err(to_js_error)?;
+
+        let ns = self.framework.namespace().await;
+
+        if !merge {
+            let mut singularity = self.framework.singularity.write().await;
+            let ns = self.framework.namespace().await;
+            singularity.clear(&ns);
+        }
+
+        let mut singularity = self.framework.singularity.write().await;
+        for concept in &payload.concepts {
+            self.framework
+                .validate_concept(concept)
+                .map_err(to_js_error)?;
+            singularity
+                .inject(&ns, concept.clone())
+                .map_err(to_js_error)?;
+        }
+
+        for (from, to, strength) in &payload.associations {
+            if let Err(error) = singularity.associate(&ns, from, to, *strength) {
+                warn!(
+                    from_id = %from,
+                    to_id = %to,
+                    strength = *strength,
+                    error = %error,
+                    "skipping invalid association during wasm import"
+                );
+            }
+        }
+
+        Ok(payload.concepts.len())
+    }
+}
+
+#[wasm_bindgen]
+pub fn random_hypervector() -> Box<[u8]> {
+    HVec10240::random().to_bytes().into_boxed_slice()
+}
+
+#[wasm_bindgen]
+pub fn encode_text(text: &str) -> Box<[u8]> {
+    let encoder = csm_core::encoder::TextEncoder::new();
+    encoder.encode(text).to_bytes().into_boxed_slice()
+}
+
+#[wasm_bindgen]
+pub fn cosine_similarity(a: &[u8], b: &[u8]) -> Result<f32, JsValue> {
+    let hvec_a = HVec10240::from_bytes(a).map_err(to_js_error)?;
+    let hvec_b = HVec10240::from_bytes(b).map_err(to_js_error)?;
+
+    Ok(hvec_a.cosine_similarity(&hvec_b))
+}
+
+#[wasm_bindgen(typescript_custom_section)]
+const TS: &'static str = r#"
+export interface ProbeResult { id: string; score: number; }
+export interface AssociationResult { to: string; strength: number; }
+"#;

--- a/crates/csm-wasm/src/wasm_ext.rs
+++ b/crates/csm-wasm/src/wasm_ext.rs
@@ -1,0 +1,362 @@
+//! WASM extension methods: stats, text encoding, graph traversal, metadata ops.
+//!
+//! Split from `wasm.rs` to keep each file under the 500-LOC project limit.
+
+// Redundant clones are intentional for WASM ownership semantics
+
+#[cfg(target_arch = "wasm32")]
+use js_sys::{Array, Function, Uint8Array};
+#[cfg(target_arch = "wasm32")]
+use tokio::sync::broadcast::error::RecvError;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_futures::spawn_local;
+
+#[cfg(target_arch = "wasm32")]
+use crate::wasm::WasmFramework;
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+impl WasmFramework {
+    /// Get framework stats
+    pub async fn stats(&self) -> Result<JsValue, JsValue> {
+        let stats = self.framework.stats().await.map_err(to_js_error)?;
+
+        let obj = js_sys::Object::new();
+        js_sys::Reflect::set(
+            &obj,
+            &"concept_count".into(),
+            &(stats.concept_count as u32).into(),
+        )
+        .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+        js_sys::Reflect::set(
+            &obj,
+            &"db_size_bytes".into(),
+            &stats
+                .db_size_bytes
+                .map_or(JsValue::NULL, |v| (v as f64).into()),
+        )
+        .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+
+        Ok(obj.into())
+    }
+
+    /// Get concept count (convenience method)
+    pub async fn concept_count(&self) -> Result<usize, JsValue> {
+        let sing = self.framework.singularity.read().await;
+        let ns = self.framework.namespace().await;
+        Ok(sing.len(&ns))
+    }
+
+    /// Update a concept's metadata from a JSON string.
+    ///
+    /// The `metadata_json` argument must be a valid JSON object string,
+    /// e.g. `{"category":"science","score":0.9}`.
+    ///
+    /// Note: In WASM, persistence is in-memory only. Use `exportToBytes` to
+    /// snapshot state to IndexedDB or other storage.
+    pub async fn update_concept_metadata(
+        &self,
+        id: String,
+        metadata_json: String,
+    ) -> Result<(), JsValue> {
+        let metadata: std::collections::HashMap<String, serde_json::Value> =
+            serde_json::from_str(&metadata_json)
+                .map_err(|e| JsValue::from_str(&format!("invalid metadata JSON: {e}")))?;
+        self.framework
+            .update_concept_metadata(&id, metadata)
+            .await
+            .map_err(to_js_error)
+    }
+
+    /// Clear all outbound associations for a concept.
+    pub async fn clear_associations(&self, id: String) -> Result<(), JsValue> {
+        let mut sing = self.framework.singularity.write().await;
+        let ns = self.framework.namespace().await;
+        sing.clear_associations(&ns, &id).map_err(to_js_error)
+    }
+
+    /// Get direct neighbors of a concept with edge strengths.
+    ///
+    /// Returns an Array of `{to: string, strength: number}` objects.
+    pub async fn neighbors(&self, id: String, min_strength: f32) -> Result<Array, JsValue> {
+        let sing = self.framework.singularity.read().await;
+        let ns = self.framework.namespace().await;
+        let neighbors = sing.neighbors(&ns, &id, min_strength);
+        let array = Array::new();
+        for (to, strength) in neighbors {
+            let obj = js_sys::Object::new();
+            js_sys::Reflect::set(&obj, &"to".into(), &to.into())
+                .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            js_sys::Reflect::set(&obj, &"strength".into(), &strength.into())
+                .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            array.push(&obj);
+        }
+        Ok(array)
+    }
+
+    /// Probe for similar concepts with metadata filtering.
+    pub async fn probe_filtered(
+        &self,
+        vector: &[u8],
+        top_k: usize,
+        filter_json: String,
+    ) -> Result<Array, JsValue> {
+        let query = csm_core::hyperdim::HVec10240::from_bytes(vector).map_err(to_js_error)?;
+        let filter: crate::metadata_filter::MetadataFilter = serde_json::from_str(&filter_json)
+            .map_err(|e| JsValue::from_str(&format!("invalid filter JSON: {e}")))?;
+
+        let results = self
+            .framework
+            .probe_filtered(&query, top_k, &filter)
+            .await
+            .map_err(to_js_error)?;
+
+        let array = Array::new();
+        for (id, score) in results {
+            let obj = js_sys::Object::new();
+            js_sys::Reflect::set(&obj, &"id".into(), &id.into())
+                .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            js_sys::Reflect::set(&obj, &"score".into(), &score.into())
+                .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            array.push(&obj);
+        }
+
+        Ok(array)
+    }
+
+    /// Register a callback for memory events.
+    pub fn on_event(&self, callback: Function) {
+        let mut receiver = self.framework.subscribe();
+        spawn_local(async move {
+            loop {
+                match receiver.recv().await {
+                    Ok(event) => {
+                        let js_event = memory_event_to_js_value(&event);
+                        let _ = callback.call1(&JsValue::NULL, &js_event);
+                    }
+                    Err(RecvError::Lagged(_)) => continue,
+                    Err(RecvError::Closed) => break,
+                }
+            }
+        });
+    }
+
+    /// Inject a concept from text
+    pub async fn inject_text(&self, id: String, text: String) -> Result<(), JsValue> {
+        self.framework
+            .inject_text(&id, &text)
+            .await
+            .map_err(to_js_error)
+    }
+
+    /// Probe for similar concepts using text
+    pub async fn probe_text(&self, query: String, top_k: usize) -> Result<Array, JsValue> {
+        let results = self
+            .framework
+            .probe_text(&query, top_k)
+            .await
+            .map_err(to_js_error)?;
+
+        let array = Array::new();
+        for (id, similarity) in results {
+            let obj = js_sys::Object::new();
+            js_sys::Reflect::set(&obj, &"id".into(), &id.into())
+                .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            js_sys::Reflect::set(&obj, &"similarity".into(), &similarity.into())
+                .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            array.push(&obj);
+        }
+
+        Ok(array)
+    }
+
+    /// List all historical versions of a concept.
+    #[wasm_bindgen(js_name = listVersions)]
+    pub async fn list_versions(&self, id: String) -> Result<Array, JsValue> {
+        let versions = self
+            .framework
+            .list_versions(&id)
+            .await
+            .map_err(to_js_error)?;
+        let array = Array::new();
+        for v in versions {
+            let obj = js_sys::Object::new();
+            js_sys::Reflect::set(&obj, &"conceptId".into(), &v.concept_id.into())
+                .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            js_sys::Reflect::set(&obj, &"version".into(), &(v.version as u32).into())
+                .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            js_sys::Reflect::set(
+                &obj,
+                &"timestampUnix".into(),
+                &(v.timestamp_unix as f64).into(),
+            )
+            .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            if let Some(vc) = v.vector_changed {
+                js_sys::Reflect::set(&obj, &"vectorChanged".into(), &vc.into())
+                    .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            }
+            if let Some(mc) = v.metadata_changed {
+                js_sys::Reflect::set(&obj, &"metadataChanged".into(), &mc.into())
+                    .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            }
+            array.push(&obj);
+        }
+        Ok(array)
+    }
+
+    /// Load a specific concept version.
+    #[wasm_bindgen(js_name = getVersion)]
+    pub async fn get_version(&self, id: String, version: u32) -> Result<JsValue, JsValue> {
+        let concept_opt = self
+            .framework
+            .get_version(&id, version as u64)
+            .await
+            .map_err(to_js_error)?;
+        match concept_opt {
+            Some(concept) => concept_to_js_value(&concept),
+            None => Ok(JsValue::NULL),
+        }
+    }
+
+    /// Diff two versions of a concept.
+    #[wasm_bindgen(js_name = diffVersions)]
+    pub async fn diff_versions(
+        &self,
+        id: String,
+        from_version: u32,
+        to_version: u32,
+    ) -> Result<JsValue, JsValue> {
+        let diff = self
+            .framework
+            .diff_versions(&id, from_version as u64, to_version as u64)
+            .await
+            .map_err(to_js_error)?;
+        let json_str =
+            serde_json::to_string(&diff).map_err(|e| JsValue::from_str(&e.to_string()))?;
+        js_sys::JSON::parse(&json_str).map_err(|_| JsValue::from_str("failed to parse diff JSON"))
+    }
+
+    /// Roll back a concept to a historical version.
+    #[wasm_bindgen(js_name = rollbackToVersion)]
+    pub async fn rollback_to_version(&self, id: String, version: u32) -> Result<JsValue, JsValue> {
+        let concept = self
+            .framework
+            .rollback_to_version(&id, version as u64)
+            .await
+            .map_err(to_js_error)?;
+        concept_to_js_value(&concept)
+    }
+
+    /// Export a namespace to bytes for in-browser storage.
+    #[wasm_bindgen(js_name = exportNamespaceToBytes)]
+    pub async fn export_namespace_to_bytes(&self, ns: String) -> Result<Uint8Array, JsValue> {
+        let data = self
+            .framework
+            .export_namespace_to_bytes(&ns)
+            .await
+            .map_err(to_js_error)?;
+        Ok(Uint8Array::from(data.as_slice()))
+    }
+}
+
+/// Convert a Concept to a JsValue object
+#[cfg(target_arch = "wasm32")]
+#[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+pub(crate) fn concept_to_js_value(
+    concept: &crate::singularity::Concept,
+) -> Result<JsValue, JsValue> {
+    let obj = js_sys::Object::new();
+
+    js_sys::Reflect::set(&obj, &"id".into(), &concept.id.clone().into())
+        .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+
+    js_sys::Reflect::set(
+        &obj,
+        &"vector".into(),
+        &Uint8Array::from(concept.vector.to_bytes().as_slice()),
+    )
+    .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+
+    // Convert metadata HashMap to JS object
+    let metadata_obj = js_sys::Object::new();
+    for (key, value) in &concept.metadata {
+        let value_str = serde_json::to_string(value).map_err(to_js_error)?;
+        let js_value = js_sys::JSON::parse(&value_str)
+            .map_err(|_| JsValue::from_str("failed to parse metadata JSON"))?;
+        js_sys::Reflect::set(&metadata_obj, &key.clone().into(), &js_value)
+            .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+    }
+    js_sys::Reflect::set(&obj, &"metadata".into(), &metadata_obj.into())
+        .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+
+    js_sys::Reflect::set(
+        &obj,
+        &"created_at".into(),
+        &(concept.created_at as f64).into(),
+    )
+    .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+
+    js_sys::Reflect::set(
+        &obj,
+        &"modified_at".into(),
+        &(concept.modified_at as f64).into(),
+    )
+    .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+
+    let expires_at = concept
+        .expires_at
+        .map_or(JsValue::NULL, |v| (v as f64).into());
+    js_sys::Reflect::set(&obj, &"expires_at".into(), &expires_at)
+        .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+
+    let canonical_ids = Array::new();
+    for id in &concept.canonical_concept_ids {
+        canonical_ids.push(&JsValue::from_str(id));
+    }
+    js_sys::Reflect::set(&obj, &"canonical_concept_ids".into(), &canonical_ids.into())
+        .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+
+    Ok(obj.into())
+}
+
+#[cfg(target_arch = "wasm32")]
+#[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+pub(crate) fn to_js_error<E: std::fmt::Display>(error: E) -> JsValue {
+    JsValue::from_str(&error.to_string())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn memory_event_to_js_value(event: &crate::framework_events::MemoryEvent) -> JsValue {
+    let obj = js_sys::Object::new();
+    match event {
+        crate::framework_events::MemoryEvent::ConceptInjected { id, timestamp } => {
+            let _ = js_sys::Reflect::set(&obj, &"type".into(), &"ConceptInjected".into());
+            let _ = js_sys::Reflect::set(&obj, &"id".into(), &id.clone().into());
+            let _ = js_sys::Reflect::set(&obj, &"timestamp".into(), &(*timestamp as f64).into());
+        }
+        crate::framework_events::MemoryEvent::ConceptUpdated { id, timestamp } => {
+            let _ = js_sys::Reflect::set(&obj, &"type".into(), &"ConceptUpdated".into());
+            let _ = js_sys::Reflect::set(&obj, &"id".into(), &id.clone().into());
+            let _ = js_sys::Reflect::set(&obj, &"timestamp".into(), &(*timestamp as f64).into());
+        }
+        crate::framework_events::MemoryEvent::ConceptDeleted { id, timestamp } => {
+            let _ = js_sys::Reflect::set(&obj, &"type".into(), &"ConceptDeleted".into());
+            let _ = js_sys::Reflect::set(&obj, &"id".into(), &id.clone().into());
+            let _ = js_sys::Reflect::set(&obj, &"timestamp".into(), &(*timestamp as f64).into());
+        }
+        crate::framework_events::MemoryEvent::Associated { from, to, strength } => {
+            let _ = js_sys::Reflect::set(&obj, &"type".into(), &"Associated".into());
+            let _ = js_sys::Reflect::set(&obj, &"from".into(), &from.clone().into());
+            let _ = js_sys::Reflect::set(&obj, &"to".into(), &to.clone().into());
+            let _ = js_sys::Reflect::set(&obj, &"strength".into(), &(*strength as f64).into());
+        }
+        crate::framework_events::MemoryEvent::Disassociated { from, to } => {
+            let _ = js_sys::Reflect::set(&obj, &"type".into(), &"Disassociated".into());
+            let _ = js_sys::Reflect::set(&obj, &"from".into(), &from.clone().into());
+            let _ = js_sys::Reflect::set(&obj, &"to".into(), &to.clone().into());
+        }
+    }
+    obj.into()
+}

--- a/crates/csm-wasm/src/wasm_ext_tests.rs
+++ b/crates/csm-wasm/src/wasm_ext_tests.rs
@@ -1,0 +1,476 @@
+//! Tests for WASM extension methods to run underlying data pattern tests on native targets.
+
+#[cfg(test)]
+mod tests {
+    use crate::framework_builder::FrameworkBuilder;
+    use crate::framework_events::MemoryEvent;
+    use crate::graph_traversal::TraversalConfig;
+    use crate::metadata_filter::MetadataFilter;
+    use csm_core::hyperdim::HVec10240;
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    // to_js_error is a string conversion that works on native targets too
+    fn to_js_error_test(msg: &str) -> bool {
+        !msg.is_empty()
+    }
+
+    #[test]
+    fn metadata_filter_eq_json_roundtrip() {
+        let filter = MetadataFilter::eq("type", "document");
+        let json = serde_json::to_string(&filter).unwrap();
+        let parsed: MetadataFilter = serde_json::from_str(&json).unwrap();
+        assert_eq!(filter, parsed);
+    }
+
+    #[test]
+    fn metadata_filter_in_json_roundtrip() {
+        let filter = MetadataFilter::in_("tag", vec![json!("rust"), json!("python")]);
+        let json = serde_json::to_string(&filter).unwrap();
+        let parsed: MetadataFilter = serde_json::from_str(&json).unwrap();
+        assert_eq!(filter, parsed);
+    }
+
+    #[test]
+    fn metadata_filter_exists_json_roundtrip() {
+        let filter = MetadataFilter::exists("title");
+        let json = serde_json::to_string(&filter).unwrap();
+        let parsed: MetadataFilter = serde_json::from_str(&json).unwrap();
+        assert_eq!(filter, parsed);
+    }
+
+    #[test]
+    fn metadata_filter_and_json_roundtrip() {
+        let filter = MetadataFilter::and(vec![
+            MetadataFilter::eq("type", "document"),
+            MetadataFilter::exists("author"),
+        ]);
+        let json = serde_json::to_string(&filter).unwrap();
+        let parsed: MetadataFilter = serde_json::from_str(&json).unwrap();
+        assert_eq!(filter, parsed);
+    }
+
+    #[test]
+    fn metadata_filter_or_json_roundtrip() {
+        let filter = MetadataFilter::or(vec![
+            MetadataFilter::eq("status", "active"),
+            MetadataFilter::eq("status", "pending"),
+        ]);
+        let json = serde_json::to_string(&filter).unwrap();
+        let parsed: MetadataFilter = serde_json::from_str(&json).unwrap();
+        assert_eq!(filter, parsed);
+    }
+
+    #[test]
+    fn metadata_filter_not_json_roundtrip() {
+        let filter = MetadataFilter::Not(Box::new(MetadataFilter::eq("private", true)));
+        let json = serde_json::to_string(&filter).unwrap();
+        let parsed: MetadataFilter = serde_json::from_str(&json).unwrap();
+        assert_eq!(filter, parsed);
+    }
+
+    #[test]
+    fn metadata_filter_nested_complex_json_roundtrip() {
+        let filter = MetadataFilter::and(vec![
+            MetadataFilter::eq("type", "document"),
+            MetadataFilter::in_("tag", vec![json!("rust"), json!("python")]),
+            MetadataFilter::Not(Box::new(MetadataFilter::eq("private", true))),
+        ]);
+        let json = serde_json::to_string(&filter).unwrap();
+        let parsed: MetadataFilter = serde_json::from_str(&json).unwrap();
+        assert_eq!(filter, parsed);
+    }
+
+    #[test]
+    fn metadata_filter_json_string_format() {
+        let filter = MetadataFilter::eq("category", "science");
+        let json = serde_json::to_string(&filter).unwrap();
+        assert!(json.contains("Eq") && json.contains("category") && json.contains("science"));
+    }
+
+    #[test]
+    fn traversal_config_defaults() {
+        let config = TraversalConfig::default();
+        assert_eq!(config.max_depth, 3);
+        assert!((config.min_strength - (0.0)).abs() < 1e-6);
+        assert_eq!(config.max_results, 100);
+    }
+
+    #[test]
+    fn traversal_config_custom_values() {
+        let config = TraversalConfig {
+            max_depth: 5,
+            min_strength: 0.7,
+            ..Default::default()
+        };
+        assert_eq!(config.max_depth, 5);
+        assert!((config.min_strength - (0.7)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn hvec_bytes_roundtrip() {
+        let original = HVec10240::random();
+        let bytes = original.to_bytes();
+        let restored = HVec10240::from_bytes(&bytes).unwrap();
+        assert_eq!(original, restored);
+    }
+
+    #[test]
+    fn hvec_bytes_length() {
+        let hvec = HVec10240::random();
+        let bytes = hvec.to_bytes();
+        assert_eq!(bytes.len(), 1280); // 10240 bits / 8 = 1280 bytes
+    }
+
+    #[test]
+    fn hvec_from_bytes_invalid_length() {
+        let short_bytes = vec![0u8; 100];
+        assert!(HVec10240::from_bytes(&short_bytes).is_err());
+    }
+
+    #[test]
+    fn memory_event_variants_construct() {
+        let injected = MemoryEvent::ConceptInjected {
+            id: "test-id".to_string(),
+            timestamp: 12345,
+        };
+        let updated = MemoryEvent::ConceptUpdated {
+            id: "test-id".to_string(),
+            timestamp: 12346,
+        };
+        let deleted = MemoryEvent::ConceptDeleted {
+            id: "test-id".to_string(),
+            timestamp: 12347,
+        };
+        let associated = MemoryEvent::Associated {
+            from: "a".to_string(),
+            to: "b".to_string(),
+            strength: 0.8,
+        };
+        let disassociated = MemoryEvent::Disassociated {
+            from: "a".to_string(),
+            to: "b".to_string(),
+        };
+
+        assert!(matches!(injected, MemoryEvent::ConceptInjected { .. }));
+        assert!(format!("{updated:?}").contains("ConceptUpdated"));
+        assert!(format!("{deleted:?}").contains("ConceptDeleted"));
+        assert!(format!("{associated:?}").contains("Associated"));
+        assert!(format!("{disassociated:?}").contains("Disassociated"));
+    }
+
+    #[test]
+    fn memory_event_clone_preserves_data() {
+        let event = MemoryEvent::Associated {
+            from: "source".to_string(),
+            to: "target".to_string(),
+            strength: 0.95,
+        };
+        let cloned = event;
+        match cloned {
+            MemoryEvent::Associated { from, to, strength } => {
+                assert_eq!(from, "source");
+                assert_eq!(to, "target");
+                assert!((strength - 0.95).abs() < 0.001);
+            }
+            _ => panic!("Expected Associated variant"),
+        }
+    }
+
+    #[test]
+    fn metadata_filter_matches_empty_metadata() {
+        let filter = MetadataFilter::eq("type", "document");
+        let empty_metadata = HashMap::new();
+        assert!(!filter.matches(&empty_metadata));
+    }
+
+    #[test]
+    fn metadata_filter_exists_on_empty_metadata() {
+        let filter = MetadataFilter::exists("field");
+        let empty_metadata = HashMap::new();
+        assert!(!filter.matches(&empty_metadata));
+    }
+
+    #[test]
+    fn wasm_hvec_bytes_roundtrip() {
+        let v = HVec10240::random();
+        let bytes = v.to_bytes();
+        let v2 = HVec10240::from_bytes(&bytes).unwrap();
+        assert_eq!(v, v2);
+    }
+
+    #[test]
+    fn wasm_hvec_bytes_invalid_len() {
+        assert!(HVec10240::from_bytes(&[0u8; 100]).is_err());
+    }
+
+    #[test]
+    fn wasm_to_js_error_msg() {
+        assert!(to_js_error_test("test error"));
+    }
+
+    #[tokio::test]
+    async fn wasm_namespace_switching_isolates_concepts() {
+        let framework = FrameworkBuilder::new()
+            .without_persistence()
+            .build()
+            .await
+            .unwrap();
+
+        // 1. Inject into default namespace
+        framework
+            .inject_concept("default-concept", HVec10240::random())
+            .await
+            .unwrap();
+
+        // 2. Switch namespace
+        framework.set_namespace("tenant-a").await.unwrap();
+        assert_eq!(framework.namespace().await, "tenant-a");
+
+        // 3. Verify default concept is not visible in tenant-a
+        let results = framework.probe(HVec10240::random(), 10).await.unwrap();
+        assert!(results.is_empty());
+
+        // 4. Inject into tenant-a
+        framework
+            .inject_concept("tenant-concept", HVec10240::random())
+            .await
+            .unwrap();
+        let results = framework.probe(HVec10240::random(), 10).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "tenant-concept");
+
+        // 5. Switch back to default
+        framework.set_namespace("_default").await.unwrap();
+        assert_eq!(framework.namespace().await, "_default");
+
+        // 6. Verify only default concept is visible
+        let results = framework.probe(HVec10240::random(), 10).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "default-concept");
+    }
+
+    #[tokio::test]
+    async fn test_wasm_namespace_ops_defend_mutation() {
+        // Use the native framework directly to test the same logic WasmFramework uses
+        let framework = FrameworkBuilder::new()
+            .without_persistence()
+            .build()
+            .await
+            .unwrap();
+
+        assert_eq!(framework.namespace().await, "_default");
+        framework.set_namespace("new-ns").await.unwrap();
+        assert_eq!(framework.namespace().await, "new-ns");
+
+        // Verify validation rejects empty and keeps previous
+        assert!(framework.set_namespace("").await.is_err());
+        assert_eq!(framework.namespace().await, "new-ns");
+    }
+
+    fn native_enc(t: &str) -> Box<[u8]> {
+        csm_core::encoder::TextEncoder::new()
+            .encode(t)
+            .to_bytes()
+            .into_boxed_slice()
+    }
+
+    #[test]
+    fn wasm_encode_text_consistency() {
+        assert_eq!(native_enc("Test"), native_enc("Test"));
+    }
+
+    #[test]
+    fn wasm_encode_text_length() {
+        assert_eq!(native_enc("Len").len(), 1280);
+    }
+
+    #[test]
+    fn wasm_encode_text_difference() {
+        assert_ne!(native_enc("A"), native_enc("B"));
+    }
+
+    #[test]
+    fn wasm_encode_text_empty() {
+        assert_eq!(native_enc("").len(), 1280);
+    }
+
+    #[test]
+    fn encode_text_returns_nontrivial_hvec() {
+        let bytes = native_enc("hello world");
+        // HVec10240 serialised = 80 × 16 bytes = 1280 bytes
+        assert_eq!(
+            bytes.len(),
+            1280,
+            "encoded length must match HVec10240 wire size"
+        );
+        assert!(bytes.iter().any(|&b| b != 0), "result must not be all-zero");
+        assert!(
+            bytes.iter().any(|&b| b != 0xff),
+            "result must not be all-ones"
+        );
+    }
+
+    #[test]
+    fn encode_text_matches_encoder_directly() {
+        use csm_core::encoder::TextEncoder;
+        let encoder = TextEncoder::new();
+        let direct = encoder.encode("mutation-test-input").to_bytes();
+        let wrapped = native_enc("mutation-test-input");
+        assert_eq!(direct.as_slice(), wrapped.as_ref());
+    }
+
+    #[test]
+    fn encode_text_deterministic_across_calls() {
+        let a = native_enc("determinism-check");
+        let b = native_enc("determinism-check");
+        let c = native_enc("determinism-check");
+        assert_eq!(a, b);
+        assert_eq!(b, c);
+    }
+
+    #[tokio::test]
+    async fn probe_filtered_excludes_nonmatching_metadata() {
+        let fw = crate::ChaoticSemanticFramework::builder()
+            .without_persistence()
+            .build()
+            .await
+            .unwrap();
+
+        let v1 = HVec10240::random();
+        let v2 = HVec10240::random();
+
+        let mut meta_a = std::collections::HashMap::new();
+        meta_a.insert("type".to_string(), json!("article"));
+        meta_a.insert("status".to_string(), json!("published"));
+        fw.inject_concept_with_metadata("doc-a", v1, meta_a)
+            .await
+            .unwrap();
+
+        let mut meta_b = std::collections::HashMap::new();
+        meta_b.insert("type".to_string(), json!("image"));
+        meta_b.insert("status".to_string(), json!("draft"));
+        fw.inject_concept_with_metadata("doc-b", v2, meta_b)
+            .await
+            .unwrap();
+
+        let filter = MetadataFilter::eq("type", "article");
+        let results = fw.probe_filtered(&v1, 10, &filter).await.unwrap();
+        assert!(
+            results.iter().any(|(id, _)| id == "doc-a"),
+            "filtered results must include the matching concept"
+        );
+        assert!(
+            !results.iter().any(|(id, _)| id == "doc-b"),
+            "filtered results must exclude the non-matching concept"
+        );
+    }
+
+    #[tokio::test]
+    async fn probe_filtered_returns_empty_when_no_match() {
+        let fw = crate::ChaoticSemanticFramework::builder()
+            .without_persistence()
+            .build()
+            .await
+            .unwrap();
+
+        let v1 = HVec10240::random();
+        let mut meta = std::collections::HashMap::new();
+        meta.insert("type".to_string(), json!("video"));
+        fw.inject_concept_with_metadata("only-doc", v1, meta)
+            .await
+            .unwrap();
+
+        let filter = MetadataFilter::eq("type", "nonexistent");
+        let results = fw.probe_filtered(&v1, 10, &filter).await.unwrap();
+        assert!(
+            results.is_empty(),
+            "no results should match a filter with no matching concepts"
+        );
+    }
+
+    #[tokio::test]
+    async fn probe_with_graph_returns_results_for_associated_concepts() {
+        let fw = crate::ChaoticSemanticFramework::builder()
+            .without_persistence()
+            .build()
+            .await
+            .unwrap();
+
+        let v1 = HVec10240::random();
+        let v2 = HVec10240::random();
+
+        fw.inject_concept("anchor", v1).await.unwrap();
+        fw.inject_concept("neighbor", v2).await.unwrap();
+        fw.associate("anchor", "neighbor", 0.9).await.unwrap();
+
+        let config = crate::retrieval::GraphRagConfig {
+            anchor_top_k: 5,
+            max_hops: 2,
+            min_assoc_strength: 0.1,
+            similarity_weight: 0.7,
+            graph_weight: 0.3,
+            final_top_k: 5,
+        };
+        let results = fw.probe_with_graph(v1, config).await.unwrap();
+        assert!(
+            !results.is_empty(),
+            "probe_with_graph must return results when concepts exist"
+        );
+        let ids: Vec<&str> = results.iter().map(|r| r.id.as_str()).collect();
+        assert!(
+            ids.contains(&"anchor"),
+            "results must include the anchor concept"
+        );
+    }
+
+    #[tokio::test]
+    async fn probe_with_graph_empty_index_returns_empty() {
+        let fw = crate::ChaoticSemanticFramework::builder()
+            .without_persistence()
+            .build()
+            .await
+            .unwrap();
+
+        let config = crate::retrieval::GraphRagConfig {
+            anchor_top_k: 5,
+            max_hops: 2,
+            min_assoc_strength: 0.1,
+            similarity_weight: 0.7,
+            graph_weight: 0.3,
+            final_top_k: 5,
+        };
+        let results = fw
+            .probe_with_graph(HVec10240::random(), config)
+            .await
+            .unwrap();
+        assert!(
+            results.is_empty(),
+            "probe_with_graph on empty index must return empty"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_namespace_validation_integration() {
+    let framework: crate::ChaoticSemanticFramework = crate::ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .build()
+        .await
+        .unwrap();
+
+    // 1. Valid namespace
+    assert!(framework.set_namespace("tenant-a").await.is_ok());
+
+    // 2. Invalid namespace: empty
+    let res = framework.set_namespace("").await;
+    assert!(res.is_err());
+
+    // 3. Invalid namespace: too long
+    let res = framework.set_namespace("a".repeat(129)).await;
+    assert!(res.is_err());
+
+    // 4. Invalid namespace: control chars
+    let res = framework.set_namespace("ns\x00").await;
+    assert!(res.is_err());
+}

--- a/crates/csm-wasm/src/wasm_graph_rag.rs
+++ b/crates/csm-wasm/src/wasm_graph_rag.rs
@@ -1,0 +1,192 @@
+//! WASM GraphRAG bindings.
+//!
+//! Split from `wasm_ext.rs` to maintain the 500-LOC project limit.
+
+#[cfg(target_arch = "wasm32")]
+use js_sys::Array;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+#[cfg(target_arch = "wasm32")]
+use crate::wasm::{WasmFramework, to_js_error};
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+impl WasmFramework {
+    /// GraphRAG retrieval: similarity + graph traversal hybrid using vector query.
+    pub async fn probe_with_graph(
+        &self,
+        vector: &[u8],
+        anchor_top_k: usize,
+        max_hops: usize,
+        min_assoc_strength: f32,
+        similarity_weight: f32,
+        graph_weight: f32,
+        final_top_k: usize,
+    ) -> Result<Array, JsValue> {
+        use crate::retrieval::GraphRagConfig;
+        let query = csm_core::hyperdim::HVec10240::from_bytes(vector).map_err(to_js_error)?;
+        let config = GraphRagConfig {
+            anchor_top_k,
+            max_hops,
+            min_assoc_strength,
+            similarity_weight,
+            graph_weight,
+            final_top_k,
+        };
+
+        let results = self
+            .framework
+            .probe_with_graph(query, config)
+            .await
+            .map_err(to_js_error)?;
+
+        let array = Array::new();
+        for r in results {
+            let obj = js_sys::Object::new();
+            let _ = js_sys::Reflect::set(&obj, &"id".into(), &r.id.into());
+            let _ = js_sys::Reflect::set(&obj, &"score".into(), &r.score.into());
+            let _ = js_sys::Reflect::set(&obj, &"similarity".into(), &r.similarity.into());
+            let _ = js_sys::Reflect::set(
+                &obj,
+                &"anchor_id".into(),
+                &r.anchor_id.map_or(JsValue::NULL, |id| id.into()),
+            );
+            let _ = js_sys::Reflect::set(
+                &obj,
+                &"hop_distance".into(),
+                &(r.hop_distance as f64).into(),
+            );
+            let _ = js_sys::Reflect::set(&obj, &"assoc_strength".into(), &r.assoc_strength.into());
+            array.push(&obj);
+        }
+
+        Ok(array)
+    }
+
+    /// GraphRAG retrieval: similarity + graph traversal hybrid using text query.
+    pub async fn probe_text_with_graph(
+        &self,
+        text: String,
+        anchor_top_k: usize,
+        max_hops: usize,
+        min_assoc_strength: f32,
+        similarity_weight: f32,
+        graph_weight: f32,
+        final_top_k: usize,
+    ) -> Result<Array, JsValue> {
+        use crate::retrieval::GraphRagConfig;
+        let config = GraphRagConfig {
+            anchor_top_k,
+            max_hops,
+            min_assoc_strength,
+            similarity_weight,
+            graph_weight,
+            final_top_k,
+        };
+
+        let results = self
+            .framework
+            .probe_text_with_graph(&text, config)
+            .await
+            .map_err(to_js_error)?;
+
+        let array = Array::new();
+        for r in results {
+            let obj = js_sys::Object::new();
+            let _ = js_sys::Reflect::set(&obj, &"id".into(), &r.id.into());
+            let _ = js_sys::Reflect::set(&obj, &"score".into(), &r.score.into());
+            let _ = js_sys::Reflect::set(&obj, &"similarity".into(), &r.similarity.into());
+            let _ = js_sys::Reflect::set(
+                &obj,
+                &"anchor_id".into(),
+                &r.anchor_id.map_or(JsValue::NULL, |id| id.into()),
+            );
+            let _ = js_sys::Reflect::set(
+                &obj,
+                &"hop_distance".into(),
+                &(r.hop_distance as f64).into(),
+            );
+            let _ = js_sys::Reflect::set(&obj, &"assoc_strength".into(), &r.assoc_strength.into());
+            array.push(&obj);
+        }
+
+        Ok(array)
+    }
+
+    /// Breadth-first traversal from a starting concept.
+    ///
+    /// Returns an Array of `{id: string, depth: number}` objects.
+    /// Uses default `TraversalConfig`.
+    pub async fn bfs(&self, start: String) -> Result<Array, JsValue> {
+        use crate::graph_traversal::TraversalConfig;
+        let sing = self.framework.singularity.read().await;
+        let ns = self.framework.namespace().await;
+        let config = TraversalConfig::default();
+        let results = sing.bfs(&ns, &start, &config).map_err(to_js_error)?;
+        let array = Array::new();
+        for (id, depth) in results {
+            let obj = js_sys::Object::new();
+            js_sys::Reflect::set(&obj, &"id".into(), &id.into())
+                .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            js_sys::Reflect::set(&obj, &"depth".into(), &(depth as f64).into())
+                .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            array.push(&obj);
+        }
+        Ok(array)
+    }
+
+    /// Find the minimum-cost path between two concepts (weighted Dijkstra).
+    ///
+    /// Returns an Array of concept ID strings, or an empty Array if no path exists.
+    /// Uses default `TraversalConfig`.
+    pub async fn shortest_path(&self, from: String, to: String) -> Result<Array, JsValue> {
+        let path = self
+            .framework
+            .shortest_path(&from, &to)
+            .await
+            .map_err(to_js_error)?;
+        let array = Array::new();
+        if let Some(nodes) = path {
+            for id in nodes {
+                array.push(&id.into());
+            }
+        }
+        Ok(array)
+    }
+
+    /// Breadth-first traversal from a starting concept with custom config.
+    pub async fn traverse(
+        &self,
+        start: String,
+        max_depth: u32,
+        min_strength: f32,
+    ) -> Result<Array, JsValue> {
+        let mut config = crate::graph_traversal::TraversalConfig::default();
+        config.max_depth = max_depth as usize;
+        config.min_strength = min_strength;
+
+        let results = self
+            .framework
+            .traverse(&start, config)
+            .await
+            .map_err(to_js_error)?;
+
+        let array = Array::new();
+        for (id, depth) in results {
+            let obj = js_sys::Object::new();
+            js_sys::Reflect::set(&obj, &"id".into(), &id.into())
+                .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            js_sys::Reflect::set(&obj, &"depth".into(), &(depth as f64).into())
+                .map_err(|_| JsValue::from_str("failed to set JS property"))?;
+            array.push(&obj);
+        }
+        Ok(array)
+    }
+}
+
+// Ensure tests can use the wasm_graph_rag logic on native if needed
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    // Shared tests for WASM GraphRAG patterns could go here
+}

--- a/llms.txt
+++ b/llms.txt
@@ -1296,6 +1296,7 @@ members = [
     "crates/csm-persistence",
     "crates/csm-cli",
     "crates/csm-traits",
+    "crates/csm-wasm",
     ".",
     "benchmarks",
     "crates/chaotic_semantic_memory_duckdb",


### PR DESCRIPTION
## Summary

- Create `csm-wasm` crate with WASM bindings
- Fix `unix_now_secs` / `unix_now_ns` in csm-memory and csm-traits for WASM compatibility
- Add `js-sys` dependency for WASM time functions
- Add `csm-wasm` to workspace members

## Changes

- Created `crates/csm-wasm/` with WASM bindings re-exported from main crate
- Fixed `unix_now_secs()` and `unix_now_ns()` in csm-memory to use `js_sys::Date` on WASM
- Fixed `unix_now_secs()` and `unix_now_ns()` in csm-traits to use `js_sys::Date` on WASM
- Added `js-sys` as WASM-only dependency to csm-memory and csm-traits
- Added `csm-wasm` to workspace members

## Testing

- `cargo build -p csm-wasm --target wasm32-unknown-unknown --no-default-features` passes
- `cargo test --quiet` passes (all tests)
- `cargo check --all-features` passes
- `cargo clippy -- -D warnings` passes
- `cargo fmt --check` passes

## Related Issues

- Closes #369