### PR TITLE
ci: add per-crate test matrix for workspace crates (#373)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
     name: Test Workspace Crates
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      PROTOC: /usr/bin/protoc
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
     - name: Test ${{ matrix.crate }}
-      run: cargo test -p ${{ matrix.crate }} --all-features --locked -- --quiet
+      run: cargo test -p ${{ matrix.crate }} --locked -- --quiet
 
   test-duckdb:
     name: Test DuckDB Companion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,6 @@ jobs:
           - csm-memory
           - csm-retrieval
           - csm-persistence
-          - csm-cli
           - csm-traits
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
     - name: Test ${{ matrix.crate }}
+      # Default features only; --all-features causes conflicts (wasm+persistence).
+      # Full feature coverage is in the main 'test' job.
       run: cargo test -p ${{ matrix.crate }} --locked -- --quiet
 
   test-duckdb:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,8 @@ jobs:
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
     - name: Test ${{ matrix.crate }}
-      # Default features only; --all-features causes conflicts (wasm+persistence).
+      # Default features only; --all-features activates mutually exclusive
+      # crate features (e.g. wasm vs persistence in csm-persistence).
       # Full feature coverage is in the main 'test' job.
       run: cargo test -p ${{ matrix.crate }} --locked -- --quiet
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,32 @@ jobs:
     - name: Run tests
       run: cargo test --all-features --locked -- --quiet
 
+  test-workspace-crates:
+    name: Test Workspace Crates
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        crate:
+          - csm-core
+          - csm-embedding
+          - csm-memory
+          - csm-retrieval
+          - csm-persistence
+          - csm-cli
+          - csm-traits
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    - name: Install Rust
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+      with:
+        cache: false
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+    - name: Test ${{ matrix.crate }}
+      run: cargo test -p ${{ matrix.crate }} --all-features --locked -- --quiet
+
   test-duckdb:
     name: Test DuckDB Companion
     runs-on: ubuntu-latest

--- a/crates/csm-cli/Cargo.toml
+++ b/crates/csm-cli/Cargo.toml
@@ -32,5 +32,6 @@ name = "csm"
 path = "src/main.rs"
 
 [features]
-default = ["persistence"]
+default = ["cli", "persistence"]
+cli = []
 persistence = ["csm-persistence/libsql"]

--- a/crates/csm-persistence/src/persistence_concepts.rs
+++ b/crates/csm-persistence/src/persistence_concepts.rs
@@ -1,4 +1,4 @@
-#![cfg(all(not(target_arch = "wasm32"), feature = "libsql"))]
+#![cfg(all(not(target_arch = "wasm32"), feature = "persistence"))]
 use crate::persistence::Persistence;
 use csm_core::error::{MemoryError, Result};
 use csm_core::hyperdim::HVec10240;

--- a/crates/csm-persistence/src/persistence_ops.rs
+++ b/crates/csm-persistence/src/persistence_ops.rs
@@ -314,8 +314,8 @@ impl Persistence {
 #[cfg(feature = "persistence")]
 mod tests {
     use crate::persistence::Persistence;
-    use crate::singularity::Concept;
     use csm_core::hyperdim::HVec10240;
+    use csm_memory::Concept;
     use std::collections::HashMap;
     use tempfile::NamedTempFile;
 


### PR DESCRIPTION
## Summary

Addresses #373: Add per-crate test jobs to CI for each workspace crate.

### Changes
- Add `test-workspace-crates` job with matrix strategy testing 6 crates: csm-core, csm-embedding, csm-memory, csm-retrieval, csm-persistence, csm-traits
- Uses default features (not --all-features) since individual crates have mutually exclusive features (e.g. wasm vs persistence in csm-persistence)
- Added PROTOC env var for crates that need protobuf
- csm-cli excluded from matrix due to pre-existing circular dependency on main crate

### Bug Fixes (pre-existing from workspace extraction)
- **csm-persistence**: Fixed `persistence_concepts.rs` cfg gate from `feature="libsql"` to `feature="persistence"` so `save_concept`/`load_concept`/`delete_concept` methods compile with default features
- **csm-persistence**: Fixed test import from `crate::singularity::Concept` to `csm_memory::Concept`
- **csm-cli**: Added `cli=[]` feature to Cargo.toml (was used in `#[cfg(feature="cli")]` but never defined)

### Already Closed Issues
- #370: Workspace members already finalized (csm-traits included)
- #374: llms.txt/llms-full.txt already up to date
- #353: Delegated to Jules as #387

Closes #373