### PR TITLE
chore(goap): reconcile Wave 30 completion state

### DIFF
--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -4166,7 +4166,7 @@ actions:
     effects:
       deny_toml_created: true
     cost: 3
-    status: queued
+    status: complete
     file: deny.toml, .github/workflows/ci.yml
     description: |
       Create deny.toml for supply chain auditing:
@@ -4183,7 +4183,7 @@ actions:
       rust_toolchain_toml_created: true
       msrv_bumped_to_1_88: true
     cost: 1
-    status: queued
+    status: complete
     file: rust-toolchain.toml, Cargo.toml
     description: |
       Create rust-toolchain.toml pinning stable 1.88.0.
@@ -4236,7 +4236,7 @@ actions:
     effects:
       arch_fitness_tests_created: true
     cost: 3
-    status: queued
+    status: complete
     file: tests/arch_fitness.rs
     description: |
       Architecture fitness tests enforced at compile/test time:
@@ -4277,7 +4277,8 @@ actions:
     effects:
       chaos_logic_isolated: true
     cost: 8
-    status: queued
+    status: complete
+    file: crates/csm-chaos/
     description: |
       Extract chaotic maps and hashing primitives into a standalone 'csm-chaos' crate.
       Provides no_std + libm support for WASM/embedded targets and isolates
@@ -4289,7 +4290,8 @@ actions:
     effects:
       lsh_projection_simd_accelerated: true
     cost: 5
-    status: queued
+    status: complete
+    file: crates/csm-chaos/src/hashing/chaotic_lsh.rs
     description: |
       Implement SIMD (AVX2/NEON) acceleration for the ChaoticLsh dot-product loop.
       Leverage the pre-generated projection matrix for vectorized multiplication and sign-bit extraction.

--- a/plans/ADR_REGISTRY.md
+++ b/plans/ADR_REGISTRY.md
@@ -93,6 +93,7 @@
 | 0088 | Pre-existing Issues Documented During PR #356 Codacy Remediation | Accepted | [adr/0088-pre-existing-issues-pr356-codacy-remediation.md](adr/0088-pre-existing-issues-pr356-codacy-remediation.md) |
 | 0089 | GOAP Reconciliation 2026-06-16 | Accepted | [adr/0089-goap-reconciliation-2026-06-16.md](adr/0089-goap-reconciliation-2026-06-16.md) |
 | 0090 | Harness Engineering & rust-2026-template Alignment | Accepted | [adr/0090-harness-engineering-template-alignment.md](adr/0090-harness-engineering-template-alignment.md) |
+| 0091 | Hyperchaotic Bit-Slicing for Binary Semantic Hashing | Accepted | [adr/0091-hyperchaotic-bit-slicing.md](adr/0091-hyperchaotic-bit-slicing.md) |
 
 ## Status Definitions
 

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -1561,7 +1561,8 @@ world_state:
   deny_toml_created: true
   arch_fitness_tests_created: true
   lsh_projection_simd_accelerated: true
-  agents_context_created: true
+  agents_context_created: false          # Was created in d3c620b but deleted by Jules merge (7acfa78)
+  chaos_logic_isolated: true             # csm-chaos crate extracted (PR #441, 2026-06-26)
 
   # ═══════════════════════════════════════════════════════
   # PR Triage 2026-06-26 (GOAP Orchestrated)
@@ -1576,3 +1577,24 @@ world_state:
   pr_437_closed: true
   pr_437_closed_reason: "semver-incompatible upgrade (0.27→0.32) requiring opentelemetry API migration"
   fastembed_cache_removed_from_git: true  # PR #442
+
+  # ═══════════════════════════════════════════════════════
+  # Wave 30 Status (2026-06-27)
+  # ═══════════════════════════════════════════════════════
+  wave_30_status: mostly_complete
+  wave_30_completed_actions:
+    - create_rust_toolchain_toml
+    - create_deny_toml
+    - create_arch_fitness_tests
+    - simd_optimize_chaotic_lsh
+    - extract_csm_chaos_crate
+    - hyperchaotic_bit_slicing_research_2026_06
+  wave_30_remaining_queued:
+    - create_agents_context       # File deleted by Jules merge; needs re-creation
+  ci_main_status: in_progress     # Run 28268048957 (ddda1bc): 3/13 jobs passed, rest in queue
+  ci_main_partial_results:
+    wasm: success
+    csm_persistence: success
+    duckdb_companion: success
+  ci_dependabot_opentelemetry: closed  # PR #437 closed, not blocking
+  adr_0091_registered: true


### PR DESCRIPTION
## Summary

Reconcile GOAP state with actual codebase after Wave 30 completion.

### Changes

- **ACTIONS.md**: Mark 5 actions as `complete` (verified artifacts exist on disk):
  - `create_deny_toml` → `deny.toml`
  - `create_rust_toolchain_toml` → `rust-toolchain.toml`
  - `create_arch_fitness_tests` → `tests/arch_fitness.rs`
  - `extract_csm_chaos_crate` → `crates/csm-chaos/`
  - `simd_optimize_chaotic_lsh` → AVX2+NEON in `crates/csm-chaos/src/hashing/chaotic_lsh.rs`

- **ADR_REGISTRY.md**: Add ADR-0091 (Hyperchaotic Bit-Slicing for Binary Semantic Hashing)

- **GOAP_STATE.md**:
  - Fix `agents_context_created: false` (file deleted by Jules merge in 7acfa78)
  - Add `chaos_logic_isolated: true`
  - Add Wave 30 status section with CI tracking
  - Only 1 queued action remains: `create_agents_context`

### Codebase Analysis

Full codebase audit found:
- 0 TODO/FIXME/unimplemented markers
- 1 intentional stub (`CrossEncoderReranker` behind opt-in `rerank-cross` feature)
- 1 README docs inaccuracy (non-existent `analytics` feature in decision tree)
