### PR TITLE
fix(build): separate cdylib target into csm-wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,9 +258,9 @@ jobs:
     - name: Install wasm-pack
       run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
     - name: Build WASM
-      run: wasm-pack build --dev --target web -- --no-default-features --features wasm
+      run: wasm-pack build crates/csm-wasm --dev --target web
     - name: Check WASM
-      run: cargo check --target wasm32-unknown-unknown --no-default-features --features wasm
+      run: cargo check --target wasm32-unknown-unknown -p csm-wasm
     - name: Verify WASM TS Freshness
       run: bash scripts/check-wasm-freshness.sh
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,7 +256,7 @@ debug = 1
 workspace = true
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [[bin]]
 name = "csm"

--- a/scripts/check-wasm-freshness.sh
+++ b/scripts/check-wasm-freshness.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 WASM_DIR="./wasm"
 CHECKED_IN_DTS="${WASM_DIR}/chaotic_semantic_memory.d.ts"
 TEMP_PKG_DIR=$(mktemp -d)
-wasm-pack build --dev --target web --out-dir "${TEMP_PKG_DIR}" -- --features wasm > /dev/null 2>&1
-GENERATED_DTS="${TEMP_PKG_DIR}/chaotic_semantic_memory.d.ts"
+wasm-pack build crates/csm-wasm --dev --target web --out-dir "${TEMP_PKG_DIR}" > /dev/null 2>&1
+GENERATED_DTS="${TEMP_PKG_DIR}/csm_wasm.d.ts"
 # Filter out wasm_bindgen closure hashes and sort to handle non-deterministic ordering
 filter_dts() { grep -v 'wasm_bindgen__convert__closures_____invoke__' | sort; }
 if diff -u <(filter_dts < "${CHECKED_IN_DTS}") <(filter_dts < "${GENERATED_DTS}"); then

--- a/scripts/wasm_size_gate.sh
+++ b/scripts/wasm_size_gate.sh
@@ -6,10 +6,10 @@ MAX_BYTES="${CSM_WASM_SIZE_MAX_BYTES:-${DEFAULT_MAX_BYTES}}"
 REPORT_PATH="plans/handoffs/W5_C_to_D_wasm_size_report.md"
 
 rustup target add wasm32-unknown-unknown >/dev/null 2>&1 || true
-cargo build --target wasm32-unknown-unknown --release --features wasm >/dev/null
+cargo build --target wasm32-unknown-unknown --release -p csm-wasm >/dev/null
 
-# Find the library WASM (chaotic_semantic_memory.wasm), not the CLI binary (csm.wasm)
-WASM_FILE="target/wasm32-unknown-unknown/release/chaotic_semantic_memory.wasm"
+# Find the library WASM (csm_wasm.wasm from the csm-wasm crate)
+WASM_FILE="target/wasm32-unknown-unknown/release/csm_wasm.wasm"
 if [[ ! -f "${WASM_FILE}" ]]; then
   # Fallback: find any .wasm that's not the CLI binary
   WASM_FILE="$(find target/wasm32-unknown-unknown/release -maxdepth 1 -name '*.wasm' ! -name 'csm.wasm' | head -n 1)"


### PR DESCRIPTION
Removes cdylib from root crate [lib] section. Native builds no longer produce unnecessary shared library artifacts. The csm-wasm crate retains the cdylib target for WASM compilation.

Closes #474