### PR TITLE
chore: add shareable pre-push hook mirroring CI lint checks

### DIFF
--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Pre-push hook: mirrors CI lint checks locally
+set -e
+
+echo "🔍 Running pre-push validation (clippy + fmt)..."
+cargo fmt --check --quiet
+cargo clippy --all-targets --all-features -- -D warnings
+echo "✅ Pre-push checks passed"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Install git hooks that mirror CI checks locally
+set -e
+
+HOOKS_DIR="$(git rev-parse --git-dir)/hooks"
+
+cp scripts/hooks/pre-push "$HOOKS_DIR/pre-push"
+chmod +x "$HOOKS_DIR/pre-push"
+
+echo "✅ Git hooks installed"


### PR DESCRIPTION
Adds `scripts/hooks/pre-push` and `scripts/install-hooks.sh` so contributors can install a local pre-push hook that runs `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` before every push — matching CI exactly.

Usage after cloning:
```bash
./scripts/install-hooks.sh
```