### PR TITLE
chore: bump workspace versions and add explicit dependency requirements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "chaotic_semantic_memory_duckdb"
-version = "0.1.0"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "csm-cli"
-version = "0.1.0"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "chaotic_semantic_memory",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "csm-core"
-version = "0.1.0"
+version = "0.3.6"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "csm-embedding"
-version = "0.1.0"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "csm-core",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "csm-memory"
-version = "0.1.0"
+version = "0.3.6"
 dependencies = [
  "bincode",
  "csm-core",
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "csm-persistence"
-version = "0.1.0"
+version = "0.3.6"
 dependencies = [
  "csm-core",
  "csm-memory",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "csm-retrieval"
-version = "0.1.0"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "csm-core",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "csm-traits"
-version = "0.1.0"
+version = "0.3.6"
 dependencies = [
  "csm-core",
  "js-sys",
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "csm-wasm"
-version = "0.1.0"
+version = "0.3.6"
 dependencies = [
  "chaotic_semantic_memory",
  "console_error_panic_hook",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "do-chaotic-semantic-memory-bench"
-version = "0.1.0"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "chaotic_semantic_memory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,10 +60,10 @@ include = [
 ]
 
 [dependencies]
-csm-core = { path = "crates/csm-core" }
-csm-embedding = { path = "crates/csm-embedding" }
-csm-memory = { path = "crates/csm-memory" }
-csm-retrieval = { path = "crates/csm-retrieval" }
+csm-core = { path = "crates/csm-core", version = "0.3.6" }
+csm-embedding = { path = "crates/csm-embedding", version = "0.3.6" }
+csm-memory = { path = "crates/csm-memory", version = "0.3.6" }
+csm-retrieval = { path = "crates/csm-retrieval", version = "0.3.6" }
 
 tempfile = { workspace = true }
 # Serialization
@@ -120,7 +120,7 @@ rayon = { version = "1.10.0", optional = true }
 
 # Database - Use libsql NOT turso-client (opt-in via "persistence" feature)
 libsql = { version = "0.9.30", default-features = false, features = ["sync", "hrana", "remote"], optional = true }
-csm-persistence = { path = "crates/csm-persistence" }
+csm-persistence = { path = "crates/csm-persistence", version = "0.3.6" }
 # `net` is required by the Prometheus /metrics server (ADR-0072).
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "fs", "net"] }
 
@@ -136,7 +136,7 @@ wasm-bindgen = "0.2.100"
 wasm-bindgen-futures = "0.4.64"
 js-sys = "0.3.77"
 console_error_panic_hook = { version = "0.1", optional = false }
-csm-persistence = { path = "crates/csm-persistence", default-features = false, features = ["wasm"] }
+csm-persistence = { path = "crates/csm-persistence", version = "0.3.6", default-features = false, features = ["wasm"] }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "do-chaotic-semantic-memory-bench"
-version = "0.1.0"
+version = "0.3.6"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"
@@ -22,7 +22,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
 uuid = { workspace = true, features = ["serde", "v4"] }
 
-chaotic_semantic_memory = { path = ".." }
+chaotic_semantic_memory = { path = "..", version = "0.3.6" }
 
 [features]
 default = []

--- a/crates/chaotic_semantic_memory_duckdb/Cargo.toml
+++ b/crates/chaotic_semantic_memory_duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chaotic_semantic_memory_duckdb"
-version = "0.1.0"
+version = "0.3.6"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
@@ -22,7 +22,7 @@ tokio = { workspace = true, optional = true, features = ["rt-multi-thread", "mac
 duckdb = { version = "1.1", features = ["bundled"] }
 
 [dev-dependencies]
-chaotic_semantic_memory = { path = "../../", default-features = false, features = ["persistence"] }
+chaotic_semantic_memory = { path = "../../", version = "0.3.6", default-features = false, features = ["persistence"] }
 tempfile = { workspace = true }
 insta = "1.40.0"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/csm-cli/Cargo.toml
+++ b/crates/csm-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csm-cli"
-version = "0.1.0"
+version = "0.3.6"
 edition = "2024"
 rust-version = "1.85"
 description = "CLI for chaotic_semantic_memory"
@@ -8,12 +8,12 @@ license = "MIT"
 repository = "https://github.com/d-o-hub/chaotic_semantic_memory"
 
 [dependencies]
-chaotic_semantic_memory = { path = "../..", default-features = false }
-csm-core = { path = "../csm-core" }
-csm-memory = { path = "../csm-memory" }
-csm-embedding = { path = "../csm-embedding" }
-csm-retrieval = { path = "../csm-retrieval" }
-csm-persistence = { path = "../csm-persistence" }
+chaotic_semantic_memory = { path = "../..", version = "0.3.6", default-features = false }
+csm-core = { path = "../csm-core", version = "0.3.6" }
+csm-memory = { path = "../csm-memory", version = "0.3.6" }
+csm-embedding = { path = "../csm-embedding", version = "0.3.6" }
+csm-retrieval = { path = "../csm-retrieval", version = "0.3.6" }
+csm-persistence = { path = "../csm-persistence", version = "0.3.6" }
 clap = { version = "4.5", features = ["derive", "env", "string"] }
 clap_complete = { version = "4.5.42" }
 anyhow = "1.0.102"

--- a/crates/csm-core/Cargo.toml
+++ b/crates/csm-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csm-core"
-version = "0.1.0"
+version = "0.3.6"
 edition = "2024"
 rust-version = "1.85"
 description = "Hyperdimensional computing kernel for chaotic_semantic_memory"

--- a/crates/csm-embedding/Cargo.toml
+++ b/crates/csm-embedding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csm-embedding"
-version = "0.1.0"
+version = "0.3.6"
 edition = "2024"
 rust-version = "1.85"
 description = "Embedding providers for chaotic_semantic_memory"
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/d-o-hub/chaotic_semantic_memory"
 
 [dependencies]
-csm-core = { path = "../csm-core" }
+csm-core = { path = "../csm-core", version = "0.3.6" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/csm-memory/Cargo.toml
+++ b/crates/csm-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csm-memory"
-version = "0.1.0"
+version = "0.3.6"
 edition = "2024"
 rust-version = "1.85"
 description = "Concept store and singularity engine for chaotic_semantic_memory"
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/d-o-hub/chaotic_semantic_memory"
 
 [dependencies]
-csm-core = { path = "../csm-core" }
+csm-core = { path = "../csm-core", version = "0.3.6" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/csm-persistence/Cargo.toml
+++ b/crates/csm-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csm-persistence"
-version = "0.1.0"
+version = "0.3.6"
 edition = "2024"
 rust-version = "1.85"
 description = "Persistence backends for chaotic_semantic_memory"
@@ -8,8 +8,8 @@ license = "MIT"
 repository = "https://github.com/d-o-hub/chaotic_semantic_memory"
 
 [dependencies]
-csm-core = { path = "../csm-core" }
-csm-memory = { path = "../csm-memory" }
+csm-core = { path = "../csm-core", version = "0.3.6" }
+csm-memory = { path = "../csm-memory", version = "0.3.6" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/csm-retrieval/Cargo.toml
+++ b/crates/csm-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csm-retrieval"
-version = "0.1.0"
+version = "0.3.6"
 edition = "2024"
 rust-version = "1.85"
 description = "Retrieval backends for chaotic_semantic_memory"
@@ -8,8 +8,8 @@ license = "MIT"
 repository = "https://github.com/d-o-hub/chaotic_semantic_memory"
 
 [dependencies]
-csm-core = { path = "../csm-core" }
-csm-memory = { path = "../csm-memory" }
+csm-core = { path = "../csm-core", version = "0.3.6" }
+csm-memory = { path = "../csm-memory", version = "0.3.6" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/csm-traits/Cargo.toml
+++ b/crates/csm-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csm-traits"
-version = "0.1.0"
+version = "0.3.6"
 edition = "2024"
 rust-version = "1.85"
 description = "Shared types and traits for chaotic_semantic_memory workspace"
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/d-o-hub/chaotic_semantic_memory"
 
 [dependencies]
-csm-core = { path = "../csm-core" }
+csm-core = { path = "../csm-core", version = "0.3.6" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/csm-wasm/Cargo.toml
+++ b/crates/csm-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csm-wasm"
-version = "0.1.0"
+version = "0.3.6"
 edition = "2024"
 rust-version = "1.85"
 description = "WASM bindings for chaotic_semantic_memory"
@@ -8,11 +8,11 @@ license = "MIT"
 repository = "https://github.com/d-o-hub/chaotic_semantic_memory"
 
 [dependencies]
-chaotic_semantic_memory = { path = "../..", default-features = false, features = ["wasm"] }
-csm-core = { path = "../csm-core" }
-csm-memory = { path = "../csm-memory" }
-csm-retrieval = { path = "../csm-retrieval", default-features = false }
-csm-traits = { path = "../csm-traits" }
+chaotic_semantic_memory = { path = "../..", version = "0.3.6", default-features = false, features = ["wasm"] }
+csm-core = { path = "../csm-core", version = "0.3.6" }
+csm-memory = { path = "../csm-memory", version = "0.3.6" }
+csm-retrieval = { path = "../csm-retrieval", version = "0.3.6", default-features = false }
+csm-traits = { path = "../csm-traits", version = "0.3.6" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 wasm-bindgen = "0.2.100"

--- a/export.json
+++ b/export.json
@@ -1,6 +1,6 @@
 {
   "version": "0.3.6",
-  "exported_at": 1781586974,
+  "exported_at": 1781713294,
   "concepts": [],
   "associations": []
 }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ tokio = { version = "1.43.0", features = ["rt", "macros"] }
 serde_json = "1.0.149"
 
 [dependencies.chaotic_semantic_memory]
-path = ".."
+path = "..", version = "0.3.6"
 
 [workspace]
 


### PR DESCRIPTION
Update all internal workspace crates to version 0.3.6 to match the main package. Add explicit version requirements to all path dependencies to satisfy crates.io publishing requirements. This ensures that consumers can resolve internal dependencies correctly when the suite is published.

- Bumped csm-core, csm-memory, csm-retrieval, csm-embedding, csm-persistence, csm-traits, csm-cli, csm-wasm, and chaotic_semantic_memory_duckdb to 0.3.6.
- Added version = "0.3.6" to all path dependencies in root and member Cargo.toml files.
- Updated benchmarks and fuzz crates to use versioned path dependencies.

---
*PR created automatically by Jules for task [1265183387820224394](https://jules.google.com/task/1265183387820224394) started by @d-o-hub*