### PR TITLE
docs: clarify npm CLI installation and fix permissions guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,17 +97,28 @@ npm install @d-o-hub/chaotic_semantic_memory
 
 ### CLI Binary
 
-**via npm (recommended for Node.js users):**
+**via npx (recommended — no install needed):**
+```bash
+npx @d-o-hub/csm --version
+npx @d-o-hub/csm inject my-concept --database csm_memory.db
+```
+
+**via npm global install:**
 ```bash
 npm install -g @d-o-hub/csm
 ```
+
+> **Permission errors?** Global installs may fail with `EACCES`. Fix with:
+> ```bash
+> npm config set prefix ~/.npm-global
+> export PATH=~/.npm-global/bin:$PATH  # Add to ~/.bashrc or ~/.zshrc to persist
+> ```
+> Or simply use `npx` above, which requires no global install.
 
 **via cargo:**
 ```bash
 cargo install chaotic_semantic_memory --bin csm
 ```
-
-> **Note:** Using `"0.2"` ensures compatibility with the latest 0.2.x patch versions.
 
 ## Core Components
 

--- a/cli-npm/README.md
+++ b/cli-npm/README.md
@@ -4,9 +4,21 @@ Command-line interface for [chaotic_semantic_memory](https://github.com/d-o-hub/
 
 ## Installation
 
+**Recommended: use npx (no install needed)**
+```bash
+npx @d-o-hub/csm --version
+```
+
+**Global install:**
 ```bash
 npm install -g @d-o-hub/csm
 ```
+
+> **Permission errors (EACCES)?** Configure npm prefix to avoid needing sudo:
+> ```bash
+> npm config set prefix ~/.npm-global
+> export PATH=~/.npm-global/bin:$PATH  # Add to ~/.bashrc or ~/.zshrc to persist
+> ```
 
 ## Usage
 


### PR DESCRIPTION
Extracted docs-only changes from the closed PR #492 (which bundled a crate rename).

Changes:
- Recommend `npx` as primary usage method (no install needed)
- Add EACCES permission error fix guidance with `npm config set prefix`
- Note to persist PATH changes in shell profile
- Mirror changes in both README.md and cli-npm/README.md

Supersedes the docs portion of #492.