### PR TITLE
ci: fix Release timeout and gate mutation-test on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,11 @@ jobs:
       run: cargo test --features mcp --locked -- --quiet
 
   mutation-test:
+    # Mutation testing is expensive (~20 min per run). Run it only on PRs so
+    # main-branch CI stays fast enough to fit inside the Release workflow's
+    # wait-for-ci window. Push-to-main already gets full mutation coverage on
+    # the PR that introduced the change.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     needs: test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,11 @@ jobs:
     - name: Wait for CI workflow to complete
       id: check-ci
       run: |
-        # Wait up to 10 minutes for CI workflow to complete
-        MAX_WAIT=600
+        # Wait up to 30 minutes for CI workflow to complete.
+        # The mutation-test job alone can take ~20 min on PRs, and main-branch CI
+        # has historically been cancelled and re-triggered by the concurrency group,
+        # so 10 min was not enough and Release silently timed out (see run #412).
+        MAX_WAIT=1800
         SLEEP_INTERVAL=30
         ELAPSED=0
 
@@ -56,8 +59,9 @@ jobs:
               echo "passed=true" >> $GITHUB_OUTPUT
               exit 0
             else
-              echo "❌ CI failed with conclusion: $CI_CONCLUSION"
-              echo "::error::CI workflow failed. Release blocked."
+              # Covers failure, cancelled, timed_out, action_required, etc.
+              echo "❌ CI ended with conclusion: $CI_CONCLUSION"
+              echo "::error::CI workflow $CI_CONCLUSION. Release blocked."
               echo "passed=false" >> $GITHUB_OUTPUT
               exit 1
             fi
@@ -68,7 +72,7 @@ jobs:
           ELAPSED=$((ELAPSED + SLEEP_INTERVAL))
         done
 
-        echo "::error::Timeout waiting for CI workflow to complete"
+        echo "::error::Timeout waiting for CI workflow to complete after ${MAX_WAIT}s"
         echo "passed=false" >> $GITHUB_OUTPUT
         exit 1
       env:

--- a/scripts/mutation_test.sh
+++ b/scripts/mutation_test.sh
@@ -126,12 +126,16 @@ if [[ "${CI_MODE}" == "true" ]]; then
   if [[ "${SCORE}" == "0" ]]; then
     if grep -q -E 'No mutants generated|Diff changes no|No mutants to filter' "${LOG_FILE}" 2>/dev/null; then
       echo "mutation score: no Rust source files changed, CI check skipped"
+      exit 0
     else
       echo "error: could not parse mutation score from ${LOG_FILE}" >&2
       exit 1
     fi
   elif awk -v s="${SCORE}" -v t="${THRESHOLD}" 'BEGIN { exit !(s >= t) }'; then
     echo "mutation score ${SCORE}% >= ${THRESHOLD}%, CI check passed"
+    # Score meets threshold: succeed even if cargo-mutants returned non-zero
+    # (it exits 2 whenever any mutant is missed, regardless of the threshold).
+    exit 0
   else
     echo "mutation score ${SCORE}% < ${THRESHOLD}%, CI check failed" >&2
     exit 1


### PR DESCRIPTION
## Problem

The `Release` workflow has been failing on every push to `main` for the last ~24h (runs #410, #411, #412). The `wait-for-ci` job times out after polling CI for 10 minutes, then exits 1 — blocking every release (validate, build-cli-matrix, publish-crates, create-github-release, publish-npm-wasm, publish-npm-cli, and verify-release are all skipped).

Root cause: CI on `main` routinely takes longer than 10 min — the `mutation-test` job alone runs ~20 min (see run #1589 log: `52 mutants tested in 20m`). The polling loop in `release.yml` only had `MAX_WAIT=600`, so it never observed a `completed` conclusion before its budget ran out. A secondary issue is that main-branch CI runs are repeatedly cancelled by `ci.yml`'s `concurrency: cancel-in-progress: true` as new pushes land — the polling script then never sees the cancellation either, since the only path through the loop branches on `success` vs everything-else.

Separately, the `mutation-test` job in `ci.yml` runs on both `push` and `pull_request`, doubling the cost (~20 min × 2) and re-running mutation testing on `main` even though the PR that introduced the change already got full coverage. The `scripts/mutation_test.sh` CI-mode block also had a latent bug: it computed a mutation score and checked it against the 85% threshold, but the final `exit "${RESULT}"` always returned cargo-mutants' exit code 2 (set whenever any mutant survived), making the threshold gate dead code.

## Changes

### `.github/workflows/release.yml`
- Raise `MAX_WAIT` from `600` (10 min) to `1800` (30 min) so `wait-for-ci` can survive a full CI run including the mutation-test job.
- Update the failure log/error message to say `CI workflow <conclusion>` instead of `CI workflow failed`, so cancellations and timeouts are reported accurately (the existing `else` branch already handled `cancelled`, `failure`, `timed_out`, etc., but the message was misleading).
- Add a comment explaining the 10 min → 30 min bump and the historical reason.

### `.github/workflows/ci.yml`
- Gate `mutation-test` behind `if: github.event_name == 'pull_request'`. This keeps full mutation coverage on the PR that introduces a change, but skips the ~20 min re-run on every push to `main`. As a result, main-branch CI fits comfortably inside the Release workflow's wait-for-ci window.

### `scripts/mutation_test.sh`
- In CI mode, when the parsed mutation score meets the threshold, `exit 0` instead of falling through to `exit "${RESULT}"`. `cargo-mutants` exits 2 whenever any mutant is missed, regardless of the configured threshold — previously this meant the threshold check was effectively ignored and CI failed even when the score was above 85% (e.g. 47/52 = 90.4% in run #1589 still produced `exit 2`).
- Also `exit 0` in the "no Rust source files changed" branch, so the script returns success consistently when the check is intentionally skipped.

## Validation
- YAML syntax validated with `python3 -c 'import yaml; yaml.safe_load(...)'` for both workflow files.
- Shell syntax validated with `bash -n scripts/mutation_test.sh`.
- No behavioral change to the actual mutation testing logic — only the CI-mode exit code path.

## Risk
- Skipping `mutation-test` on push-to-main is a coverage tradeoff. The risk is low because the PR that introduced any code change already runs mutation testing. A follow-up could add a scheduled nightly run of `mutation-test` on `main` if full main-branch coverage is desired.

## Related
- Failing Release runs: #410, #411, #412
- Failing CI mutation-test runs: #1588, #1589 (resolved by PR #399's author)
