### PR TITLE
fix(singularity): add security bounds to RetrievalConfig

### DIFF
--- a/crates/csm-memory/src/singularity_retrieval.rs
+++ b/crates/csm-memory/src/singularity_retrieval.rs
@@ -77,11 +77,33 @@ pub struct RetrievalConfig {
     pub enable_bucket_candidates: bool,
 }
 
+/// Hard security limits for retrieval parameters (CWE-770).
+pub const MAX_RETRIEVAL_CANDIDATES: usize = 100_000;
+pub const MAX_GRAPH_DEPTH: u8 = 32;
+pub const MAX_GRAPH_FANOUT: usize = 10_000;
 /// Maximum allowed bucket probe width to prevent excessive memory usage.
 const MAX_BUCKET_PROBE_WIDTH: usize = 16;
 
 impl RetrievalConfig {
     pub fn validate(&self) -> Result<()> {
+        if self.max_candidates > MAX_RETRIEVAL_CANDIDATES {
+            return Err(csm_core::error::MemoryError::InvalidInput {
+                field: "max_candidates".to_string(),
+                reason: format!("max_candidates exceeds {MAX_RETRIEVAL_CANDIDATES}"),
+            });
+        }
+        if self.graph_depth > MAX_GRAPH_DEPTH {
+            return Err(csm_core::error::MemoryError::InvalidInput {
+                field: "graph_depth".to_string(),
+                reason: format!("graph_depth exceeds {MAX_GRAPH_DEPTH}"),
+            });
+        }
+        if self.graph_fanout > MAX_GRAPH_FANOUT {
+            return Err(csm_core::error::MemoryError::InvalidInput {
+                field: "graph_fanout".to_string(),
+                reason: format!("graph_fanout exceeds {MAX_GRAPH_FANOUT}"),
+            });
+        }
         if self.bucket_probe_width > MAX_BUCKET_PROBE_WIDTH {
             return Err(csm_core::error::MemoryError::InvalidInput {
                 field: "bucket_probe_width".to_string(),

--- a/progress/LEARNINGS.md
+++ b/progress/LEARNINGS.md
@@ -76,3 +76,8 @@
 - **Unreachable code is a mutation smell**: When refactoring a `visited.contains(&id) || depth > max_depth` style guard into `!visited.insert(id.clone())`, audit the queue invariant. If new entries are only enqueued at `depth + 1` when `depth < max_depth`, the original `depth > max_depth` check becomes unreachable and cargo-mutants will catch the `||` -> `&&` substitution as a missed mutant. Remove the dead branch and document the invariant.
 - **Mutation test cost is acceptable for PR fixes**: `cargo-mutants --in-diff <pr.diff> --in-place --no-shuffle` against a 35-line PR diff takes ~14 minutes locally and exercises both the original and mutated compile/test paths. 11 mutants → 10 caught, 1 unviable, 0 missed is a strong signal the fix is correct.
 - **Always run `--in-diff` on the post-fix tree**: cargo-mutants reports the baseline, so the diff must reflect the fix (not the pre-fix PR head). Generate the diff with `git diff origin/main > /tmp/pr.diff` after the fix is staged.
+
+## 2026-06-05 — RetrievalConfig parameters missing security bounds
+**Vulnerability:** RetrievalConfig parameters max_candidates, graph_depth, and graph_fanout lacked upper bounds, potentially leading to resource exhaustion (CWE-770) during candidate generation in similarity searches.
+**Learning:** While bucket_probe_width had a hard limit, other fields in the same struct were overlooked during its initial implementation and subsequent expansion of retrieval strategies.
+**Prevention:** Always enforce hard security limits on any parameter that controls recursion depth, fan-out, or allocation sizes in public APIs, even if they are nested in configuration structs.

--- a/tests/retrieval_config_security.rs
+++ b/tests/retrieval_config_security.rs
@@ -1,0 +1,57 @@
+use chaotic_semantic_memory::RetrievalConfig;
+use chaotic_semantic_memory::singularity::{Singularity, SingularityConfig};
+use csm_core::hyperdim::HVec10240;
+
+#[test]
+fn test_retrieval_config_validation_security_limits() {
+    // 1. Test max_candidates limit
+    let config = RetrievalConfig {
+        max_candidates: 100_001,
+        ..RetrievalConfig::default()
+    };
+    assert!(config.validate().is_err());
+
+    // 2. Test graph_depth limit
+    let config = RetrievalConfig {
+        graph_depth: 33,
+        ..RetrievalConfig::default()
+    };
+    assert!(config.validate().is_err());
+
+    // 3. Test graph_fanout limit
+    let config = RetrievalConfig {
+        graph_fanout: 10_001,
+        ..RetrievalConfig::default()
+    };
+    assert!(config.validate().is_err());
+
+    // 4. Test bucket_probe_width limit (existing)
+    let config = RetrievalConfig {
+        bucket_probe_width: 17,
+        ..RetrievalConfig::default()
+    };
+    assert!(config.validate().is_err());
+
+    // 5. Test valid config
+    let config = RetrievalConfig {
+        max_candidates: 100_000,
+        graph_depth: 32,
+        graph_fanout: 10_000,
+        bucket_probe_width: 16,
+        ..RetrievalConfig::default()
+    };
+    assert!(config.validate().is_ok());
+}
+
+#[test]
+fn test_singularity_set_retrieval_config_enforces_validation() {
+    let mut s = Singularity::<HVec10240>::new(SingularityConfig::default());
+
+    let invalid_config = RetrievalConfig {
+        max_candidates: 200_000,
+        ..RetrievalConfig::default()
+    };
+
+    let result = s.set_retrieval_config(invalid_config);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
**Severity:** MEDIUM
**Finding:** RetrievalConfig parameters max_candidates, graph_depth, and graph_fanout lacked upper bounds in crates/csm-memory/src/singularity_retrieval.rs.
**Impact:** An attacker or malicious configuration could cause resource exhaustion (memory/CPU) during similarity searches by specifying extremely large values for these parameters.
**Fix:** Added hard security limits and implemented validation in RetrievalConfig::validate() to ensure these parameters stay within safe bounds.
**Verification:** all gates pass — new test tests/retrieval_config_security.rs verifies the limits are enforced. Existing retrieval tests passed.

---
*PR created automatically by Jules for task [4454408365982656033](https://jules.google.com/task/4454408365982656033) started by @d-o-hub*