### PR TITLE
build: set explicit python version for sonarcloud analysis

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,4 @@
+# .sonarcloud.properties
+sonar.python.version=3.12
+sonar.sources=scripts,tests
+sonar.exclusions=target/**,**/*.lock,llms-full.txt,llms.txt


### PR DESCRIPTION
What: Created .sonarcloud.properties to explicitly set sonar.python.version=3.12.
Why: SonarCloud emitted a warning about imprecise analysis when no Python version is specified, falling back to compatibility with all Python 3 versions.
Impact: Resolves the warning and enables precise version-specific security and quality rules. Scoped analysis improves efficiency by excluding build artifacts and focusing on relevant Python source directories.

---
*PR created automatically by Jules for task [18114789847913043267](https://jules.google.com/task/18114789847913043267) started by @d-o-hub*