### PR TITLE
feat(persistence): wave32 ann envelopes, mcp base64, evidence ci

### DIFF
--- a/.github/workflows/benchmark-ci.yml
+++ b/.github/workflows/benchmark-ci.yml
@@ -42,6 +42,12 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
+      # Unit tests for the benchmarks workspace (also run on every PR via ci.yml
+      # test-benchmarks). Kept here so path-filtered benchmark changes still
+      # validate the harness before the retrieval-only smoke run.
+      - name: Benchmark workspace unit tests
+        run: cargo test --manifest-path benchmarks/Cargo.toml --locked --quiet
+
       - name: Run benchmark
         run: cargo run --manifest-path benchmarks/Cargo.toml -- --dataset-dir benchmarks/datasets/v1/small --mode retrieval-only --out-dir benchmarks/results/ci
 
@@ -77,8 +83,10 @@ jobs:
               return True
 
           ok = True
-          ok &= require('recall_at_1', 0.7)
-          ok &= require('recall_at_5', 0.7)
+          # ADR-0095: recall_at_* is multi-label recall (not hit rate). Hit rate was
+          # historically ~0.75+; true multi-label mean on the small CI profile is lower.
+          ok &= require('recall_at_1', 0.55)
+          ok &= require('recall_at_5', 0.55)
           ok &= require('abstain_precision', 0.5)
           ok &= require('abstain_recall', 0.5)
           ok &= require_positive('storage_bytes')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,9 @@ jobs:
     - name: Run Miri tests
       run: cargo miri test -p chaotic_semantic_memory --no-default-features --features ann-hnsw --lib
       env:
-        MIRIFLAGS: "-Zmiri-disable-isolation"
+        # deterministic-floats: BM25/ln/recip scoring must be bit-stable across
+        # repeated searches; miri's default non-det floats break cache parity tests.
+        MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-deterministic-floats"
 
   build-cli:
     name: Build CLI (${{ matrix.platform }}-${{ matrix.arch }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,27 +199,28 @@ jobs:
       run: cargo test --features mcp --locked -- --quiet
 
   mutation-test:
-    # Mutation testing is expensive (~20 min per run). Run it only on PRs so
-    # main-branch CI stays fast enough to fit inside the Release workflow's
-    # wait-for-ci window. Push-to-main already gets full mutation coverage on
-    # the PR that introduced the change.
+    # Fast profile (2026-07-16): in-diff + unit tests only (--lib) + 60s timeout.
+    # Analysis of job 87601199764: full cargo test spent ~97s on integration vs
+    # ~12s on --lib; 120 mutants × full suite exceeded 50+ min. Target wall ≤20 min.
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 45
     needs: test
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.1.7
       with:
         fetch-depth: 0
 
-    # --- NEW: skip entire job if no Rust source files changed ---
     - name: Check for Rust changes
       id: rust_changes
       run: |
-        git fetch origin ${{ github.base_ref }} --depth=1
-        CHANGED=$(git diff --name-only origin/${{ github.base_ref }} | grep '\.rs$' || true)
+        # Fetch enough base history for three-dot merge-base (in-diff accuracy).
+        git fetch origin "${{ github.base_ref }}" --depth=50
+        CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" | grep '\.rs$' || true)
         if [ -n "$CHANGED" ]; then
           echo "has_rust_changes=true" >> "$GITHUB_OUTPUT"
+          echo "Changed Rust files:"
+          echo "$CHANGED"
         else
           echo "has_rust_changes=false" >> "$GITHUB_OUTPUT"
         fi
@@ -234,7 +235,7 @@ jobs:
       if: steps.rust_changes.outputs.has_rust_changes == 'true'
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.7.3
       with:
-        shared-key: mutation-test   # dedicated cache bucket, avoids evicting test-job cache
+        shared-key: mutation-test
 
     - name: Install cargo-mutants
       if: steps.rust_changes.outputs.has_rust_changes == 'true'
@@ -244,11 +245,14 @@ jobs:
 
     - name: Run mutation tests
       if: steps.rust_changes.outputs.has_rust_changes == 'true'
-      run: bash scripts/mutation_test.sh fast --ci
+      run: bash scripts/mutation_test.sh --ci fast
       env:
         MUTATION_THRESHOLD: ${{ github.event.pull_request.draft && '75' || '85' }}
         DIFF_TARGET: origin/${{ github.base_ref || 'main' }}
-        MUTANTS_JOBS: "4"   # passed into script below
+        # Parallel mutants; each runs cargo test --lib (see scripts/mutation_test.sh).
+        MUTANTS_JOBS: "4"
+        CARGO_TERM_COLOR: always
+        RUST_BACKTRACE: "0"
 
   wasm:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,10 +102,12 @@ jobs:
     - name: Run DuckDB tests
       run: cargo test -p csm-duckdb --locked -- --test-threads=1 --quiet
 
+  # Run on push (main) and pull_request so PR CI catches miri regressions
+  # before merge (main was red on test_cache_consistency after Wave 32 P0).
   miri:
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     env:
       PROTOC: /usr/bin/protoc
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
       fail-fast: false
       matrix:
         crate:
+          # Keep in sync with workspace members under crates/ (excl. csm-wasm, csm-duckdb).
+          # csm-duckdb has a dedicated job; csm-wasm is covered by the wasm job.
+          - csm-chaos
           - csm-cli
           - csm-core
           - csm-embedding
@@ -263,6 +266,14 @@ jobs:
       run: cargo check --target wasm32-unknown-unknown -p csm-wasm
     - name: Verify WASM TS Freshness
       run: bash scripts/check-wasm-freshness.sh
+    # WASM JS smoke (wasm/test.js) is intentionally NOT run in this job:
+    # 1) Build uses --target web; Node cannot initialize that package (fetch of
+    #    file:// wasm fails under undici: "not implemented... yet...").
+    # 2) crates/csm-wasm wasm-pack output is named csm_wasm.js; wasm/test.js
+    #    imports chaotic_semantic_memory.js (publish/out-name).
+    # 3) Smoke currently only succeeds against a nodejs-target package with that
+    #    name (e.g. checked-in wasm/pkg-node). Re-enable after packaging is
+    #    aligned (nodejs CI artifact + matching out-name or test env).
 
   lint:
     runs-on: ubuntu-latest
@@ -286,6 +297,48 @@ jobs:
       run: bash scripts/validate-skill-format.sh
     - name: LOC gate
       run: bash scripts/validate.sh
+
+  # ADR-0095 Tier 1: supply-chain / license / advisory gate (deny.toml).
+  # Lightweight job: install cargo-deny via taiki-e (same pin as cargo-mutants).
+  # Add job name "Cargo Deny" to branch-protection required checks when ready.
+  cargo-deny:
+    name: Cargo Deny
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.1.7
+    - name: Install Rust
+      uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+      with:
+        cache: false
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.7.3
+    - name: Install cargo-deny
+      uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853  # v2.83.2
+      with:
+        tool: cargo-deny
+    - name: cargo deny check
+      # Global --locked asserts Cargo.lock is unchanged (cargo-deny CLI option;
+      # must precede the `check` subcommand — `check --locked` is rejected).
+      run: cargo deny --locked check
+
+  # ADR-0095 Tier 1: benchmark crate unit tests (separate workspace manifest).
+  test-benchmarks:
+    name: Test Benchmark Workspace
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      PROTOC: /usr/bin/protoc
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.1.7
+    - name: Install Rust
+      uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+      with:
+        cache: false
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.7.3
+    - name: Benchmark workspace unit tests
+      run: cargo test --manifest-path benchmarks/Cargo.toml --locked --quiet
 
   # ADR-0095 Tier 1: fuzz targets must compile on every PR/push.
   # Lightweight check only (no long fuzz runs). cargo-fuzz CLI / nightly not required.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,116 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  # Path change detection so expensive / specialized jobs can skip when irrelevant.
+  # Push to main always runs full coverage (DIFF empty → all true) to protect the trunk.
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      duckdb: ${{ steps.filter.outputs.duckdb }}
+      wasm: ${{ steps.filter.outputs.wasm }}
+      fuzz: ${{ steps.filter.outputs.fuzz }}
+      mcp: ${{ steps.filter.outputs.mcp }}
+      cli_cross: ${{ steps.filter.outputs.cli_cross }}
+      mutation: ${{ steps.filter.outputs.mutation }}
+      rust_src: ${{ steps.filter.outputs.rust_src }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.1.7
+        with:
+          fetch-depth: 0
+      - id: filter
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "${{ github.base_ref }}" --depth=50
+            BASE="origin/${{ github.base_ref }}"
+            DIFF=$(git diff --name-only "${BASE}...HEAD" || true)
+          elif [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ] \
+            && [ -n "${{ github.event.before }}" ]; then
+            DIFF=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" || true)
+          else
+            # First push / unknown base: run everything
+            DIFF=""
+          fi
+
+          # Empty DIFF (e.g. first push) → enable all specialized jobs
+          if [ -z "${DIFF}" ]; then
+            for k in duckdb wasm fuzz mcp cli_cross mutation rust_src; do
+              echo "${k}=true" >> "$GITHUB_OUTPUT"
+            done
+            echo "detect-changes: empty DIFF → all jobs enabled"
+            exit 0
+          fi
+
+          echo "Changed files:"
+          echo "${DIFF}"
+
+          match() {
+            local pattern=$1
+            echo "${DIFF}" | grep -qE "${pattern}"
+          }
+
+          # Always true on push to main for trunk protection of optional crates
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "duckdb=true" >> "$GITHUB_OUTPUT"
+            echo "wasm=true" >> "$GITHUB_OUTPUT"
+            echo "fuzz=true" >> "$GITHUB_OUTPUT"
+            echo "mcp=true" >> "$GITHUB_OUTPUT"
+            echo "cli_cross=true" >> "$GITHUB_OUTPUT"
+            echo "mutation=false" >> "$GITHUB_OUTPUT"  # mutation is PR-only
+            if match '\.rs$|Cargo\.(toml|lock)$|build\.rs$'; then
+              echo "rust_src=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "rust_src=false" >> "$GITHUB_OUTPUT"
+            fi
+            exit 0
+          fi
+
+          # PR: path-filtered specialized jobs
+          if match '^(crates/csm-duckdb/|Cargo\.(toml|lock)$)'; then
+            echo "duckdb=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "duckdb=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if match '^(crates/csm-wasm/|src/wasm|wasm/|Cargo\.(toml|lock)$)'; then
+            echo "wasm=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "wasm=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if match '^(fuzz/|Cargo\.(toml|lock)$)'; then
+            echo "fuzz=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "fuzz=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if match '^(src/mcp/|Cargo\.(toml|lock)$|\.github/workflows/ci\.yml$)'; then
+            echo "mcp=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "mcp=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Cross-platform CLI (macOS/Windows): only when CLI surface or build wiring changes
+          if match '^(src/bin/|src/cli/|crates/csm-cli/|cli-npm/|Cargo\.(toml|lock)$|\.github/workflows/ci\.yml$)'; then
+            echo "cli_cross=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "cli_cross=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Mutation: production-relevant sources + manifests + mutation tooling
+          if match '\.rs$|Cargo\.(toml|lock)$|build\.rs$|scripts/mutation_test\.sh$|\.cargo/|deny\.toml$'; then
+            echo "mutation=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "mutation=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if match '\.rs$|Cargo\.(toml|lock)$|build\.rs$'; then
+            echo "rust_src=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "rust_src=false" >> "$GITHUB_OUTPUT"
+          fi
+
   commitlint:
     runs-on: ubuntu-latest
     steps:
@@ -28,8 +138,9 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4.0.3
         with:
           node-version: '20'
+          cache: 'npm'
       - name: Install commitlint
-        run: npm install --save-dev @commitlint/config-conventional @commitlint/cli
+        run: npm ci
       - name: Validate PR commits with commitlint
         if: github.event_name == 'pull_request'
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
@@ -50,6 +161,8 @@ jobs:
         cache: false
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.7.3
+      with:
+        shared-key: test
     - name: Run tests
       run: cargo test --all-features --locked -- --quiet
 
@@ -81,6 +194,8 @@ jobs:
         cache: false
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.7.3
+      with:
+        shared-key: test
     - name: Test ${{ matrix.crate }}
       # Default features only; --all-features activates mutually exclusive
       # crate features (e.g. wasm vs persistence in csm-persistence).
@@ -89,6 +204,8 @@ jobs:
 
   test-duckdb:
     name: Test DuckDB Companion
+    needs: detect-changes
+    if: needs.detect-changes.outputs.duckdb == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -99,15 +216,17 @@ jobs:
         cache: false
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.7.3
+      with:
+        shared-key: test
     - name: Run DuckDB tests
       run: cargo test -p csm-duckdb --locked -- --test-threads=1 --quiet
 
-  # Run on push (main) and pull_request so PR CI catches miri regressions
-  # before merge (main was red on test_cache_consistency after Wave 32 P0).
+  # Miri: push + PR. Path-skip docs-only when no Rust/Cargo changes (detect-changes.rust_src).
   miri:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.rust_src == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
     env:
       PROTOC: /usr/bin/protoc
     steps:
@@ -120,6 +239,8 @@ jobs:
         components: miri
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.7.3
+      with:
+        shared-key: miri
     - name: Run Miri tests
       run: cargo miri test -p chaotic_semantic_memory --no-default-features --features ann-hnsw --lib
       env:
@@ -127,17 +248,35 @@ jobs:
         # repeated searches; miri's default non-det floats break cache parity tests.
         MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-deterministic-floats"
 
+  # Always build linux-x64 CLI after tests (cheap smoke compile).
   build-cli:
-    name: Build CLI (${{ matrix.platform }}-${{ matrix.arch }})
+    name: Build CLI (linux-x64)
     needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.1.7
+    - name: Install Rust
+      uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+      with:
+        cache: false
+        target: x86_64-unknown-linux-gnu
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.7.3
+      with:
+        shared-key: cli
+    - name: Build CLI
+      run: cargo build --release --bin csm --features cli --target x86_64-unknown-linux-gnu --locked
+
+  # Cross-platform CLI (arm64/macOS/Windows): PR path-filtered or always on push to main.
+  build-cli-cross:
+    name: Build CLI (${{ matrix.platform }}-${{ matrix.arch }})
+    needs: [test, detect-changes]
+    if: needs.detect-changes.outputs.cli_cross == 'true'
     strategy:
       fail-fast: true
       matrix:
         include:
-          - platform: linux
-            arch: x64
-            runner: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
           - platform: linux
             arch: arm64
             runner: ubuntu-latest
@@ -167,6 +306,8 @@ jobs:
 
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.7.3
+      with:
+        shared-key: cli
 
     - name: Install cross-compilation linker (Linux arm64)
       if: matrix.target == 'aarch64-unknown-linux-gnu'
@@ -179,6 +320,8 @@ jobs:
       run: cargo build --release --bin csm --features cli --target ${{ matrix.target }} --locked
 
   mcp-feature:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.mcp == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -193,68 +336,56 @@ jobs:
         cache: false
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.7.3
-    - name: Build MCP feature
-      run: cargo build --features mcp --locked
+      with:
+        shared-key: test
+    # cargo test already compiles; no separate cargo build step
     - name: Test MCP feature
       run: cargo test --features mcp --locked -- --quiet
 
   mutation-test:
-    # Fast profile (2026-07-16): in-diff + unit tests only (--lib) + 60s timeout.
-    # Analysis of job 87601199764: full cargo test spent ~97s on integration vs
-    # ~12s on --lib; 120 mutants × full suite exceeded 50+ min. Target wall ≤20 min.
-    if: github.event_name == 'pull_request'
+    # Fast profile: in-diff + unit tests only (--lib) + tight timeouts.
+    if: github.event_name == 'pull_request' && needs.detect-changes.outputs.mutation == 'true'
+    needs: [test, detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    needs: test
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.1.7
       with:
         fetch-depth: 0
 
-    - name: Check for Rust changes
-      id: rust_changes
-      run: |
-        # Fetch enough base history for three-dot merge-base (in-diff accuracy).
-        git fetch origin "${{ github.base_ref }}" --depth=50
-        CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" | grep '\.rs$' || true)
-        if [ -n "$CHANGED" ]; then
-          echo "has_rust_changes=true" >> "$GITHUB_OUTPUT"
-          echo "Changed Rust files:"
-          echo "$CHANGED"
-        else
-          echo "has_rust_changes=false" >> "$GITHUB_OUTPUT"
-        fi
+    - name: Fetch base for three-dot in-diff
+      run: git fetch origin "${{ github.base_ref }}" --depth=50
 
     - name: Install Rust
-      if: steps.rust_changes.outputs.has_rust_changes == 'true'
       uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
       with:
         cache: false
 
     - name: Cache Rust dependencies
-      if: steps.rust_changes.outputs.has_rust_changes == 'true'
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.7.3
       with:
         shared-key: mutation-test
 
     - name: Install cargo-mutants
-      if: steps.rust_changes.outputs.has_rust_changes == 'true'
       uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853  # v2.83.2
       with:
         tool: cargo-mutants
 
     - name: Run mutation tests
-      if: steps.rust_changes.outputs.has_rust_changes == 'true'
       run: bash scripts/mutation_test.sh --ci fast
       env:
         MUTATION_THRESHOLD: ${{ github.event.pull_request.draft && '75' || '85' }}
         DIFF_TARGET: origin/${{ github.base_ref || 'main' }}
-        # Parallel mutants; each runs cargo test --lib (see scripts/mutation_test.sh).
         MUTANTS_JOBS: "4"
+        # Absolute timeout budget + fraction of viable (see scripts/mutation_test.sh)
+        MUTATION_TIMEOUT_BUDGET: "5"
+        MUTATION_TIMEOUT_FRACTION: "0.10"
         CARGO_TERM_COLOR: always
         RUST_BACKTRACE: "0"
 
   wasm:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.wasm == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -266,8 +397,12 @@ jobs:
         target: wasm32-unknown-unknown
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.7.3
+      with:
+        shared-key: wasm
     - name: Install wasm-pack
-      run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853  # v2.83.2
+      with:
+        tool: wasm-pack
     - name: Build WASM
       run: wasm-pack build crates/csm-wasm --dev --target web
     - name: Check WASM
@@ -297,6 +432,8 @@ jobs:
         components: clippy, rustfmt
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.7.3
+      with:
+        shared-key: test
     - name: Format check
       run: cargo fmt --all -- --check
     - name: Clippy
@@ -306,9 +443,6 @@ jobs:
     - name: LOC gate
       run: bash scripts/validate.sh
 
-  # ADR-0095 Tier 1: supply-chain / license / advisory gate (deny.toml).
-  # Lightweight job: install cargo-deny via taiki-e (same pin as cargo-mutants).
-  # Add job name "Cargo Deny" to branch-protection required checks when ready.
   cargo-deny:
     name: Cargo Deny
     runs-on: ubuntu-latest
@@ -321,16 +455,15 @@ jobs:
         cache: false
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.7.3
+      with:
+        shared-key: test
     - name: Install cargo-deny
       uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853  # v2.83.2
       with:
         tool: cargo-deny
     - name: cargo deny check
-      # Global --locked asserts Cargo.lock is unchanged (cargo-deny CLI option;
-      # must precede the `check` subcommand — `check --locked` is rejected).
       run: cargo deny --locked check
 
-  # ADR-0095 Tier 1: benchmark crate unit tests (separate workspace manifest).
   test-benchmarks:
     name: Test Benchmark Workspace
     runs-on: ubuntu-latest
@@ -345,14 +478,15 @@ jobs:
         cache: false
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.7.3
+      with:
+        shared-key: test
     - name: Benchmark workspace unit tests
       run: cargo test --manifest-path benchmarks/Cargo.toml --locked --quiet
 
-  # ADR-0095 Tier 1: fuzz targets must compile on every PR/push.
-  # Lightweight check only (no long fuzz runs). cargo-fuzz CLI / nightly not required.
-  # Add job name "Fuzz Workspace Build" to branch-protection required checks.
   fuzz-build:
     name: Fuzz Workspace Build
+    needs: detect-changes
+    if: needs.detect-changes.outputs.fuzz == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -371,5 +505,6 @@ jobs:
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.7.3
       with:
         workspaces: fuzz
+        shared-key: fuzz
     - name: Check all fuzz targets compile
       run: cargo check --manifest-path fuzz/Cargo.toml --all-targets --locked

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ pkg/
 # Auto-generated exports
 
 
+# CI-only root npm (commitlint); lockfile is committed, modules are not
+/node_modules/
+
 # IDE / editor tooling
 .opencode/node_modules/
 .opencode/bun.lock

--- a/benchmarks/src/metrics.rs
+++ b/benchmarks/src/metrics.rs
@@ -23,19 +23,16 @@ pub fn aggregate(
         };
     }
 
-    // Calculate recall-based metrics only for cases with gold evidence
+    // Mean multi-label recall / MRR / NDCG over cases that should answer (not abstain gold)
     let (recall_at_1, recall_at_5, recall_at_10, mrr, ndcg_at_10) = {
-        let gold_cases: Vec<_> = results
-            .iter()
-            .filter(|r| !matches!(r.task_type, TaskType::Abstain | TaskType::Isolation))
-            .collect();
+        let gold_cases: Vec<_> = results.iter().filter(|r| !r.should_abstain).collect();
         let gold_count = gold_cases.len();
 
         if gold_count > 0 {
             (
-                gold_cases.iter().filter(|r| r.recall_at_1).count() as f32 / gold_count as f32,
-                gold_cases.iter().filter(|r| r.recall_at_5).count() as f32 / gold_count as f32,
-                gold_cases.iter().filter(|r| r.recall_at_10).count() as f32 / gold_count as f32,
+                gold_cases.iter().map(|r| r.recall_at_1).sum::<f32>() / gold_count as f32,
+                gold_cases.iter().map(|r| r.recall_at_5).sum::<f32>() / gold_count as f32,
+                gold_cases.iter().map(|r| r.recall_at_10).sum::<f32>() / gold_count as f32,
                 gold_cases.iter().map(|r| r.reciprocal_rank).sum::<f32>() / gold_count as f32,
                 gold_cases.iter().map(|r| r.ndcg_at_10).sum::<f32>() / gold_count as f32,
             )
@@ -44,23 +41,29 @@ pub fn aggregate(
         }
     };
 
-    let abstain_cases: Vec<_> = results
+    // Abstention confusion matrix uses QueryCase.should_abstain as gold label,
+    // not task-type inference alone (ADR-0095).
+    let should_abstain_count = results.iter().filter(|r| r.should_abstain).count();
+    let true_positives = results
         .iter()
-        .filter(|r| matches!(r.task_type, TaskType::Abstain | TaskType::Isolation))
-        .collect();
-    let abstain_count = abstain_cases.len();
+        .filter(|r| r.should_abstain && r.abstained)
+        .count() as f32;
+    let false_positives = results
+        .iter()
+        .filter(|r| !r.should_abstain && r.abstained)
+        .count() as f32;
 
-    let (abstain_precision, abstain_recall) = if abstain_count > 0 {
-        let true_positives = abstain_cases.iter().filter(|r| r.abstained).count() as f32;
-        let false_positives = results
-            .iter()
-            .filter(|r| {
-                !matches!(r.task_type, TaskType::Abstain | TaskType::Isolation) && r.abstained
-            })
-            .count() as f32;
-
-        let precision = true_positives / (true_positives + false_positives).max(1.0);
-        let recall = true_positives / abstain_count as f32;
+    let (abstain_precision, abstain_recall) = if should_abstain_count > 0 || false_positives > 0.0 {
+        let precision = if true_positives + false_positives > 0.0 {
+            true_positives / (true_positives + false_positives)
+        } else {
+            0.0
+        };
+        let recall = if should_abstain_count > 0 {
+            true_positives / should_abstain_count as f32
+        } else {
+            0.0
+        };
         (precision, recall)
     } else {
         (0.0, 0.0)
@@ -71,7 +74,7 @@ pub fn aggregate(
         .filter(|r| matches!(r.task_type, TaskType::Association))
         .collect();
     let association_success_rate = if !association_cases.is_empty() {
-        association_cases.iter().filter(|r| r.recall_at_5).count() as f32
+        association_cases.iter().map(|r| r.recall_at_5).sum::<f32>()
             / association_cases.len() as f32
     } else {
         0.0
@@ -82,7 +85,10 @@ pub fn aggregate(
         .filter(|r| matches!(r.task_type, TaskType::MultiSession))
         .collect();
     let multisession_recall = if !multisession_cases.is_empty() {
-        multisession_cases.iter().filter(|r| r.recall_at_5).count() as f32
+        multisession_cases
+            .iter()
+            .map(|r| r.recall_at_5)
+            .sum::<f32>()
             / multisession_cases.len() as f32
     } else {
         0.0
@@ -158,10 +164,11 @@ mod tests {
     fn make_result(
         query_id: &str,
         task_type: TaskType,
-        recall_at_1: bool,
-        recall_at_5: bool,
+        recall_at_1: f32,
+        recall_at_5: f32,
         latency_ms: u128,
         abstained: bool,
+        should_abstain: bool,
     ) -> CaseResult {
         CaseResult {
             query_id: query_id.into(),
@@ -175,11 +182,12 @@ mod tests {
             recall_at_1,
             recall_at_5,
             recall_at_10: recall_at_5,
-            reciprocal_rank: if recall_at_1 { 1.0 } else { 0.0 },
-            ndcg_at_10: if recall_at_1 { 1.0 } else { 0.0 },
+            reciprocal_rank: if recall_at_1 > 0.0 { 1.0 } else { 0.0 },
+            ndcg_at_10: if recall_at_1 > 0.0 { 1.0 } else { 0.0 },
             predicted_answer: None,
             exact_match: None,
             abstained,
+            should_abstain,
             latency_ms,
             latency_us: latency_ms * 1000, // Simulate us from ms for tests
             prompt_tokens: 0,
@@ -198,7 +206,15 @@ mod tests {
 
     #[test]
     fn aggregate_single_result() {
-        let results = vec![make_result("q1", TaskType::Recall, true, true, 10, false)];
+        let results = vec![make_result(
+            "q1",
+            TaskType::Recall,
+            1.0,
+            1.0,
+            10,
+            false,
+            false,
+        )];
         let summary = aggregate(&results, 100, 1024, 512);
         assert_eq!(summary.cases, 1);
         assert_eq!(summary.recall_at_1, 1.0);
@@ -213,8 +229,8 @@ mod tests {
     #[test]
     fn aggregate_recall_mixed() {
         let results = vec![
-            make_result("q1", TaskType::Recall, true, true, 10, false),
-            make_result("q2", TaskType::Recall, false, false, 20, false),
+            make_result("q1", TaskType::Recall, 1.0, 1.0, 10, false, false),
+            make_result("q2", TaskType::Recall, 0.0, 0.0, 20, false, false),
         ];
         let summary = aggregate(&results, 100, 1024, 512);
         assert_eq!(summary.cases, 2);
@@ -224,24 +240,65 @@ mod tests {
     }
 
     #[test]
+    fn aggregate_multi_label_mean_recall() {
+        // Fractional multi-label recall averages correctly
+        let results = vec![
+            make_result("q1", TaskType::Recall, 1.0, 2.0 / 3.0, 10, false, false),
+            make_result("q2", TaskType::Recall, 0.5, 0.5, 10, false, false),
+        ];
+        let summary = aggregate(&results, 100, 1024, 512);
+        assert!((summary.recall_at_1 - 0.75).abs() < 1e-6);
+        assert!((summary.recall_at_5 - (2.0 / 3.0 + 0.5) / 2.0).abs() < 1e-6);
+    }
+
+    #[test]
     fn aggregate_abstention_metrics() {
         let results = vec![
-            make_result("q1", TaskType::Abstain, false, false, 10, true), // true positive
-            make_result("q2", TaskType::Abstain, false, false, 10, false), // false negative
-            make_result("q3", TaskType::Recall, false, false, 10, true),  // false positive
-            make_result("q4", TaskType::Recall, false, false, 10, false), // true negative
+            make_result("q1", TaskType::Abstain, 0.0, 0.0, 10, true, true), // TP
+            make_result("q2", TaskType::Abstain, 0.0, 0.0, 10, false, true), // FN
+            make_result("q3", TaskType::Recall, 0.0, 0.0, 10, true, false), // FP
+            make_result("q4", TaskType::Recall, 0.0, 0.0, 10, false, false), // TN
         ];
         let summary = aggregate(&results, 100, 1024, 512);
         // 1 TP, 1 FP -> precision = 1/2 = 0.5
-        // 2 abstain cases, 1 abstained -> recall = 1/2 = 0.5
+        // 2 should_abstain, 1 abstained -> recall = 1/2 = 0.5
         assert_eq!(summary.abstain_precision, 0.5);
         assert_eq!(summary.abstain_recall, 0.5);
     }
 
     #[test]
+    fn aggregate_abstention_label_disagreement() {
+        // should_abstain=true but task is NOT Abstain (e.g. Isolation / custom label)
+        let results = vec![
+            make_result("q1", TaskType::Isolation, 0.0, 0.0, 10, true, true), // TP via label
+            make_result("q2", TaskType::Recall, 0.0, 0.0, 10, true, true),    // TP: label not task
+            make_result("q3", TaskType::Abstain, 0.0, 0.0, 10, false, false), // TN: task Abstain but gold says no
+            make_result("q4", TaskType::Recall, 0.0, 0.0, 10, true, false),   // FP
+        ];
+        let summary = aggregate(&results, 100, 1024, 512);
+        // TP=2 (q1,q2), FP=1 (q4) → precision = 2/3
+        // should_abstain=2 (q1,q2), TP=2 → recall = 1.0
+        // q3 has task Abstain but should_abstain=false → not counted as gold positive
+        assert!((summary.abstain_precision - 2.0 / 3.0).abs() < 1e-6);
+        assert!((summary.abstain_recall - 1.0).abs() < 1e-6);
+        // Gold-answer cases exclude should_abstain; only q3+q4 contribute to mean recall (both 0)
+        assert_eq!(summary.recall_at_1, 0.0);
+    }
+
+    #[test]
     fn aggregate_latency_percentiles() {
         let results: Vec<_> = (1..=10)
-            .map(|i| make_result(&format!("q{i}"), TaskType::Recall, false, false, i, false))
+            .map(|i| {
+                make_result(
+                    &format!("q{i}"),
+                    TaskType::Recall,
+                    0.0,
+                    0.0,
+                    i,
+                    false,
+                    false,
+                )
+            })
             .collect();
         let summary = aggregate(&results, 100, 1024, 512);
         // Sorted latencies: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]

--- a/benchmarks/src/runner.rs
+++ b/benchmarks/src/runner.rs
@@ -131,23 +131,25 @@ pub async fn run(cli: Cli) -> Result<()> {
             session_id: query_case.session_id.clone(),
             task_type: query_case.task_type.clone(),
             retrieved,
-            recall_at_1: false,
-            recall_at_5: false,
-            recall_at_10: false,
+            recall_at_1: 0.0,
+            recall_at_5: 0.0,
+            recall_at_10: 0.0,
             reciprocal_rank: 0.0,
             ndcg_at_10: 0.0,
             predicted_answer: None,
             exact_match: None,
             abstained: false,
+            should_abstain: query_case.should_abstain,
             latency_ms,
             latency_us,
             prompt_tokens: 0,
             completion_tokens: 0,
         };
 
-        result.recall_at_1 = scorer::hit_at_k(&query_case, &result, 1);
-        result.recall_at_5 = scorer::hit_at_k(&query_case, &result, 5);
-        result.recall_at_10 = scorer::hit_at_k(&query_case, &result, 10);
+        // Multi-label recall (not hit rate); hit_at_k remains available for hit-rate use cases
+        result.recall_at_1 = scorer::recall_at_k(&query_case, &result, 1);
+        result.recall_at_5 = scorer::recall_at_k(&query_case, &result, 5);
+        result.recall_at_10 = scorer::recall_at_k(&query_case, &result, 10);
         result.reciprocal_rank = scorer::reciprocal_rank(&query_case, &result);
         result.ndcg_at_10 = scorer::ndcg_at_k(&query_case, &result, 10);
 

--- a/benchmarks/src/scorer.rs
+++ b/benchmarks/src/scorer.rs
@@ -1,8 +1,8 @@
 use crate::types::{CaseResult, QueryCase};
 use std::collections::HashSet;
 
+/// Hit rate@k: true if any gold evidence ID appears in the top-k retrieved items.
 pub fn hit_at_k(case: &QueryCase, result: &CaseResult, k: usize) -> bool {
-    // Use HashSet for O(1) lookup of gold evidence IDs
     let gold: HashSet<&str> = case.gold_evidence_ids.iter().map(|s| s.as_str()).collect();
     result
         .retrieved
@@ -11,8 +11,24 @@ pub fn hit_at_k(case: &QueryCase, result: &CaseResult, k: usize) -> bool {
         .any(|r| gold.contains(r.memory_id.as_str()))
 }
 
+/// Multi-label recall@k: |unique gold ∩ retrieved@k| / |unique gold|.
+/// Returns 0.0 when gold is empty.
+pub fn recall_at_k(case: &QueryCase, result: &CaseResult, k: usize) -> f32 {
+    let gold: HashSet<&str> = case.gold_evidence_ids.iter().map(|s| s.as_str()).collect();
+    if gold.is_empty() {
+        return 0.0;
+    }
+    let retrieved: HashSet<&str> = result
+        .retrieved
+        .iter()
+        .take(k)
+        .map(|r| r.memory_id.as_str())
+        .collect();
+    let hits = gold.intersection(&retrieved).count();
+    hits as f32 / gold.len() as f32
+}
+
 pub fn reciprocal_rank(case: &QueryCase, result: &CaseResult) -> f32 {
-    // Use HashSet for O(1) lookup of gold evidence IDs
     let gold: HashSet<&str> = case.gold_evidence_ids.iter().map(|s| s.as_str()).collect();
     for item in &result.retrieved {
         if gold.contains(item.memory_id.as_str()) {
@@ -22,31 +38,38 @@ pub fn reciprocal_rank(case: &QueryCase, result: &CaseResult) -> f32 {
     0.0
 }
 
+/// Logarithmic position discount for 0-indexed list position `i`.
+/// Equals `1 / log2(rank + 1)` where rank is 1-indexed (`rank = i + 1`).
+#[inline]
+fn log_discount(i: usize) -> f32 {
+    1.0 / ((i as f32 + 2.0).log2())
+}
+
 /// Compute Normalized Discounted Cumulative Gain at k.
-/// Uses logarithmic discount: relevance / 2^(position) where position is 1-indexed.
+///
+/// Uses true logarithmic discount: relevance / log2(rank + 1) for 1-indexed rank
+/// (equivalently `1.0 / ((i as f32 + 2.0).log2())` for 0-indexed position `i`).
 /// For binary relevance (gold/not-gold), this rewards systems that return relevant
 /// items higher in the result list.
 pub fn ndcg_at_k(case: &QueryCase, result: &CaseResult, k: usize) -> f32 {
     let gold: HashSet<&str> = case.gold_evidence_ids.iter().map(|s| s.as_str()).collect();
+    if gold.is_empty() {
+        return 0.0;
+    }
 
-    // Compute DCG: sum of relevance / 2^(position) for each relevant item found
+    // DCG: sum of log-discount for each relevant item in the top-k ranking
     let dcg: f32 = result
         .retrieved
         .iter()
         .take(k)
         .enumerate()
         .filter(|(_, r)| gold.contains(r.memory_id.as_str()))
-        .map(|(i, _)| 1.0 / 2.0_f32.powi(i as i32))
+        .map(|(i, _)| log_discount(i))
         .sum();
 
-    // Compute ideal DCG: what we'd get if all gold items were at the top
-    let ideal_dcg: f32 = case
-        .gold_evidence_ids
-        .iter()
-        .take(k)
-        .enumerate()
-        .map(|(i, _)| 1.0 / 2.0_f32.powi(i as i32))
-        .sum();
+    // Ideal DCG: all unique gold items ranked at the top (up to k)
+    let ideal_count = gold.len().min(k);
+    let ideal_dcg: f32 = (0..ideal_count).map(log_discount).sum();
 
     if ideal_dcg > 0.0 {
         dcg / ideal_dcg
@@ -85,14 +108,15 @@ mod tests {
                     score: *score,
                 })
                 .collect(),
-            recall_at_1: false,
-            recall_at_5: false,
-            recall_at_10: false,
+            recall_at_1: 0.0,
+            recall_at_5: 0.0,
+            recall_at_10: 0.0,
             reciprocal_rank: 0.0,
             ndcg_at_10: 0.0,
             predicted_answer: None,
             exact_match: None,
             abstained: false,
+            should_abstain: false,
             latency_ms: 0,
             latency_us: 0,
             prompt_tokens: 0,
@@ -140,6 +164,62 @@ mod tests {
     }
 
     #[test]
+    fn test_recall_at_k_multi_gold_partial() {
+        // 2 of 3 gold in top-5 → 2/3
+        let case = make_query_case(vec!["gold-1", "gold-2", "gold-3"]);
+        let result = make_case_result(vec![
+            ("gold-1", 1, 0.9),
+            ("other-1", 2, 0.8),
+            ("gold-2", 3, 0.7),
+            ("other-2", 4, 0.6),
+            ("other-3", 5, 0.5),
+        ]);
+        assert!((recall_at_k(&case, &result, 5) - 2.0 / 3.0).abs() < 1e-6);
+        // Only 1 of 3 in top-1
+        assert!((recall_at_k(&case, &result, 1) - 1.0 / 3.0).abs() < 1e-6);
+        // Hit rate is still true for partial multi-gold
+        assert!(hit_at_k(&case, &result, 5));
+        assert_ne!(
+            recall_at_k(&case, &result, 5),
+            if hit_at_k(&case, &result, 5) {
+                1.0
+            } else {
+                0.0
+            }
+        );
+    }
+
+    #[test]
+    fn test_recall_at_k_all_gold_found() {
+        let case = make_query_case(vec!["gold-1", "gold-2"]);
+        let result = make_case_result(vec![("gold-1", 1, 0.9), ("gold-2", 2, 0.8)]);
+        assert!((recall_at_k(&case, &result, 5) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_recall_at_k_empty_gold() {
+        let case = make_query_case(vec![]);
+        let result = make_case_result(vec![("other-1", 1, 0.9)]);
+        assert_eq!(recall_at_k(&case, &result, 5), 0.0);
+        assert!(!hit_at_k(&case, &result, 5));
+    }
+
+    #[test]
+    fn test_recall_at_k_duplicate_gold_ids() {
+        // Duplicate gold IDs collapse to unique set: still one gold item
+        let case = make_query_case(vec!["gold-1", "gold-1", "gold-1"]);
+        let result = make_case_result(vec![("gold-1", 1, 0.9), ("other", 2, 0.7)]);
+        assert!((recall_at_k(&case, &result, 5) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_recall_at_k_no_match() {
+        let case = make_query_case(vec!["gold-1", "gold-2"]);
+        let result = make_case_result(vec![("other-1", 1, 0.9), ("other-2", 2, 0.8)]);
+        assert_eq!(recall_at_k(&case, &result, 10), 0.0);
+    }
+
+    #[test]
     fn test_reciprocal_rank_at_1() {
         let case = make_query_case(vec!["gold-1"]);
         let result = make_case_result(vec![("gold-1", 1, 0.9)]);
@@ -172,16 +252,16 @@ mod tests {
     }
 
     #[test]
-    fn test_ndcg_perfect() {
-        // All gold items at the top
+    fn test_ndcg_perfect_log2() {
+        // All gold items at the top → NDCG = 1.0 under log2 discount
         let case = make_query_case(vec!["gold-1", "gold-2"]);
         let result = make_case_result(vec![("gold-1", 1, 0.9), ("gold-2", 2, 0.8)]);
         assert!((ndcg_at_k(&case, &result, 10) - 1.0).abs() < 1e-6);
     }
 
     #[test]
-    fn test_ndcg_partial() {
-        // One gold at position 1, one at position 5
+    fn test_ndcg_partial_log2() {
+        // One gold at position 1 (i=0), one at position 5 (i=4)
         let case = make_query_case(vec!["gold-1", "gold-2"]);
         let result = make_case_result(vec![
             ("gold-1", 1, 0.9),
@@ -190,11 +270,14 @@ mod tests {
             ("other-3", 4, 0.6),
             ("gold-2", 5, 0.5),
         ]);
-        // DCG = 1/2^0 + 1/2^4 = 1.0625
-        // IDCG = 1/2^0 + 1/2^1 = 1.5
-        // NDCG = 1.0625 / 1.5 = 0.70833...
-        let expected = (1.0 + 1.0 / 16.0) / (1.0 + 0.5);
+        // DCG = 1/log2(2) + 1/log2(6) = 1.0 + 1/log2(6)
+        // IDCG = 1/log2(2) + 1/log2(3) = 1.0 + 1/log2(3)
+        let dcg = log_discount(0) + log_discount(4);
+        let idcg = log_discount(0) + log_discount(1);
+        let expected = dcg / idcg;
         assert!((ndcg_at_k(&case, &result, 10) - expected).abs() < 1e-5);
+        // Partial ranking must be strictly less than perfect
+        assert!(expected < 1.0);
     }
 
     #[test]
@@ -209,5 +292,20 @@ mod tests {
         let case = make_query_case(vec!["gold-1"]);
         let result = make_case_result(vec![("gold-1", 1, 0.9)]);
         assert!((ndcg_at_k(&case, &result, 10) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_ndcg_empty_gold() {
+        let case = make_query_case(vec![]);
+        let result = make_case_result(vec![("other-1", 1, 0.9)]);
+        assert_eq!(ndcg_at_k(&case, &result, 10), 0.0);
+    }
+
+    #[test]
+    fn test_log_discount_formula() {
+        // rank 1 → log2(2) = 1 → discount 1.0
+        assert!((log_discount(0) - 1.0).abs() < 1e-6);
+        // rank 3 → log2(4) = 2 → discount 0.5
+        assert!((log_discount(2) - 0.5).abs() < 1e-6);
     }
 }

--- a/benchmarks/src/types.rs
+++ b/benchmarks/src/types.rs
@@ -95,15 +95,15 @@ pub struct CaseResult {
     pub task_type: TaskType,
     /// List of retrieved items.
     pub retrieved: Vec<RetrievedItem>,
-    /// Whether gold evidence was found at rank 1.
-    pub recall_at_1: bool,
-    /// Whether gold evidence was found in top 5.
-    pub recall_at_5: bool,
-    /// Whether gold evidence was found in top 10.
-    pub recall_at_10: bool,
+    /// Multi-label recall@1: |gold ∩ top-1| / |gold| (0 if gold empty).
+    pub recall_at_1: f32,
+    /// Multi-label recall@5: |gold ∩ top-5| / |gold| (0 if gold empty).
+    pub recall_at_5: f32,
+    /// Multi-label recall@10: |gold ∩ top-10| / |gold| (0 if gold empty).
+    pub recall_at_10: f32,
     /// Reciprocal rank of first gold evidence match.
     pub reciprocal_rank: f32,
-    /// NDCG@10 for multi-gold evidence cases.
+    /// NDCG@10 with log2 position discount for multi-gold evidence cases.
     pub ndcg_at_10: f32,
     /// Predicted answer (in reader-lite mode).
     pub predicted_answer: Option<String>,
@@ -111,6 +111,9 @@ pub struct CaseResult {
     pub exact_match: Option<bool>,
     /// Whether the system abstained from answering.
     pub abstained: bool,
+    /// Gold label: whether the system *should* abstain (from QueryCase.should_abstain).
+    #[serde(default)]
+    pub should_abstain: bool,
     /// Query latency in milliseconds.
     pub latency_ms: u128,
     /// Query latency in microseconds (precise for sub-ms measurements).
@@ -127,22 +130,22 @@ pub struct CaseResult {
 pub struct SummaryMetrics {
     /// Total number of query cases evaluated.
     pub cases: usize,
-    /// Fraction of cases with gold at rank 1.
+    /// Mean multi-label recall@1 across gold cases.
     pub recall_at_1: f32,
-    /// Fraction of cases with gold in top 5.
+    /// Mean multi-label recall@5 across gold cases.
     pub recall_at_5: f32,
-    /// Fraction of cases with gold in top 10.
+    /// Mean multi-label recall@10 across gold cases.
     pub recall_at_10: f32,
     /// Mean reciprocal rank across all cases.
     pub mrr: f32,
-    /// Mean NDCG@10 across all cases.
+    /// Mean NDCG@10 (log2 discount) across all cases.
     #[serde(default)]
     pub ndcg_at_10: f32,
     /// Exact match accuracy (reader mode only).
     pub exact_match: Option<f32>,
-    /// Precision of abstention decisions.
+    /// Precision of abstention decisions (gold = should_abstain).
     pub abstain_precision: f32,
-    /// Recall of abstention decisions.
+    /// Recall of abstention decisions (gold = should_abstain).
     pub abstain_recall: f32,
     /// Success rate of association tasks.
     #[serde(default)]

--- a/crates/csm-retrieval/src/bm25.rs
+++ b/crates/csm-retrieval/src/bm25.rs
@@ -303,12 +303,11 @@ impl Bm25Index {
 
             DOC_SCORES_BUFFER.with(|buffer| {
                 let mut doc_scores = buffer.borrow_mut();
-                // Active prefix zeroed each search (residuals break sparse touch tracking).
+                // Always clear the active prefix (resize alone does not zero old slots).
                 if doc_scores.len() < num_docs {
                     doc_scores.resize(num_docs, 0.0);
-                } else {
-                    doc_scores[..num_docs].fill(0.0);
                 }
+                doc_scores[..num_docs].fill(0.0);
 
                 self.ensure_norm_cache();
                 {
@@ -478,7 +477,7 @@ impl Bm25Index {
 }
 
 fn score_cmp_desc(a: &(usize, f32), b: &(usize, f32)) -> Ordering {
-    b.1.total_cmp(&a.1)
+    b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0))
 }
 
 #[cfg(test)]

--- a/crates/csm-retrieval/src/bm25.rs
+++ b/crates/csm-retrieval/src/bm25.rs
@@ -303,10 +303,11 @@ impl Bm25Index {
 
             DOC_SCORES_BUFFER.with(|buffer| {
                 let mut doc_scores = buffer.borrow_mut();
-                // Ensure buffer is large enough; we use sparse zeroing to maintain it.
-                // Buffer retains high-water-mark size; shrinking is O(N) and not worth it.
+                // Active prefix zeroed each search (residuals break sparse touch tracking).
                 if doc_scores.len() < num_docs {
                     doc_scores.resize(num_docs, 0.0);
+                } else {
+                    doc_scores[..num_docs].fill(0.0);
                 }
 
                 self.ensure_norm_cache();
@@ -316,6 +317,7 @@ impl Bm25Index {
                         .read()
                         .expect("Bm25Index norm_cache lock poisoned");
                     let factors = &cache.factors;
+                    debug_assert_eq!(factors.len(), num_docs);
 
                     for (weighted_idf, entries) in query_weights {
                         if weighted_idf <= 0.0 {
@@ -323,26 +325,18 @@ impl Bm25Index {
                         }
 
                         for &(doc_idx, tf) in entries {
-                            // SAFETY: doc_idx is guaranteed to be within bounds because:
-                            // 1. It is derived from the postings index which is strictly synchronized with
-                            //    the documents vector in add_document/remove_document_at.
-                            // 2. doc_scores is ensured to be >= num_docs at search start.
-                            // 3. Normalization buffers are synchronized in ensure_norm_cache() before access.
-                            // Mathematical Impact: O(Q * D_q) search complexity.
+                            // SAFETY: doc_idx from postings; buffers sized to num_docs.
                             unsafe {
                                 let score_ptr = doc_scores.get_unchecked_mut(doc_idx);
                                 if *score_ptr == 0.0 {
                                     touched_indices.push(doc_idx);
                                 }
-
                                 let (doc_term_b, tf1_recip) = *factors.get_unchecked(doc_idx);
                                 if tf == 1 {
-                                    // Fast path for the most common case: single term frequency.
                                     *score_ptr += weighted_idf * tf1_recip;
                                 } else {
                                     let tf = tf as f32;
-                                    let denominator = tf + doc_term_b;
-                                    *score_ptr += (tf * weighted_idf) / denominator;
+                                    *score_ptr += (tf * weighted_idf) / (tf + doc_term_b);
                                 }
                             }
                         }
@@ -429,8 +423,15 @@ impl Bm25Index {
     #[allow(clippy::significant_drop_tightening)]
     #[allow(clippy::expect_used)]
     fn ensure_norm_cache(&self) {
+        let n_docs = self.documents.len();
         if !self.norm_cache_dirty.load(AtomicOrdering::Acquire) {
-            return;
+            let cache = self
+                .norm_cache
+                .read()
+                .expect("Bm25Index norm_cache lock poisoned");
+            if cache.factors.len() == n_docs {
+                return;
+            }
         }
 
         if self.is_empty() {
@@ -438,13 +439,12 @@ impl Bm25Index {
             return;
         }
 
-        // Double-checked locking to prevent redundant work
         let mut cache = self
             .norm_cache
             .write()
             .expect("Bm25Index norm_cache lock poisoned");
 
-        if !self.norm_cache_dirty.load(AtomicOrdering::Acquire) {
+        if !self.norm_cache_dirty.load(AtomicOrdering::Acquire) && cache.factors.len() == n_docs {
             return;
         }
 

--- a/crates/csm-retrieval/src/bm25/tests.rs
+++ b/crates/csm-retrieval/src/bm25/tests.rs
@@ -265,9 +265,13 @@ fn test_cache_consistency() {
     // Scores should change because avgdl changed
     assert!((score1_initial - score1_after).abs() > 1e-6);
 
-    // Warm-cache search must match cold-after-mutation scores bit-for-bit.
+    // Warm-cache parity (use miri -Zmiri-deterministic-floats in CI).
     let results3 = index.search(&["hello"], 10);
-    assert_eq!(results2, results3);
+    assert_eq!(results2.len(), results3.len());
+    for ((id_a, s_a), (id_b, s_b)) in results2.iter().zip(results3.iter()) {
+        assert_eq!(id_a, id_b);
+        assert!((s_a - s_b).abs() < 1e-6, "{id_a}: {s_a} vs {s_b}");
+    }
 }
 
 #[test]

--- a/crates/csm-retrieval/src/bm25/tests.rs
+++ b/crates/csm-retrieval/src/bm25/tests.rs
@@ -265,10 +265,9 @@ fn test_cache_consistency() {
     // Scores should change because avgdl changed
     assert!((score1_initial - score1_after).abs() > 1e-6);
 
-    // Identity check for cached search
+    // Warm-cache search must match cold-after-mutation scores bit-for-bit.
     let results3 = index.search(&["hello"], 10);
-    let score1_cached = results3.iter().find(|(id, _)| id == "doc1").unwrap().1;
-    assert!((score1_after - score1_cached).abs() < 1e-6);
+    assert_eq!(results2, results3);
 }
 
 #[test]

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -442,6 +442,16 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 
 - pub use csm_memory::index::*
 
+### src/index_envelope.rs
+
+- pub const INDEX_ENVELOPE_MAGIC
+- pub const INDEX_ENVELOPE_VERSION
+- pub const VECTOR_FORMAT_HVEC10240
+- pub struct IndexSnapshotEnvelope
+- impl IndexSnapshotEnvelope
+- pub fn fnv1a64
+- pub fn backend_fingerprint
+
 ### src/lib.rs
 
 - pub use bridge_retrieval::BridgeRetrieval
@@ -474,6 +484,7 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub mod semantic_triples
 - pub use metadata_filter::MetadataFilter
 - pub mod index
+- pub mod index_envelope
 - pub mod persistence
 - pub mod persistence_wasm
 - pub use csm_core::reservoir
@@ -3122,6 +3133,75 @@ pub use csm_memory::graph_traversal::*;
 pub use csm_memory::index::*;
 ```
 
+## src/index_envelope.rs
+
+### INDEX_ENVELOPE_MAGIC
+
+```rust
+pub const INDEX_ENVELOPE_MAGIC: &[u8; N]
+```
+
+Magic prefix for envelope-wrapped index blobs (`CSMIDX01`).
+
+### INDEX_ENVELOPE_VERSION
+
+```rust
+pub const INDEX_ENVELOPE_VERSION: u32
+```
+
+Envelope schema version (not DB schema version).
+
+### IndexSnapshotEnvelope
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IndexSnapshotEnvelope {
+    pub envelope_version: u32,
+    pub namespace_revision: u64,
+    pub backend_fingerprint: String,
+    pub vector_format: String,
+    pub index_data: Vec<u8>,
+    pub checksum: u64,
+}
+```
+
+Revisioned ANN snapshot envelope (ADR-0093).
+
+### VECTOR_FORMAT_HVEC10240
+
+```rust
+pub const VECTOR_FORMAT_HVEC10240: &str
+```
+
+Canonical vector format identifier for 10240-bit HDC vectors.
+
+### backend_fingerprint
+
+```rust
+pub fn backend_fingerprint(backend: &crate::index::IndexBackend) -> String
+```
+
+Fingerprint an [`crate::index::IndexBackend`] for envelope matching.
+
+### fnv1a64
+
+```rust
+pub fn fnv1a64(data: &[u8]) -> u64
+```
+
+FNV-1a 64-bit hash for envelope checksums.
+
+### impl IndexSnapshotEnvelope
+
+```rust
+impl IndexSnapshotEnvelope {
+    pub fn new(namespace_revision: u64, backend_fingerprint: impl Trait, index_data: Vec<u8>) -> Self;
+    pub fn validate_integrity(&self) -> Result<()>;
+    pub fn encode(&self) -> Result<Vec<u8>>;
+    pub fn try_decode(bytes: &[u8]) -> Result<Option<Self>>;
+}
+```
+
 ## src/lib.rs
 
 ### Persistence
@@ -3299,6 +3379,11 @@ impl Persistence {
     pub fn save_association(&self, _ns: &str, _from: &str, _to: &str, _strength: f32) -> Result<()>;
     pub fn save_associations(&self, _ns: &str, _associations: &[(String, String, f32)]) -> Result<()>;
     pub fn load_associations(&self, _ns: &str, _id: &str) -> Result<Vec<(String, f32, u64)>>;
+    pub fn load_all_associations(&self, _ns: &str) -> Result<Vec<(String, String, f32, u64)>>;
+    pub fn get_namespace_revision(&self, _ns: &str) -> Result<u64>;
+    pub fn bump_namespace_revision(&self, _ns: &str) -> Result<u64>;
+    pub fn save_index_envelope(&self, _ns: &str, _id: &str, _envelope: &crate::index_envelope::IndexSnapshotEnvelope) -> Result<()>;
+    pub fn load_index_envelope(&self, _ns: &str, _id: &str) -> Result<Option<crate::index_envelope::IndexSnapshotEnvelope>>;
     pub fn delete_association(&self, _ns: &str, _from: &str, _to: &str) -> Result<()>;
     pub fn clear_concept_associations(&self, _ns: &str, _id: &str) -> Result<()>;
     pub fn clear_all(&self) -> Result<()>;
@@ -3908,7 +3993,12 @@ impl Persistence {
 ```rust
 impl Persistence {
     pub fn save_index(&self, ns: &str, id: &str, data: &[u8]) -> Result<()>;
+    pub fn save_index_envelope(&self, ns: &str, id: &str, envelope: &IndexSnapshotEnvelope) -> Result<()>;
     pub fn load_index(&self, ns: &str, id: &str) -> Result<Option<Vec<u8>>>;
+    pub fn load_index_envelope(&self, ns: &str, id: &str) -> Result<Option<IndexSnapshotEnvelope>>;
+    pub fn get_namespace_revision(&self, ns: &str) -> Result<u64>;
+    pub fn bump_namespace_revision(&self, ns: &str) -> Result<u64>;
+    pub fn load_all_associations(&self, ns: &str) -> Result<Vec<(String, String, f32, u64)>>;
 }
 ```
 
@@ -3986,6 +4076,10 @@ impl Persistence {
     pub fn save_associations(&self, _ns: &str, _associations: &[(String, String, f32)]) -> Result<()>;
     pub fn load_associations(&self, _ns: &str, _id: &str) -> Result<Vec<(String, f32, u64)>>;
     pub fn load_all_associations(&self, _ns: &str) -> Result<Vec<(String, String, f32, u64)>>;
+    pub fn get_namespace_revision(&self, _ns: &str) -> Result<u64>;
+    pub fn bump_namespace_revision(&self, _ns: &str) -> Result<u64>;
+    pub fn save_index_envelope(&self, _ns: &str, _id: &str, _envelope: &crate::index_envelope::IndexSnapshotEnvelope) -> Result<()>;
+    pub fn load_index_envelope(&self, _ns: &str, _id: &str) -> Result<Option<crate::index_envelope::IndexSnapshotEnvelope>>;
     pub fn clear_namespace(&self, _ns: &str) -> Result<()>;
     pub fn clear_all(&self) -> Result<()>;
     pub fn get_version_scoped(&self, _ns: &str, _id: &str, _version: u64) -> Result<Option<Concept>>;

--- a/llms.txt
+++ b/llms.txt
@@ -442,6 +442,16 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 
 - pub use csm_memory::index::*
 
+### src/index_envelope.rs
+
+- pub const INDEX_ENVELOPE_MAGIC
+- pub const INDEX_ENVELOPE_VERSION
+- pub const VECTOR_FORMAT_HVEC10240
+- pub struct IndexSnapshotEnvelope
+- impl IndexSnapshotEnvelope
+- pub fn fnv1a64
+- pub fn backend_fingerprint
+
 ### src/lib.rs
 
 - pub use bridge_retrieval::BridgeRetrieval
@@ -474,6 +484,7 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub mod semantic_triples
 - pub use metadata_filter::MetadataFilter
 - pub mod index
+- pub mod index_envelope
 - pub mod persistence
 - pub mod persistence_wasm
 - pub use csm_core::reservoir

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1638 @@
+{
+  "name": "chaotic-semantic-memory-ci",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "chaotic-semantic-memory-ci",
+      "devDependencies": {
+        "@commitlint/cli": "^19.8.1",
+        "@commitlint/config-conventional": "^19.8.1"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@commitlint/cli": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.8.1.tgz",
+      "integrity": "sha512-LXUdNIkspyxrlV6VDHWBmCZRtkEVRpBKxi2Gtw3J54cGWhLCTouVD/Q6ZSaSvd2YaDObWK8mDjrz3TIKtaQMAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/format": "^19.8.1",
+        "@commitlint/lint": "^19.8.1",
+        "@commitlint/load": "^19.8.1",
+        "@commitlint/read": "^19.8.1",
+        "@commitlint/types": "^19.8.1",
+        "tinyexec": "^1.0.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "commitlint": "cli.js"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/config-conventional": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.8.1.tgz",
+      "integrity": "sha512-/AZHJL6F6B/G959CsMAzrPKKZjeEiAVifRyEwXxcT6qtqbPwGw+iQxmNS+Bu+i09OCtdNRW6pNpBvgPrtMr9EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^19.8.1",
+        "conventional-changelog-conventionalcommits": "^7.0.2"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/config-validator": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.8.1.tgz",
+      "integrity": "sha512-0jvJ4u+eqGPBIzzSdqKNX1rvdbSU1lPNYlfQQRIFnBgLy26BtC0cFnr7c/AyuzExMxWsMOte6MkTi9I3SQ3iGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^19.8.1",
+        "ajv": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/ensure": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.8.1.tgz",
+      "integrity": "sha512-mXDnlJdvDzSObafjYrOSvZBwkD01cqB4gbnnFuVyNpGUM5ijwU/r/6uqUmBXAAOKRfyEjpkGVZxaDsCVnHAgyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^19.8.1",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.snakecase": "^4.1.1",
+        "lodash.startcase": "^4.4.0",
+        "lodash.upperfirst": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/execute-rule": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.8.1.tgz",
+      "integrity": "sha512-YfJyIqIKWI64Mgvn/sE7FXvVMQER/Cd+s3hZke6cI1xgNT/f6ZAz5heND0QtffH+KbcqAwXDEE1/5niYayYaQA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/format": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-19.8.1.tgz",
+      "integrity": "sha512-kSJj34Rp10ItP+Eh9oCItiuN/HwGQMXBnIRk69jdOwEW9llW9FlyqcWYbHPSGofmjsqeoxa38UaEA5tsbm2JWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^19.8.1",
+        "chalk": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/is-ignored": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.8.1.tgz",
+      "integrity": "sha512-AceOhEhekBUQ5dzrVhDDsbMaY5LqtN8s1mqSnT2Kz1ERvVZkNihrs3Sfk1Je/rxRNbXYFzKZSHaPsEJJDJV8dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^19.8.1",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/lint": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.8.1.tgz",
+      "integrity": "sha512-52PFbsl+1EvMuokZXLRlOsdcLHf10isTPlWwoY1FQIidTsTvjKXVXYb7AvtpWkDzRO2ZsqIgPK7bI98x8LRUEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/is-ignored": "^19.8.1",
+        "@commitlint/parse": "^19.8.1",
+        "@commitlint/rules": "^19.8.1",
+        "@commitlint/types": "^19.8.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/load": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.8.1.tgz",
+      "integrity": "sha512-9V99EKG3u7z+FEoe4ikgq7YGRCSukAcvmKQuTtUyiYPnOd9a2/H9Ak1J9nJA1HChRQp9OA/sIKPugGS+FK/k1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^19.8.1",
+        "@commitlint/execute-rule": "^19.8.1",
+        "@commitlint/resolve-extends": "^19.8.1",
+        "@commitlint/types": "^19.8.1",
+        "chalk": "^5.3.0",
+        "cosmiconfig": "^9.0.0",
+        "cosmiconfig-typescript-loader": "^6.1.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "lodash.uniq": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/message": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-19.8.1.tgz",
+      "integrity": "sha512-+PMLQvjRXiU+Ae0Wc+p99EoGEutzSXFVwQfa3jRNUZLNW5odZAyseb92OSBTKCu+9gGZiJASt76Cj3dLTtcTdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/parse": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-19.8.1.tgz",
+      "integrity": "sha512-mmAHYcMBmAgJDKWdkjIGq50X4yB0pSGpxyOODwYmoexxxiUCy5JJT99t1+PEMK7KtsCtzuWYIAXYAiKR+k+/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^19.8.1",
+        "conventional-changelog-angular": "^7.0.0",
+        "conventional-commits-parser": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/read": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-19.8.1.tgz",
+      "integrity": "sha512-03Jbjb1MqluaVXKHKRuGhcKWtSgh3Jizqy2lJCRbRrnWpcM06MYm8th59Xcns8EqBYvo0Xqb+2DoZFlga97uXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/top-level": "^19.8.1",
+        "@commitlint/types": "^19.8.1",
+        "git-raw-commits": "^4.0.0",
+        "minimist": "^1.2.8",
+        "tinyexec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/resolve-extends": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.8.1.tgz",
+      "integrity": "sha512-GM0mAhFk49I+T/5UCYns5ayGStkTt4XFFrjjf0L4S26xoMTSkdCf9ZRO8en1kuopC4isDFuEm7ZOm/WRVeElVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^19.8.1",
+        "@commitlint/types": "^19.8.1",
+        "global-directory": "^4.0.1",
+        "import-meta-resolve": "^4.0.0",
+        "lodash.mergewith": "^4.6.2",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/rules": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-19.8.1.tgz",
+      "integrity": "sha512-Hnlhd9DyvGiGwjfjfToMi1dsnw1EXKGJNLTcsuGORHz6SS9swRgkBsou33MQ2n51/boIDrbsg4tIBbRpEWK2kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/ensure": "^19.8.1",
+        "@commitlint/message": "^19.8.1",
+        "@commitlint/to-lines": "^19.8.1",
+        "@commitlint/types": "^19.8.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/to-lines": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.8.1.tgz",
+      "integrity": "sha512-98Mm5inzbWTKuZQr2aW4SReY6WUukdWXuZhrqf1QdKPZBCCsXuG87c+iP0bwtD6DBnmVVQjgp4whoHRVixyPBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/top-level": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.8.1.tgz",
+      "integrity": "sha512-Ph8IN1IOHPSDhURCSXBz44+CIu+60duFwRsg6HqaISFHQHbmBtxVw4ZrFNIYUzEP7WwrNPxa2/5qJ//NK1FGcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/types": {
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.8.1.tgz",
+      "integrity": "sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/conventional-commits-parser": "^5.0.0",
+        "chalk": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@types/conventional-commits-parser": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.2.tgz",
+      "integrity": "sha512-BgT2szDXnVypgpNxOK8aL5SGjUdaQbC++WZNjF1Qge3Og2+zhHj+RWhmehLhYyvQwqAmvezruVfOf8+3m74W+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-ify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/compare-func": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^5.1.0"
+      }
+    },
+    "node_modules/conventional-changelog-angular": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
+      "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/conventional-commits-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz",
+      "integrity": "sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-text-path": "^2.0.0",
+        "JSONStream": "^1.3.5",
+        "meow": "^12.0.1",
+        "split2": "^4.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "cli.mjs"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cosmiconfig-typescript-loader": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.3.0.tgz",
+      "integrity": "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jiti": "2.6.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "cosmiconfig": ">=9",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/dargs": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz",
+      "integrity": "sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/find-up": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-7.0.0.tgz",
+      "integrity": "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^7.2.0",
+        "path-exists": "^5.0.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/git-raw-commits": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-4.0.0.tgz",
+      "integrity": "sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==",
+      "deprecated": "Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dargs": "^8.0.0",
+        "meow": "^12.0.1",
+        "split2": "^4.0.0"
+      },
+      "bin": {
+        "git-raw-commits": "cli.mjs"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-text-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
+      "integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "text-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      },
+      "bin": {
+        "JSONStream": "bin.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.upperfirst": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
+      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/meow": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+      "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-extensions": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.4.0.tgz",
+      "integrity": "sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "chaotic-semantic-memory-ci",
+  "private": true,
+  "description": "CI-only tooling (commitlint). Not published.",
+  "devDependencies": {
+    "@commitlint/cli": "^19.8.1",
+    "@commitlint/config-conventional": "^19.8.1"
+  }
+}

--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -4487,14 +4487,14 @@ actions:
       persistence_failure_leaves_memory_unchanged: true
       load_merge_index_preserves_union: true
     cost: 8
-    status: queued
-    file: src/framework.rs, src/framework_persistence.rs, src/persistence_index.rs, src/persistence_migrations.rs
+    status: complete
+    file: src/framework.rs, src/framework_persistence.rs, src/persistence_index.rs, src/persistence_migrations.rs, src/index_envelope.rs, tests/ann_revision_envelope.rs
     adr: ADR-0093
     description: |
-      Make persisted rows authoritative, add namespace revision and index envelope
-      fingerprints, reject stale/corrupt/incompatible snapshots, and recover memory
-      from durable rows after a post-commit in-memory failure. Test stale snapshots
-      after insert/update/delete, backend mismatch, corruption, and merge union.
+      2026-07-16: Schema v11 csm_namespace_meta; IndexSnapshotEnvelope (magic+
+      revision+backend fingerprint+checksum); durable inject/delete before
+      memory; load rejects stale/legacy/mismatched snapshots; load_merge rebuilds
+      union. Tests in tests/ann_revision_envelope.rs.
 
   - name: repair_fuzz_workspace_and_gate
     preconditions:
@@ -4581,13 +4581,13 @@ actions:
       association_load_queries_constant: true
       no_framework_state_lock_across_io_await: true
     cost: 5
-    status: queued
-    file: src/framework_persistence.rs, src/persistence_ops.rs, crates/csm-persistence/src/
+    status: complete
+    file: src/framework_persistence.rs, src/persistence_index.rs
     adr: ADR-0093
     description: |
-      Add namespace-scoped bulk association loading and copy state/index bytes
-      before I/O. Acceptance: one association SELECT for 1/1k/10k concepts and
-      bounded concurrent inject/probe/persist/load completes without starvation.
+      2026-07-16: load_all_associations single namespace SELECT; load_replace/
+      load_merge/persist perform I/O without holding singularity locks; index
+      bytes copied under short lock then envelope written after release.
 
   - name: enforce_workspace_feature_contracts
     preconditions:
@@ -4624,12 +4624,12 @@ actions:
     effects:
       mcp_full_width_vector_wire_contract: true
     cost: 3
-    status: queued
+    status: complete
     file: src/mcp/schema.rs, src/mcp/tools.rs, tests/mcp_integration.rs
     adr: ADR-0094
     description: |
-      Replace unsafe JSON integer words with canonical base64 bytes (preferred) or
-      explicit halves. Test words with high bits set and schema/parser round trips.
+      2026-07-16: schema vector is base64 of 1280-byte HVec; parse_hvec accepts
+      base64 primary + legacy 160 u64 halves; high-bit round-trip tests (<<80).
 
   - name: align_wasm_ci_release_artifact
     preconditions:
@@ -4683,13 +4683,13 @@ actions:
       cargo_deny_required_in_ci: true
       benchmark_workspace_tests_run_in_ci: true
     cost: 5
-    status: queued
-    file: .github/workflows/ci.yml, .github/workflows/benchmark-ci.yml, scripts/quality-gates.sh
+    status: complete
+    file: .github/workflows/ci.yml, .github/workflows/benchmark-ci.yml
     adr: ADR-0095
     description: |
-      Derive package coverage from cargo metadata, add omitted csm-chaos and
-      benchmark tests, run cargo deny for the release SHA, and make crates/**
-      trigger relevant quality/performance workflows.
+      2026-07-16: csm-chaos in test-workspace-crates; cargo-deny job;
+      benchmarks/ unit tests in ci.yml + benchmark-ci.yml. WASM node smoke
+      still skipped (web target vs test.js nodejs package mismatch).
 
   # P2 — evidence and missing behavior
   - name: correct_benchmark_metric_definitions
@@ -4698,13 +4698,13 @@ actions:
     effects:
       benchmark_metrics_mathematically_correct: true
     cost: 3
-    status: queued
-    file: benchmarks/src/scorer.rs, benchmarks/src/metrics.rs, benchmarks/src/types.rs
+    status: complete
+    file: benchmarks/src/scorer.rs, benchmarks/src/metrics.rs, benchmarks/src/types.rs, benchmarks/src/runner.rs
     adr: ADR-0095
     description: |
-      Separate hit rate from recall, use log2 DCG discount, and use
-      should_abstain as ground truth. Add hand-calculated multi/duplicate/empty
-      gold and label-disagreement tests.
+      2026-07-16: hit_at_k vs recall_at_k multi-label; NDCG uses log2(rank+1);
+      abstention precision/recall uses should_abstain; hand-calculated tests
+      (31 benchmark crate tests).
 
   - name: establish_tiered_benchmark_evidence
     preconditions:

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -8,7 +8,7 @@ world_state:
   binary_built: true
   sample_app_created: true
   documentation_complete: true
-  validated: false                    # 2026-07-14: fuzz workspace broken + GOAP boolean corrections; re-validation pending Wave 32 P0
+  validated: false                    # Wave 32 still in progress (feature contracts, ownership, evidence tiers remain)
   dependency_hygiene_complete: true
   adr_registry_current: true
   result_contract_clarified: true
@@ -33,7 +33,7 @@ world_state:
   orchestrator_last_run_at_utc: 2026-04-30T18:30:00Z
   goap_orchestrator_analysis_complete: true         # 2026-04-30: All actionable items verified complete
   skills_all_defined: true                          # 2026-07-14: 32 skill manifests exist; validation hardening queued
-  no_missing_implementations: false                 # 2026-07-14: BM25 absence short-circuit TODO + verified contract gaps queued
+  no_missing_implementations: false                 # BM25 absence TODO + ownership/feature contracts still queued
   book_chapters_complete: true                      # 2026-04-30: 15 book chapters verified (semantic-bridge, inertial-reservoir, ttl exist)
   changelog_links_complete: true                    # 2026-04-30: All version links verified
   hybrid_retrieval_example_compiles: true           # 2026-04-30: cargo check --example hybrid_retrieval OK
@@ -1480,7 +1480,7 @@ world_state:
   template_reference: "https://github.com/d-oit/rust-2026-template"
   template_version_analyzed: "0.3.2 (392 commits)"
 
-  action_last_completed: wave32_p0_review_followups_ci_skill_gates_2026_07_16
+  action_last_completed: wave32_p1_persistence_contracts_ci_2026_07_16
 
   # ═══════════════════════════════════════════════════════
   # PR #444 Review: BM25 Sparse Collection (2026-06-27)
@@ -1701,18 +1701,22 @@ world_state:
   adr_0095_accepted: true
   adr_0096_accepted: true
   harness_md_created: true
-  ann_snapshot_revision_validated: false
+  ann_snapshot_revision_validated: true          # 2026-07-16: IndexSnapshotEnvelope + ns revision
   ann_config_is_fallible: true                   # 2026-07-16: validate_index_backend + fallible ensure_namespace
-  persistence_failure_leaves_memory_unchanged: false
-  no_framework_state_lock_across_io_await: false
+  persistence_failure_leaves_memory_unchanged: true  # durable commit before memory mutate
+  load_merge_index_preserves_union: true
+  association_load_queries_constant: true        # load_all_associations single SELECT
+  no_framework_state_lock_across_io_await: true  # I/O before state apply; snapshot copy then await
   workspace_implementation_owners_unique: false
   no_default_features_is_lean: false
   persistence_disabled_false_success_removed: false
-  mcp_full_width_vector_wire_contract: false
+  mcp_full_width_vector_wire_contract: true      # 2026-07-16: base64 HVec wire + high-bit tests
   wasm_ci_release_artifact_identical: false
-  benchmark_metrics_mathematically_correct: false
+  benchmark_metrics_mathematically_correct: true # hit vs recall; log2 NDCG; should_abstain
   performance_claims_have_current_artifacts: false
-  cargo_deny_required_in_ci: false
+  cargo_deny_required_in_ci: true                # 2026-07-16: cargo-deny job in ci.yml
+  workspace_ci_matrix_complete: true             # csm-chaos + benchmark unit tests in CI
+  benchmark_workspace_tests_run_in_ci: true
   fuzz_build_required_in_ci: true                # 2026-07-16: ci.yml fuzz-build job (add to branch protection)
   skill_validation_fail_closed: true             # 2026-07-16: wired into validate.sh + CI lint + pre-commit
   release_skill_loc_compliant: true              # 2026-07-16: SKILL.md 161 lines + references/
@@ -1737,9 +1741,16 @@ world_state:
       - align_release_skill_with_protected_workflow
       - wire_skill_format_into_ci_and_validate
       - accept_adr_0093_0096_on_disk
-    deferred_to_followup:
+  wave32_p1_swarm_2026_07_16:
+    branch: feat/wave32-p1-persistence-contracts-ci
+    completed_actions:
       - enforce_authoritative_persistence_and_ann_revision
       - bulk_load_associations_and_release_state_locks
+      - fix_mcp_hypervector_wire_format
+      - correct_benchmark_metric_definitions
+      - complete_workspace_ci_and_supply_chain_matrix
+    deferred_to_followup:
       - run_critical_skill_behavioral_evals
       - fuzz_short_and_scheduled_runs
-      - Phase 2/3 ownership and evidence actions
+      - enforce_workspace_feature_contracts
+      - ownership consolidation and evidence tiers

--- a/scripts/mutation_test.sh
+++ b/scripts/mutation_test.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+# Mutation testing wrapper (cargo-mutants).
+#
+# Profiles:
+#   fast (default, CI): --in-diff vs base, unit tests only (--lib), tight timeouts
+#   full: entire tree, full cargo test suite (local/nightly use)
+#
+# Performance notes (2026-07-16, PR #516 analysis of job 87601199764):
+#   - Full `cargo test` ≈ 12s unit + ~97s integration per mutant.
+#   - 120 in-diff mutants × ~2 min / 4 jobs ≈ 60+ min wall time.
+#   - Fast CI uses `-- --lib` so each mutant is ~10–15s of tests after build.
 set -euo pipefail
 
 CI_MODE=false
@@ -31,7 +41,7 @@ set -- "${POSITIONAL[@]}"
 PROFILE="${1:-fast}"
 shift || true
 
-# Parallelism: default 4 on CI (runner has 4 vCPUs), 1 locally
+# Parallelism: CI sets MUTANTS_JOBS=4 (ubuntu-latest ≈ 4 vCPU); local default 1.
 JOBS="${MUTANTS_JOBS:-1}"
 
 if ! command -v cargo-mutants &>/dev/null && ! cargo mutants --version &>/dev/null; then
@@ -55,65 +65,120 @@ mkdir -p "${OUT_DIR}"
 
 HELP_TEXT="$(cargo mutants --help 2>/dev/null || true)"
 FAST_ARGS=()
+TEST_ARGS=()
+
 if [[ "${PROFILE}" == "fast" ]]; then
   if grep -q -- '--in-diff' <<<"${HELP_TEXT}"; then
     DIFF_TARGET="${DIFF_TARGET:-origin/main}"
     DIFF_FILE="$(mktemp)"
     trap 'rm -f "${DIFF_FILE}"' EXIT
-    git diff "${DIFF_TARGET}" > "${DIFF_FILE}" 2>/dev/null || true
+    # Three-dot: only commits on this branch since merge-base (true PR delta).
+    if git rev-parse --verify "${DIFF_TARGET}" >/dev/null 2>&1; then
+      git diff "${DIFF_TARGET}...HEAD" >"${DIFF_FILE}" 2>/dev/null \
+        || git diff "${DIFF_TARGET}" >"${DIFF_FILE}" 2>/dev/null \
+        || true
+    else
+      git diff "${DIFF_TARGET}" >"${DIFF_FILE}" 2>/dev/null || true
+    fi
     if [[ -s "${DIFF_FILE}" ]]; then
       FAST_ARGS+=(--in-diff "${DIFF_FILE}")
+      echo "mutation fast: in-diff against ${DIFF_TARGET} ($(wc -l <"${DIFF_FILE}") diff lines)" >&2
     else
       echo "warning: no diff against ${DIFF_TARGET}; running full target set" >&2
     fi
   else
     echo "warning: --in-diff is unsupported by installed cargo-mutants; running full target set" >&2
   fi
-  # CI mode: reuse target/ cache (safe in disposable checkout) + deterministic order
+
+  # Unit tests only: integration suite dominates wall time (~8× unit suite).
+  TEST_ARGS+=(--lib)
+
   if [[ "${CI_MODE}" == "true" ]]; then
     # --in-place is incompatible with parallel jobs (-j)
-    if [[ "$JOBS" -eq 1 ]]; then
+    if [[ "${JOBS}" -eq 1 ]]; then
       FAST_ARGS+=(--in-place)
     fi
     FAST_ARGS+=(--no-shuffle)
+    # Tight bounds: kill hung mutants; auto timeout still applies via multiplier.
+    FAST_ARGS+=(--timeout 60)
+    FAST_ARGS+=(--minimum-test-timeout 10)
+    FAST_ARGS+=(--build-timeout 120)
+  else
+    FAST_ARGS+=(--timeout 90)
+    FAST_ARGS+=(--minimum-test-timeout 15)
+    FAST_ARGS+=(--build-timeout 180)
   fi
 elif [[ "${PROFILE}" != "full" ]]; then
   echo "usage: scripts/mutation_test.sh [--ci] [--threshold=N] [fast|full] [extra cargo-mutants args...]" >&2
   exit 2
+else
+  # full profile: broader timeouts, full suite (no --lib)
+  FAST_ARGS+=(--timeout 120)
+  FAST_ARGS+=(--minimum-test-timeout 30)
+  FAST_ARGS+=(--build-timeout 180)
+fi
+
+MUTANTS_ARGS=("${FAST_ARGS[@]}")
+if [[ "${JOBS}" -gt 1 ]]; then
+  MUTANTS_ARGS+=(-j "${JOBS}")
+fi
+
+# Shared excludes: I/O, WASM stubs, MCP wire, uninteresting Drop/guards.
+EXCLUDE_ARGS=(
+  --exclude-re "WasmFramework::"
+  --exclude-re "persistence::"
+  --exclude-re "HnswIndex::serialize"
+  --exclude-re "HnswIndex::deserialize"
+  --exclude-re "OtlpGuard::"
+  --exclude-re "install_grpc_tracer"
+  --exclude-re "impl Drop for Guard"
+  --exclude-re "impl Drop for OtlpGuard"
+  --exclude-re "Result<Option<Guard>>"
+  --exclude-re "replace && with"
+  --exclude-re "delete . in init"
+  --exclude-re "replace > with >= in FrameworkBuilder::with_max_associations_per_concept"
+  --exclude-re "replace > with .* in FrameworkBuilder::build"
+  --exclude-re "ChaoticSemanticFramework::load "
+  --exclude-re "mcp::"
+  --exclude-re "McpHandler::"
+  --exclude "src/mcp/*"
+  --exclude "src/persistence_wasm.rs"
+  --exclude-re "replace > with >= in <impl Reranker for MmrReranker>::rerank"
+)
+
+# Preflight count (omit -j; listing does not need parallel workers).
+if [[ "${PROFILE}" == "fast" ]] && [[ ${#FAST_ARGS[@]} -gt 0 ]]; then
+  LIST_OUT="$(cargo mutants --list "${FAST_ARGS[@]}" "${EXCLUDE_ARGS[@]}" 2>/dev/null || true)"
+  MUTANT_COUNT="$(printf '%s\n' "${LIST_OUT}" | grep -cE '\.rs:' || true)"
+  echo "mutation preflight: ${MUTANT_COUNT:-0} mutants to test (jobs=${JOBS})" >&2
+  if [[ "${MUTANT_COUNT:-0}" -eq 0 ]]; then
+    echo "No mutants generated for changed files; writing empty report" | tee "${LOG_FILE}"
+    {
+      echo "# Mutation Test Report"
+      echo
+      echo "- Timestamp (UTC): ${TIMESTAMP}"
+      echo "- Profile: ${PROFILE}"
+      echo "- Mutants: 0"
+      echo "- Result: skip (no mutants in diff)"
+    } >"${REPORT_FILE}"
+    if [[ "${CI_MODE}" == "true" ]]; then
+      echo "mutation score: no mutants in changed Rust sources, CI check skipped"
+      exit 0
+    fi
+    exit 0
+  fi
 fi
 
 set -o pipefail
-set +e  # cargo-mutants exits 2 when any mutant is missed; we evaluate the score below
-MUTANTS_ARGS=("${FAST_ARGS[@]}")
-if [[ "$JOBS" -gt 1 ]]; then
-  MUTANTS_ARGS+=(-j "$JOBS")
+set +e # cargo-mutants exits 2 when any mutant is missed; we evaluate the score below
+RUN_CMD=(cargo mutants "${MUTANTS_ARGS[@]}" "${EXCLUDE_ARGS[@]}" "$@")
+if [[ ${#TEST_ARGS[@]} -gt 0 ]]; then
+  RUN_CMD+=(-- "${TEST_ARGS[@]}")
 fi
-
-RUSTFLAGS="" cargo mutants "${MUTANTS_ARGS[@]}" \
-  --build-timeout 180 \
-  --minimum-test-timeout 30 \
-  --exclude-re "WasmFramework::" \
-  --exclude-re "persistence::" \
-  --exclude-re "HnswIndex::serialize" \
-  --exclude-re "HnswIndex::deserialize" \
-  --exclude-re "OtlpGuard::" \
-  --exclude-re "install_grpc_tracer" \
-  --exclude-re "impl Drop for Guard" \
-  --exclude-re "impl Drop for OtlpGuard" \
-  --exclude-re "Result<Option<Guard>>" \
-  --exclude-re "replace && with" \
-  --exclude-re "delete . in init" \
-  --exclude-re "replace > with >= in FrameworkBuilder::with_max_associations_per_concept" \
-  --exclude-re "replace > with .* in FrameworkBuilder::build" \
-  --exclude-re "ChaoticSemanticFramework::load " \
-  --exclude-re "mcp::" \
-  --exclude-re "McpHandler::" \
-  --exclude "src/mcp/*" \
-  --exclude-re "replace > with >= in <impl Reranker for MmrReranker>::rerank" \
-  "$@" 2>&1 | tee "${LOG_FILE}"
+RUSTFLAGS="" RUST_BACKTRACE=0 "${RUN_CMD[@]}" 2>&1 | tee "${LOG_FILE}"
 RESULT="${PIPESTATUS[0]}"
 set +o pipefail
-set -e  # re-enable errexit for the rest of the script
+set -e
 
 {
   echo "# Mutation Test Report"
@@ -121,8 +186,10 @@ set -e  # re-enable errexit for the rest of the script
   echo "- Timestamp (UTC): ${TIMESTAMP}"
   echo "- Profile: ${PROFILE}"
   echo "- Exit code: ${RESULT}"
+  echo "- Jobs: ${JOBS}"
+  echo "- Test args: ${TEST_ARGS[*]:-(full suite)}"
   echo "- Log: \`${LOG_FILE}\`"
-  echo "- Command: \`cargo mutants ${FAST_ARGS[*]} $*\`"
+  echo "- Command: \`cargo mutants ${MUTANTS_ARGS[*]} ${EXCLUDE_ARGS[*]} -- ${TEST_ARGS[*]}\`"
   echo
   echo "## Tail"
   echo
@@ -134,9 +201,6 @@ set -e  # re-enable errexit for the rest of the script
 echo "wrote ${REPORT_FILE}"
 
 if [[ "${CI_MODE}" == "true" ]]; then
-  # Parse mutation score. Supports both percentage output and "X mutants tested ... Y caught" summary.
-  # Unviable mutants (won't compile) are excluded from the denominator.
-  # Timeouts are treated as caught (mutant couldn't survive tests).
   SCORE=""
   SUMMARY_LINE="$(grep -oE "[0-9]+ mutant[s]? tested in .*" "${LOG_FILE}" | tail -1 || true)"
   if [[ -n "${SUMMARY_LINE}" ]]; then
@@ -150,13 +214,14 @@ if [[ "${CI_MODE}" == "true" ]]; then
     UNVIABLE="$(echo "${SUMMARY_LINE}" | grep -oE '[0-9]+ unviable' | awk '{print $1}')"
     UNVIABLE="${UNVIABLE:-0}"
     VIABLE=$((TOTAL - UNVIABLE))
-    # Timeouts count as caught (mutant couldn't survive testing)
+    # Timeouts count as caught for gate purposes (mutant did not pass tests in time).
     EFFECTIVE_CAUGHT=$((CAUGHT + TIMEOUTS))
     if [[ "${VIABLE}" -gt 0 ]]; then
       SCORE="$(awk -v c="${EFFECTIVE_CAUGHT}" -v v="${VIABLE}" 'BEGIN { printf "%.4f", c*100/v }')"
     else
       SCORE="100"
     fi
+    echo "mutation summary: total=${TOTAL} caught=${CAUGHT} timeout=${TIMEOUTS} missed=${MISSED} unviable=${UNVIABLE} score=${SCORE}%" >&2
   fi
   if [[ -z "${SCORE}" ]]; then
     SCORE="$(awk '/%/{ gsub(/[^0-9.]/," "); for(i=1;i<=NF;i++) if($i ~ /^[0-9]+\.?[0-9]*$/) s=$i } END { print s+0 }' "${LOG_FILE}")"
@@ -172,8 +237,6 @@ if [[ "${CI_MODE}" == "true" ]]; then
     fi
   elif awk -v s="${SCORE}" -v t="${THRESHOLD}" 'BEGIN { exit !(s >= t) }'; then
     echo "mutation score ${SCORE}% >= ${THRESHOLD}%, CI check passed"
-    # Score meets threshold: succeed even if cargo-mutants returned non-zero
-    # (it exits 2 whenever any mutant is missed, regardless of the threshold).
     exit 0
   else
     echo "mutation score ${SCORE}% < ${THRESHOLD}%, CI check failed" >&2

--- a/scripts/mutation_test.sh
+++ b/scripts/mutation_test.sh
@@ -99,14 +99,15 @@ if [[ "${PROFILE}" == "fast" ]]; then
       FAST_ARGS+=(--in-place)
     fi
     FAST_ARGS+=(--no-shuffle)
-    # Tight bounds: kill hung mutants; auto timeout still applies via multiplier.
+    # Tight bounds: kill hung mutants; keep build-timeout short so pathological
+    # const/eval mutants don't burn the full job budget (was 180s).
     FAST_ARGS+=(--timeout 60)
     FAST_ARGS+=(--minimum-test-timeout 10)
-    FAST_ARGS+=(--build-timeout 120)
+    FAST_ARGS+=(--build-timeout 60)
   else
     FAST_ARGS+=(--timeout 90)
     FAST_ARGS+=(--minimum-test-timeout 15)
-    FAST_ARGS+=(--build-timeout 180)
+    FAST_ARGS+=(--build-timeout 120)
   fi
 elif [[ "${PROFILE}" != "full" ]]; then
   echo "usage: scripts/mutation_test.sh [--ci] [--threshold=N] [fast|full] [extra cargo-mutants args...]" >&2
@@ -214,7 +215,9 @@ if [[ "${CI_MODE}" == "true" ]]; then
     UNVIABLE="$(echo "${SUMMARY_LINE}" | grep -oE '[0-9]+ unviable' | awk '{print $1}')"
     UNVIABLE="${UNVIABLE:-0}"
     VIABLE=$((TOTAL - UNVIABLE))
-    # Timeouts count as caught for gate purposes (mutant did not pass tests in time).
+    # Industry (Stryker et al.): detected = killed + timeout. Infinite-loop mutants
+    # often only surface as timeouts. ADR-0095: also fail on a timeout *budget*
+    # so a hung suite cannot masquerade as higher quality.
     EFFECTIVE_CAUGHT=$((CAUGHT + TIMEOUTS))
     if [[ "${VIABLE}" -gt 0 ]]; then
       SCORE="$(awk -v c="${EFFECTIVE_CAUGHT}" -v v="${VIABLE}" 'BEGIN { printf "%.4f", c*100/v }')"
@@ -225,6 +228,28 @@ if [[ "${CI_MODE}" == "true" ]]; then
   fi
   if [[ -z "${SCORE}" ]]; then
     SCORE="$(awk '/%/{ gsub(/[^0-9.]/," "); for(i=1;i<=NF;i++) if($i ~ /^[0-9]+\.?[0-9]*$/) s=$i } END { print s+0 }' "${LOG_FILE}")"
+  fi
+
+  # Timeout budget (ADR-0095): timeouts still count as "detected" for score, but
+  # a high timeout rate fails the job so hangs cannot look like strong coverage.
+  # Override: MUTATION_TIMEOUT_BUDGET (absolute), MUTATION_TIMEOUT_FRACTION (of viable).
+  TIMEOUT_BUDGET="${MUTATION_TIMEOUT_BUDGET:-5}"
+  TIMEOUT_FRACTION="${MUTATION_TIMEOUT_FRACTION:-0.10}"
+  if [[ -n "${TIMEOUTS:-}" ]]; then
+    if [[ "${TIMEOUTS}" -gt "${TIMEOUT_BUDGET}" ]]; then
+      echo "error: ${TIMEOUTS} mutation timeouts exceed absolute budget ${TIMEOUT_BUDGET}" >&2
+      exit 1
+    fi
+    if [[ -n "${VIABLE:-}" && "${VIABLE}" -ge 10 ]]; then
+      FRAC_LIMIT="$(awk -v v="${VIABLE}" -v f="${TIMEOUT_FRACTION}" 'BEGIN { n=v*f; printf "%d", (n==int(n)?n:int(n)+1) }')"
+      if [[ "${TIMEOUTS}" -gt "${FRAC_LIMIT}" ]]; then
+        echo "error: ${TIMEOUTS} mutation timeouts exceed ${TIMEOUT_FRACTION} of viable=${VIABLE} (limit ${FRAC_LIMIT})" >&2
+        exit 1
+      fi
+    fi
+    if [[ "${TIMEOUTS}" -gt 0 ]]; then
+      echo "mutation timeouts: ${TIMEOUTS} (budget abs=${TIMEOUT_BUDGET})" >&2
+    fi
   fi
 
   if [[ "${SCORE}" == "0" ]]; then

--- a/scripts/wasm_size_gate.sh
+++ b/scripts/wasm_size_gate.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEFAULT_MAX_BYTES=1110000
+# Headroom for ADR-0093 index envelope + durable mutation paths compiled into root.
+DEFAULT_MAX_BYTES=1120000
 MAX_BYTES="${CSM_WASM_SIZE_MAX_BYTES:-${DEFAULT_MAX_BYTES}}"
 REPORT_PATH="plans/handoffs/W5_C_to_D_wasm_size_report.md"
 

--- a/src/framework.rs
+++ b/src/framework.rs
@@ -72,26 +72,19 @@ impl ChaoticSemanticFramework {
         }
         let concept = builder.build()?;
 
-        {
-            let mut sing = self.singularity.write().await;
-            let ns = self.namespace.read().await;
-            sing.inject(&ns, concept.clone())?;
-        }
+        #[cfg(not(target_arch = "wasm32"))]
+        let p_start = std::time::Instant::now();
+        #[cfg(target_arch = "wasm32")]
+        let p_start = Date::now();
 
-        if let Some(ref persistence) = self.persistence {
-            #[cfg(not(target_arch = "wasm32"))]
-            let p_start = std::time::Instant::now();
-            #[cfg(target_arch = "wasm32")]
-            let p_start = Date::now();
+        // ADR-0093: durable commit before in-memory mutation when persistence is enabled.
+        self.durable_inject_concept(concept.clone()).await?;
 
-            let ns = self.namespace().await;
-            persistence.save_concept(&ns, &concept).await?;
-
+        if self.persistence.is_some() {
             #[cfg(not(target_arch = "wasm32"))]
             let elapsed_ms = u64::try_from(p_start.elapsed().as_millis()).unwrap_or(u64::MAX);
             #[cfg(target_arch = "wasm32")]
             let elapsed_ms = (Date::now() - p_start) as u64;
-
             self.metrics.observe_persist_latency_ms(elapsed_ms, "save");
         }
         self.metrics.inc_concepts_injected(1);
@@ -138,26 +131,18 @@ impl ChaoticSemanticFramework {
         }
         let concept = builder.build()?;
 
-        {
-            let mut sing = self.singularity.write().await;
-            let ns = self.namespace.read().await;
-            sing.inject(&ns, concept.clone())?;
-        }
+        #[cfg(not(target_arch = "wasm32"))]
+        let p_start = std::time::Instant::now();
+        #[cfg(target_arch = "wasm32")]
+        let p_start = Date::now();
 
-        if let Some(ref persistence) = self.persistence {
-            #[cfg(not(target_arch = "wasm32"))]
-            let p_start = std::time::Instant::now();
-            #[cfg(target_arch = "wasm32")]
-            let p_start = Date::now();
+        self.durable_inject_concept(concept.clone()).await?;
 
-            let ns = self.namespace().await;
-            persistence.save_concept(&ns, &concept).await?;
-
+        if self.persistence.is_some() {
             #[cfg(not(target_arch = "wasm32"))]
             let elapsed_ms = u64::try_from(p_start.elapsed().as_millis()).unwrap_or(u64::MAX);
             #[cfg(target_arch = "wasm32")]
             let elapsed_ms = (Date::now() - p_start) as u64;
-
             self.metrics.observe_persist_latency_ms(elapsed_ms, "save");
         }
         self.metrics.inc_concepts_injected(1);
@@ -414,16 +399,8 @@ impl ChaoticSemanticFramework {
     #[instrument(err, skip(self))]
     pub async fn delete_concept(&self, id: &str) -> Result<()> {
         Self::validate_concept_id(id)?;
-        {
-            let mut sing = self.singularity.write().await;
-            let ns = self.namespace.read().await;
-            sing.delete(&ns, id)?;
-        }
-
-        if let Some(ref persistence) = self.persistence {
-            let ns = self.namespace().await;
-            persistence.delete_concept(&ns, id).await?;
-        }
+        // ADR-0093: durable delete before in-memory mutation when persistence is enabled.
+        self.durable_delete_concept(id).await?;
 
         self.metrics.inc_delete_concepts(1);
         self.emit_event(MemoryEvent::ConceptDeleted {

--- a/src/framework_ops.rs
+++ b/src/framework_ops.rs
@@ -22,34 +22,22 @@ impl ChaoticSemanticFramework {
             return Ok(());
         }
         let mut to_save = Vec::with_capacity(concepts.len());
-        {
-            let mut sing = self.singularity.write().await;
-            let ns = self.namespace.read().await;
-            for (id, vector) in concepts {
-                Self::validate_concept_id(id)?;
-                let concept = ConceptBuilder::new(id.clone())
-                    .with_vector(*vector)
-                    .build()?;
-                sing.inject(&ns, concept.clone())?;
-                to_save.push(concept);
-            }
-            drop(sing);
+        for (id, vector) in concepts {
+            Self::validate_concept_id(id)?;
+            let concept = ConceptBuilder::new(id.clone())
+                .with_vector(*vector)
+                .build()?;
+            to_save.push(concept);
         }
 
-        if let Some(ref persistence) = self.persistence {
-            #[cfg(not(target_arch = "wasm32"))]
-            let p_start = std::time::Instant::now();
-            #[cfg(target_arch = "wasm32")]
-            let p_start = 0.0; // js_sys::Date not imported here, and p_start not used for WASM
-
-            let ns = self.namespace.read().await;
-            persistence.save_concepts(&ns, &to_save).await?;
-
+        #[cfg(not(target_arch = "wasm32"))]
+        let p_start = std::time::Instant::now();
+        self.durable_inject_concepts(&to_save).await?;
+        if self.persistence.is_some() {
             #[cfg(not(target_arch = "wasm32"))]
             let elapsed_ms = u64::try_from(p_start.elapsed().as_millis()).unwrap_or(u64::MAX);
             #[cfg(target_arch = "wasm32")]
-            let elapsed_ms = 0; // Persistence always None on WASM, but keep for completeness
-
+            let elapsed_ms = 0u64;
             self.metrics.observe_persist_latency_ms(elapsed_ms, "save");
         }
         self.metrics.inc_concepts_injected(to_save.len() as u64);

--- a/src/framework_persistence.rs
+++ b/src/framework_persistence.rs
@@ -1,31 +1,60 @@
 //! Framework persistence operations.
 //!
 //! Extracted from framework.rs to satisfy the 500 LOC gate.
+//! ADR-0093: rows are authoritative; ANN snapshots are revisioned derivatives;
+//! state locks are not held across persistence I/O.
 
 use tracing::warn;
 
 use crate::framework::ChaoticSemanticFramework;
 use crate::framework_events::MemoryEvent;
+use crate::index_envelope::{IndexSnapshotEnvelope, backend_fingerprint};
 use crate::singularity::{Concept, ConceptDiff, ConceptVersion};
 use csm_core::error::{MemoryError, Result};
 
 impl ChaoticSemanticFramework {
-    /// Persist all data to storage
+    /// Persist all data to storage (checkpoint + revisioned ANN snapshot).
     #[tracing::instrument(err, skip(self))]
     pub async fn persist(&self) -> Result<()> {
         if let Some(ref persistence) = self.persistence {
             #[cfg(not(target_arch = "wasm32"))]
             let p_start = std::time::Instant::now();
-            // ADR-0068: Persist ANN index state
-            {
+
+            // Snapshot under short locks; re-check revision after unlock so we never
+            // stamp a current revision onto an incomplete index (TOCTOU, ADR-0093).
+            let ns = self.namespace.read().await.clone();
+            let rev_before = persistence.get_namespace_revision(&ns).await?;
+            let (index_data, fingerprint) = {
                 let sing = self.singularity.read().await;
-                let ns = self.namespace.read().await;
-                if let Some(ns_state) = sing.get_namespace(&ns) {
-                    if let Ok(index_data) = ns_state.index.serialize() {
-                        if !index_data.is_empty() {
-                            persistence.save_index(&ns, "main", &index_data).await?;
+                let fingerprint = backend_fingerprint(&sing.config.index_backend);
+                let index_data = match sing.get_namespace(&ns) {
+                    Some(ns_state) => match ns_state.index.serialize() {
+                        Ok(data) if !data.is_empty() => Some(data),
+                        Ok(_) => None,
+                        Err(e) => {
+                            warn!(error = %e, "ANN index serialize failed; skipping envelope");
+                            None
                         }
-                    }
+                    },
+                    None => None,
+                };
+                drop(sing);
+                (index_data, fingerprint)
+            };
+
+            if let Some(index_data) = index_data {
+                let rev_after = persistence.get_namespace_revision(&ns).await?;
+                if rev_after == rev_before {
+                    let envelope = IndexSnapshotEnvelope::new(rev_after, fingerprint, index_data);
+                    persistence
+                        .save_index_envelope(&ns, "main", &envelope)
+                        .await?;
+                } else {
+                    warn!(
+                        rev_before,
+                        rev_after,
+                        "namespace revision moved during ANN snapshot; skipping envelope write"
+                    );
                 }
             }
 
@@ -54,26 +83,38 @@ impl ChaoticSemanticFramework {
     ///
     /// Clears existing state, loads persisted state. Use for fresh starts.
     /// See also: [`load_merge`](Self::load_merge) for additive semantics.
-    #[allow(clippy::significant_drop_tightening)] // Lock held for concept injection and index rebuild
+    // Lock held for inject + rebuild after all I/O is complete (ADR-0093).
+    #[allow(clippy::significant_drop_tightening)]
     #[tracing::instrument(err, skip(self))]
     pub async fn load_replace(&self) -> Result<()> {
         if let Some(ref persistence) = self.persistence {
             #[cfg(not(target_arch = "wasm32"))]
             let p_start = std::time::Instant::now();
-            let ns = self.namespace.read().await;
-            let concepts = persistence.load_all_concepts(&ns).await?;
 
+            // Namespace string + all durable I/O without holding singularity locks.
+            let ns = self.namespace.read().await.clone();
+            let concepts = persistence.load_all_concepts(&ns).await?;
             for concept in &concepts {
                 self.validate_concept(concept)?;
             }
-
-            let mut all_associations: Vec<(String, String, f32, u64)> = Vec::new();
-            for concept in &concepts {
-                let links = persistence.load_associations(&ns, &concept.id).await?;
-                for (to_id, strength, created_at) in links {
-                    all_associations.push((concept.id.clone(), to_id, strength, created_at));
+            let all_associations = persistence.load_all_associations(&ns).await?;
+            let revision = persistence.get_namespace_revision(&ns).await?;
+            // Corrupt/legacy envelopes degrade to rebuild (rows authoritative).
+            let envelope = match persistence.load_index_envelope(&ns, "main").await {
+                Ok(env) => env,
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        "ANN envelope unreadable; rebuilding index from concept rows"
+                    );
+                    None
                 }
-            }
+            };
+
+            let expected_fingerprint = {
+                let sing = self.singularity.read().await;
+                backend_fingerprint(&sing.config.index_backend)
+            };
 
             {
                 let mut sing = self.singularity.write().await;
@@ -81,32 +122,40 @@ impl ChaoticSemanticFramework {
                 for concept in concepts {
                     sing.inject(&ns, concept)?;
                 }
-
                 for (from_id, to_id, strength, created_at) in all_associations {
                     let ns_state = sing.ensure_namespace(&ns)?;
                     let neighbors = ns_state.associations.entry(from_id).or_default();
                     neighbors.insert(to_id, (strength, created_at));
                 }
-            }
 
-            // ADR-0068: Load ANN index state
-            // Prefer deserialize over rebuild if data is fresh.
-            // Propagate errors instead of silently ignoring (fixes test regression).
-            if let Ok(Some(index_data)) = persistence.load_index(&ns, "main").await {
-                {
-                    let mut sing = self.singularity.write().await;
-                    let ns_state = sing.ensure_namespace(&ns)?;
-                    ns_state.index.deserialize(&index_data)?;
-                }
-            } else {
-                // Fallback: rebuild index from concepts
-                {
-                    let mut sing = self.singularity.write().await;
+                let apply_snapshot = envelope.as_ref().is_some_and(|env| {
+                    env.namespace_revision == revision
+                        && env.backend_fingerprint == expected_fingerprint
+                });
+
+                if apply_snapshot {
+                    if let Some(env) = envelope {
+                        let ns_state = sing.ensure_namespace(&ns)?;
+                        if let Err(e) = ns_state.index.deserialize(&env.index_data) {
+                            warn!(error = %e, "ANN snapshot deserialize failed; rebuilding");
+                            let concepts_map = ns_state.concepts.clone();
+                            ns_state.index.rebuild(&concepts_map)?;
+                        }
+                    }
+                } else {
+                    if envelope.is_some() {
+                        warn!(
+                            revision,
+                            expected = %expected_fingerprint,
+                            "rejecting stale or incompatible ANN snapshot; rebuilding from rows"
+                        );
+                    }
                     let ns_state = sing.ensure_namespace(&ns)?;
                     let concepts_map = ns_state.concepts.clone();
                     ns_state.index.rebuild(&concepts_map)?;
                 }
             }
+
             #[cfg(not(target_arch = "wasm32"))]
             {
                 self.metrics.observe_persist_latency_ms(
@@ -121,17 +170,18 @@ impl ChaoticSemanticFramework {
     /// Load and merge persisted state into in-memory state.
     ///
     /// Preserves existing state, adds persisted state on top.
-    /// See also: [`load_replace`](Self::load_replace) for replacement semantics.
-    #[allow(clippy::significant_drop_tightening)] // Lock held for concept injection and index rebuild
+    /// Never applies a persisted-only ANN snapshot over the merged union (ADR-0093).
+    // Lock held for inject + rebuild after I/O (ADR-0093).
+    #[allow(clippy::significant_drop_tightening)]
     #[tracing::instrument(err, skip(self))]
     pub async fn load_merge(&self) -> Result<()> {
         if let Some(ref persistence) = self.persistence {
-            let ns = self.namespace.read().await;
+            let ns = self.namespace.read().await.clone();
             let concepts = persistence.load_all_concepts(&ns).await?;
-
             for concept in &concepts {
                 self.validate_concept(concept)?;
             }
+            let all_associations = persistence.load_all_associations(&ns).await?;
 
             {
                 let mut sing = self.singularity.write().await;
@@ -145,46 +195,126 @@ impl ChaoticSemanticFramework {
                     }
                     sing.inject(&ns, (*concept).clone())?;
                 }
-            }
-
-            let mut all_associations: Vec<(String, String, f32, u64)> = Vec::new();
-            for concept in &concepts {
-                let links = persistence.load_associations(&ns, &concept.id).await?;
-                for (to_id, strength, created_at) in links {
-                    all_associations.push((concept.id.clone(), to_id, strength, created_at));
-                }
-            }
-
-            {
-                let mut sing = self.singularity.write().await;
                 for (from_id, to_id, strength, created_at) in all_associations {
                     let ns_state = sing.ensure_namespace(&ns)?;
                     let neighbors = ns_state.associations.entry(from_id).or_default();
                     neighbors.insert(to_id, (strength, created_at));
                 }
-            }
-
-            // ADR-0068: Load ANN index state
-            // We just injected new concepts into the index via sing.inject(),
-            // so the index is already updated with merged concepts.
-            // Rebuilding ensures optimal structure if many concepts were merged.
-            // Propagate errors instead of silently ignoring.
-            if let Ok(Some(index_data)) = persistence.load_index(&ns, "main").await {
-                {
-                    let mut sing = self.singularity.write().await;
-                    let ns_state = sing.ensure_namespace(&ns)?;
-                    ns_state.index.deserialize(&index_data)?;
-                }
-            } else {
-                // Fallback: rebuild index from concepts
-                {
-                    let mut sing = self.singularity.write().await;
-                    let ns_state = sing.ensure_namespace(&ns)?;
-                    let concepts_map = ns_state.concepts.clone();
-                    ns_state.index.rebuild(&concepts_map)?;
-                }
+                // Rebuild from final union; never replace with a persisted-only snapshot.
+                let ns_state = sing.ensure_namespace(&ns)?;
+                let concepts_map = ns_state.concepts.clone();
+                ns_state.index.rebuild(&concepts_map)?;
             }
         }
+        Ok(())
+    }
+
+    /// Batch durable inject (ADR-0093): commit all rows, then apply memory.
+    #[allow(clippy::significant_drop_tightening)] // sequential inject under one write lock
+    pub(crate) async fn durable_inject_concepts(&self, concepts: &[Concept]) -> Result<()> {
+        if concepts.is_empty() {
+            return Ok(());
+        }
+        if let Some(ref persistence) = self.persistence {
+            let ns = self.namespace().await;
+            persistence.save_concepts(&ns, concepts).await?;
+            let mut sing = self.singularity.write().await;
+            for concept in concepts {
+                if let Err(e) = sing.inject(&ns, concept.clone()) {
+                    drop(sing);
+                    warn!(
+                        error = %e,
+                        "post-commit batch inject failed; reloading namespace"
+                    );
+                    self.reload_namespace_from_rows(&ns).await?;
+                    return Ok(());
+                }
+            }
+        } else {
+            let mut sing = self.singularity.write().await;
+            let ns = self.namespace.read().await;
+            for concept in concepts {
+                sing.inject(&ns, concept.clone())?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Commit a concept to durable storage first, then apply to memory (ADR-0093).
+    ///
+    /// Persistence failures leave in-memory state unchanged. A rare post-commit
+    /// memory apply failure reloads the namespace from authoritative rows.
+    pub(crate) async fn durable_inject_concept(&self, concept: Concept) -> Result<()> {
+        if let Some(ref persistence) = self.persistence {
+            let ns = self.namespace().await;
+            persistence.save_concept(&ns, &concept).await?;
+            let mut sing = self.singularity.write().await;
+            if let Err(e) = sing.inject(&ns, concept.clone()) {
+                drop(sing);
+                warn!(
+                    error = %e,
+                    concept_id = %concept.id,
+                    "post-commit memory inject failed; reloading namespace from durable rows"
+                );
+                // Durable commit succeeded; reconcile memory and return Ok so
+                // callers do not treat a successful write as failure.
+                self.reload_namespace_from_rows(&ns).await?;
+            }
+        } else {
+            let mut sing = self.singularity.write().await;
+            let ns = self.namespace.read().await;
+            sing.inject(&ns, concept)?;
+        }
+        Ok(())
+    }
+
+    /// Durable delete: commit row removal first, then memory (ADR-0093).
+    pub(crate) async fn durable_delete_concept(&self, id: &str) -> Result<()> {
+        if let Some(ref persistence) = self.persistence {
+            let ns = self.namespace().await;
+            persistence.delete_concept(&ns, id).await?;
+            let mut sing = self.singularity.write().await;
+            if let Err(e) = sing.delete(&ns, id) {
+                drop(sing);
+                warn!(
+                    error = %e,
+                    concept_id = %id,
+                    "post-commit memory delete failed; reloading namespace from durable rows"
+                );
+                self.reload_namespace_from_rows(&ns).await?;
+                return Err(MemoryError::database(format!(
+                    "in-memory delete failed after durable commit for concept {id}; namespace reloaded: {e}"
+                )));
+            }
+        } else {
+            let mut sing = self.singularity.write().await;
+            let ns = self.namespace.read().await;
+            sing.delete(&ns, id)?;
+        }
+        Ok(())
+    }
+
+    /// Reload one namespace from authoritative concept/association rows.
+    #[allow(clippy::significant_drop_tightening)] // inject + rebuild under one write lock
+    pub(crate) async fn reload_namespace_from_rows(&self, ns: &str) -> Result<()> {
+        let Some(ref persistence) = self.persistence else {
+            return Ok(());
+        };
+        let concepts = persistence.load_all_concepts(ns).await?;
+        let associations = persistence.load_all_associations(ns).await?;
+        let mut sing = self.singularity.write().await;
+        sing.clear(ns);
+        for concept in concepts {
+            sing.inject(ns, concept)?;
+        }
+        for (from_id, to_id, strength, created_at) in associations {
+            let ns_state = sing.ensure_namespace(ns)?;
+            let neighbors = ns_state.associations.entry(from_id).or_default();
+            neighbors.insert(to_id, (strength, created_at));
+        }
+        let ns_state = sing.ensure_namespace(ns)?;
+        let concepts_map = ns_state.concepts.clone();
+        ns_state.index.rebuild(&concepts_map)?;
         Ok(())
     }
 
@@ -257,24 +387,15 @@ impl ChaoticSemanticFramework {
             .as_secs();
         target_concept.modified_at = now;
 
-        {
-            let mut sing = self.singularity.write().await;
-            let ns = self.namespace.read().await;
-            sing.inject(&ns, target_concept.clone())?;
-        }
-
-        if let Some(ref persistence) = self.persistence {
-            #[cfg(not(target_arch = "wasm32"))]
-            let p_start = std::time::Instant::now();
-            let ns = self.namespace().await;
-            persistence.save_concept(&ns, &target_concept).await?;
-            #[cfg(not(target_arch = "wasm32"))]
-            {
-                self.metrics.observe_persist_latency_ms(
-                    u64::try_from(p_start.elapsed().as_millis()).unwrap_or(u64::MAX),
-                    "save",
-                );
-            }
+        #[cfg(not(target_arch = "wasm32"))]
+        let p_start = std::time::Instant::now();
+        self.durable_inject_concept(target_concept.clone()).await?;
+        #[cfg(not(target_arch = "wasm32"))]
+        if self.persistence.is_some() {
+            self.metrics.observe_persist_latency_ms(
+                u64::try_from(p_start.elapsed().as_millis()).unwrap_or(u64::MAX),
+                "save",
+            );
         }
 
         self.emit_event(MemoryEvent::ConceptInjected {

--- a/src/framework_ttl.rs
+++ b/src/framework_ttl.rs
@@ -68,26 +68,18 @@ impl crate::framework::ChaoticSemanticFramework {
             .with_ttl(ttl_seconds)
             .build()?;
 
-        {
-            let mut sing = self.singularity.write().await;
-            let ns = self.namespace.read().await;
-            sing.inject(&ns, concept.clone())?;
-        }
+        #[cfg(not(target_arch = "wasm32"))]
+        let p_start = std::time::Instant::now();
+        #[cfg(target_arch = "wasm32")]
+        let p_start = Date::now();
 
-        if let Some(ref persistence) = self.persistence {
-            #[cfg(not(target_arch = "wasm32"))]
-            let p_start = std::time::Instant::now();
-            #[cfg(target_arch = "wasm32")]
-            let p_start = Date::now();
+        self.durable_inject_concept(concept.clone()).await?;
 
-            let ns = self.namespace.read().await;
-            persistence.save_concept(&ns, &concept).await?;
-
+        if self.persistence.is_some() {
             #[cfg(not(target_arch = "wasm32"))]
             let elapsed_ms = u64::try_from(p_start.elapsed().as_millis()).unwrap_or(u64::MAX);
             #[cfg(target_arch = "wasm32")]
             let elapsed_ms = (Date::now() - p_start) as u64;
-
             self.metrics.observe_persist_latency_ms(elapsed_ms, "save");
         }
         self.metrics.inc_concepts_injected(1);

--- a/src/index_envelope.rs
+++ b/src/index_envelope.rs
@@ -1,0 +1,175 @@
+//! Revisioned ANN index snapshot envelope (ADR-0093).
+//!
+//! Pure encoding helpers with no persistence backend dependency so WASM and
+//! no-persistence builds can still reference the types.
+
+use csm_core::error::{MemoryError, Result};
+use serde::{Deserialize, Serialize};
+
+/// Magic prefix for envelope-wrapped index blobs (`CSMIDX01`).
+pub const INDEX_ENVELOPE_MAGIC: &[u8; 8] = b"CSMIDX01";
+
+/// Envelope schema version (not DB schema version).
+pub const INDEX_ENVELOPE_VERSION: u32 = 1;
+
+/// Canonical vector format identifier for 10240-bit HDC vectors.
+pub const VECTOR_FORMAT_HVEC10240: &str = "HVec10240";
+
+/// Revisioned ANN snapshot envelope (ADR-0093).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IndexSnapshotEnvelope {
+    /// Envelope format version.
+    pub envelope_version: u32,
+    /// Authoritative namespace revision at snapshot time.
+    pub namespace_revision: u64,
+    /// Backend + config fingerprint (must match live config to apply).
+    pub backend_fingerprint: String,
+    /// Vector layout identifier.
+    pub vector_format: String,
+    /// Raw backend-serialized index bytes.
+    pub index_data: Vec<u8>,
+    /// FNV-1a checksum of `index_data` (bit-rot / accidental corruption only;
+    /// not a cryptographic integrity or authenticity boundary).
+    pub checksum: u64,
+}
+
+impl IndexSnapshotEnvelope {
+    /// Build an envelope around raw index bytes.
+    #[must_use]
+    pub fn new(
+        namespace_revision: u64,
+        backend_fingerprint: impl Into<String>,
+        index_data: Vec<u8>,
+    ) -> Self {
+        let checksum = fnv1a64(&index_data);
+        Self {
+            envelope_version: INDEX_ENVELOPE_VERSION,
+            namespace_revision,
+            backend_fingerprint: backend_fingerprint.into(),
+            vector_format: VECTOR_FORMAT_HVEC10240.to_string(),
+            index_data,
+            checksum,
+        }
+    }
+
+    /// Validate internal integrity (checksum + envelope version + format).
+    pub fn validate_integrity(&self) -> Result<()> {
+        if self.envelope_version != INDEX_ENVELOPE_VERSION {
+            return Err(MemoryError::InvalidInput {
+                field: "envelope_version".to_string(),
+                reason: format!(
+                    "unsupported index envelope version {} (expected {INDEX_ENVELOPE_VERSION})",
+                    self.envelope_version
+                ),
+            });
+        }
+        if self.vector_format != VECTOR_FORMAT_HVEC10240 {
+            return Err(MemoryError::InvalidInput {
+                field: "vector_format".to_string(),
+                reason: format!(
+                    "unsupported vector format {} (expected {VECTOR_FORMAT_HVEC10240})",
+                    self.vector_format
+                ),
+            });
+        }
+        let expected = fnv1a64(&self.index_data);
+        if self.checksum != expected {
+            return Err(MemoryError::InvalidInput {
+                field: "checksum".to_string(),
+                reason: "index envelope checksum mismatch (corrupt snapshot)".to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Encode envelope as magic + bincode payload.
+    pub fn encode(&self) -> Result<Vec<u8>> {
+        let payload = bincode::serialize(self).map_err(|e| {
+            MemoryError::database(format!("Failed to serialize index envelope: {e}"))
+        })?;
+        let mut out = Vec::with_capacity(INDEX_ENVELOPE_MAGIC.len() + payload.len());
+        out.extend_from_slice(INDEX_ENVELOPE_MAGIC);
+        out.extend_from_slice(&payload);
+        Ok(out)
+    }
+
+    /// Decode envelope; returns `None` for legacy raw blobs (treat as stale).
+    pub fn try_decode(bytes: &[u8]) -> Result<Option<Self>> {
+        if bytes.len() < INDEX_ENVELOPE_MAGIC.len()
+            || &bytes[..INDEX_ENVELOPE_MAGIC.len()] != INDEX_ENVELOPE_MAGIC.as_slice()
+        {
+            return Ok(None);
+        }
+        let env: Self =
+            bincode::deserialize(&bytes[INDEX_ENVELOPE_MAGIC.len()..]).map_err(|e| {
+                MemoryError::database(format!("Failed to deserialize index envelope: {e}"))
+            })?;
+        env.validate_integrity()?;
+        Ok(Some(env))
+    }
+}
+
+/// FNV-1a 64-bit hash for envelope checksums.
+#[must_use]
+pub fn fnv1a64(data: &[u8]) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+    for byte in data {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0100_0000_01b3);
+    }
+    hash
+}
+
+/// Fingerprint an [`crate::index::IndexBackend`] for envelope matching.
+#[must_use]
+pub fn backend_fingerprint(backend: &crate::index::IndexBackend) -> String {
+    use crate::index::IndexBackend;
+    match backend {
+        IndexBackend::BruteForce => "bruteforce".to_string(),
+        #[cfg(feature = "ann-hnsw")]
+        IndexBackend::Hnsw {
+            m,
+            ef_construction,
+            ef_search,
+        } => format!("hnsw:m={m}:efc={ef_construction}:efs={ef_search}"),
+        #[cfg(feature = "ann-lsh")]
+        IndexBackend::Lsh {
+            num_tables,
+            hash_bits,
+        } => format!("lsh:tables={num_tables}:bits={hash_bits}"),
+        #[allow(unreachable_patterns)]
+        _ => "unknown".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use super::*;
+
+    #[test]
+    fn envelope_roundtrip_and_checksum() {
+        let env = IndexSnapshotEnvelope::new(7, "bruteforce", vec![1, 2, 3, 4, 5]);
+        let bytes = env.encode().unwrap();
+        let decoded = IndexSnapshotEnvelope::try_decode(&bytes).unwrap().unwrap();
+        assert_eq!(decoded, env);
+    }
+
+    #[test]
+    fn legacy_raw_blob_is_not_envelope() {
+        let raw = vec![0u8, 1, 2, 3];
+        assert!(IndexSnapshotEnvelope::try_decode(&raw).unwrap().is_none());
+    }
+
+    #[test]
+    fn corrupt_checksum_rejected() {
+        let mut env = IndexSnapshotEnvelope::new(1, "bruteforce", vec![9, 9, 9]);
+        env.checksum ^= 0xff;
+        let payload = bincode::serialize(&env).unwrap();
+        let mut bytes = INDEX_ENVELOPE_MAGIC.to_vec();
+        bytes.extend(payload);
+        let err = IndexSnapshotEnvelope::try_decode(&bytes).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("checksum") || msg.contains("Invalid") || msg.contains("mismatch"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ mod persistence_concepts;
 pub mod semantic_triples;
 pub use metadata_filter::MetadataFilter;
 pub mod index;
+pub mod index_envelope;
 #[cfg(all(not(target_arch = "wasm32"), feature = "persistence"))]
 pub mod persistence;
 #[cfg(all(not(target_arch = "wasm32"), feature = "persistence"))]
@@ -132,6 +133,33 @@ pub mod persistence {
             _id: &str,
         ) -> Result<Vec<(String, f32, u64)>> {
             Ok(Vec::new())
+        }
+        pub async fn load_all_associations(
+            &self,
+            _ns: &str,
+        ) -> Result<Vec<(String, String, f32, u64)>> {
+            Ok(Vec::new())
+        }
+        pub async fn get_namespace_revision(&self, _ns: &str) -> Result<u64> {
+            Ok(0)
+        }
+        pub async fn bump_namespace_revision(&self, _ns: &str) -> Result<u64> {
+            Ok(1)
+        }
+        pub async fn save_index_envelope(
+            &self,
+            _ns: &str,
+            _id: &str,
+            _envelope: &crate::index_envelope::IndexSnapshotEnvelope,
+        ) -> Result<()> {
+            Ok(())
+        }
+        pub async fn load_index_envelope(
+            &self,
+            _ns: &str,
+            _id: &str,
+        ) -> Result<Option<crate::index_envelope::IndexSnapshotEnvelope>> {
+            Ok(None)
         }
         pub async fn delete_association(&self, _ns: &str, _from: &str, _to: &str) -> Result<()> {
             Ok(())

--- a/src/mcp/schema.rs
+++ b/src/mcp/schema.rs
@@ -12,9 +12,8 @@ pub fn inject_schema() -> Value {
                 "description": "Unique identifier for the concept"
             },
             "vector": {
-                "type": "array",
-                "items": {"type": "integer"},
-                "description": "80-element array of u128 values representing a 10240-bit hypervector"
+                "type": "string",
+                "description": "Base64-encoded 1280-byte HVec10240 (canonical wire format from HVec10240::to_bytes())"
             },
             "metadata": {
                 "type": "object",
@@ -53,9 +52,8 @@ pub fn probe_schema() -> Value {
         "type": "object",
         "properties": {
             "vector": {
-                "type": "array",
-                "items": {"type": "integer"},
-                "description": "80-element array of u128 values representing a query hypervector"
+                "type": "string",
+                "description": "Base64-encoded 1280-byte HVec10240 query vector (canonical wire format from HVec10240::to_bytes())"
             },
             "top_k": {
                 "type": "integer",

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -17,10 +17,7 @@ impl McpHandler {
                 let id = args["concept_id"]
                     .as_str()
                     .ok_or_else(|| anyhow::anyhow!("Missing concept_id"))?;
-                let vec_data = args["vector"]
-                    .as_array()
-                    .ok_or_else(|| anyhow::anyhow!("Missing vector"))?;
-                let vector = parse_hvec(vec_data)?;
+                let vector = parse_hvec(&args["vector"])?;
                 if let Some(meta) = args.get("metadata") {
                     let meta_map: HashMap<String, Value> = serde_json::from_value(meta.clone())?;
                     fw.inject_concept_with_metadata(id, vector, meta_map)
@@ -46,10 +43,7 @@ impl McpHandler {
                 Ok(json!({"status": "ok", "concept_id": id}))
             }
             "memory_probe" => {
-                let vec_data = args["vector"]
-                    .as_array()
-                    .ok_or_else(|| anyhow::anyhow!("Missing vector"))?;
-                let vector = parse_hvec(vec_data)?;
+                let vector = parse_hvec(&args["vector"])?;
                 let top_k = args["top_k"].as_u64().unwrap_or(10) as usize;
                 let (results, _) = fw.probe_with_best_score(vector, top_k).await?;
                 Ok(json!({"status": "ok", "results": results}))
@@ -216,15 +210,51 @@ impl McpHandler {
     }
 }
 
-pub(crate) fn parse_hvec(vec_data: &[Value]) -> Result<csm_core::hyperdim::HVec10240> {
-    if vec_data.len() != 80 {
-        return Err(anyhow::anyhow!("Vector must have 80 elements"));
+/// Parse an MCP wire hypervector.
+///
+/// Primary format (ADR-0094): base64 string of 1280 little-endian bytes
+/// (`HVec10240::to_bytes()`).
+///
+/// Migration fallback: array of 160 JSON integers as u64 halves
+/// `(high_0, low_0, high_1, low_1, …)` for each of the 80 `u128` words.
+pub(crate) fn parse_hvec(value: &Value) -> Result<csm_core::hyperdim::HVec10240> {
+    if let Some(s) = value.as_str() {
+        return parse_hvec_base64(s);
+    }
+    if let Some(arr) = value.as_array() {
+        return parse_hvec_u64_halves(arr);
+    }
+    Err(anyhow::anyhow!(
+        "Missing or invalid vector: expected base64 string or array of 160 u64 halves"
+    ))
+}
+
+fn parse_hvec_base64(s: &str) -> Result<csm_core::hyperdim::HVec10240> {
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD;
+
+    let bytes = STANDARD
+        .decode(s)
+        .map_err(|e| anyhow::anyhow!("Invalid base64 vector: {e}"))?;
+    csm_core::hyperdim::HVec10240::from_bytes(&bytes)
+        .map_err(|e| anyhow::anyhow!("Invalid vector bytes: {e}"))
+}
+
+fn parse_hvec_u64_halves(arr: &[Value]) -> Result<csm_core::hyperdim::HVec10240> {
+    if arr.len() != 160 {
+        return Err(anyhow::anyhow!(
+            "Legacy vector must have 160 u64 halves (high, low × 80 words)"
+        ));
     }
     let mut data = [0u128; 80];
-    for (i, val) in vec_data.iter().enumerate() {
-        data[i] = val
+    for (i, word) in data.iter_mut().enumerate() {
+        let high = arr[i * 2]
             .as_u64()
-            .ok_or_else(|| anyhow::anyhow!("Invalid vector element"))? as u128;
+            .ok_or_else(|| anyhow::anyhow!("Invalid vector half at index {}", i * 2))?;
+        let low = arr[i * 2 + 1]
+            .as_u64()
+            .ok_or_else(|| anyhow::anyhow!("Invalid vector half at index {}", i * 2 + 1))?;
+        *word = (u128::from(high) << 64) | u128::from(low);
     }
     Ok(csm_core::hyperdim::HVec10240 { data })
 }
@@ -232,29 +262,91 @@ pub(crate) fn parse_hvec(vec_data: &[Value]) -> Result<csm_core::hyperdim::HVec1
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD;
+    use csm_core::hyperdim::HVec10240;
     use serde_json::json;
 
-    #[test]
-    fn test_parse_hvec_valid() {
-        let vec_data: Vec<Value> = (0..80).map(|i| json!(i as u64)).collect();
-        let hvec = parse_hvec(&vec_data).unwrap();
-        assert_eq!(hvec.data[0], 0);
-        assert_eq!(hvec.data[79], 79);
+    fn hvec_to_b64(hvec: &HVec10240) -> String {
+        STANDARD.encode(hvec.to_bytes())
+    }
+
+    fn zero_vector_b64() -> String {
+        hvec_to_b64(&HVec10240 { data: [0u128; 80] })
     }
 
     #[test]
-    fn test_parse_hvec_invalid_length() {
-        let vec_data = vec![json!(1u64); 79];
-        let err = parse_hvec(&vec_data).unwrap_err();
-        assert_eq!(err.to_string(), "Vector must have 80 elements");
+    fn test_parse_hvec_base64_valid() {
+        let mut data = [0u128; 80];
+        data[0] = 42;
+        data[79] = 79;
+        let hvec = HVec10240 { data };
+        let parsed = parse_hvec(&json!(hvec_to_b64(&hvec))).unwrap();
+        assert_eq!(parsed.data[0], 42);
+        assert_eq!(parsed.data[79], 79);
     }
 
     #[test]
-    fn test_parse_hvec_invalid_type() {
-        let mut vec_data = vec![json!(1u64); 80];
-        vec_data[0] = json!("not a number");
-        let err = parse_hvec(&vec_data).unwrap_err();
-        assert_eq!(err.to_string(), "Invalid vector element");
+    fn test_parse_hvec_base64_high_bits_roundtrip() {
+        // JSON integers cannot carry full u128; base64 must preserve bits above 64.
+        let mut data = [0u128; 80];
+        data[0] = 1u128 << 80;
+        data[1] = u128::MAX;
+        data[2] = (u64::MAX as u128) << 64 | 0xDEAD_BEEF;
+        let original = HVec10240 { data };
+        let parsed = parse_hvec(&json!(hvec_to_b64(&original))).unwrap();
+        assert_eq!(parsed.data[0], 1u128 << 80);
+        assert_eq!(parsed.data[1], u128::MAX);
+        assert_eq!(parsed.data[2], (u64::MAX as u128) << 64 | 0xDEAD_BEEF);
+        assert_eq!(parsed.to_bytes(), original.to_bytes());
+    }
+
+    #[test]
+    fn test_parse_hvec_legacy_u64_halves() {
+        // 160 halves: (high, low) per word. Word 0 = (1 << 80) = high=1<<16, low=0.
+        let mut halves = vec![0u64; 160];
+        halves[0] = 1u64 << 16; // high half of word 0
+        halves[1] = 0; // low half of word 0
+        halves[2] = 0xABCD;
+        halves[3] = 0x1234;
+        let arr: Vec<Value> = halves.into_iter().map(|n| json!(n)).collect();
+        let parsed = parse_hvec(&Value::Array(arr)).unwrap();
+        assert_eq!(parsed.data[0], 1u128 << 80);
+        assert_eq!(parsed.data[1], (0xABCDu128 << 64) | 0x1234);
+    }
+
+    #[test]
+    fn test_parse_hvec_invalid_base64() {
+        let err = parse_hvec(&json!("not!!!base64")).unwrap_err();
+        assert!(err.to_string().contains("Invalid base64"));
+    }
+
+    #[test]
+    fn test_parse_hvec_wrong_byte_length() {
+        let short = STANDARD.encode([0u8; 16]);
+        let err = parse_hvec(&json!(short)).unwrap_err();
+        assert!(err.to_string().contains("Invalid vector bytes"));
+    }
+
+    #[test]
+    fn test_parse_hvec_legacy_invalid_length() {
+        let arr = vec![json!(1u64); 80];
+        let err = parse_hvec(&Value::Array(arr)).unwrap_err();
+        assert!(err.to_string().contains("160 u64 halves"));
+    }
+
+    #[test]
+    fn test_parse_hvec_legacy_invalid_type() {
+        let mut arr = vec![json!(1u64); 160];
+        arr[0] = json!("not a number");
+        let err = parse_hvec(&Value::Array(arr)).unwrap_err();
+        assert!(err.to_string().contains("Invalid vector half"));
+    }
+
+    #[test]
+    fn test_parse_hvec_missing() {
+        let err = parse_hvec(&Value::Null).unwrap_err();
+        assert!(err.to_string().contains("Missing or invalid vector"));
     }
 
     /// Helper to create a handler with an in-memory framework.
@@ -272,10 +364,9 @@ mod tests {
     #[tokio::test]
     async fn test_execute_tool_inject_and_get() {
         let handler = handler_with_framework().await;
-        let vector: Vec<Value> = (0..80).map(|i| json!(i as u64)).collect();
         let args = json!({
             "concept_id": "test-concept",
-            "vector": vector,
+            "vector": zero_vector_b64(),
         });
         let result = handler.execute_tool("memory_inject", args).await.unwrap();
         assert_eq!(result["status"], "ok");
@@ -286,6 +377,46 @@ mod tests {
         let get_result = handler.execute_tool("memory_get", get_args).await.unwrap();
         assert_eq!(get_result["status"], "ok");
         assert!(get_result["concept"].is_object());
+    }
+
+    #[tokio::test]
+    async fn test_execute_tool_inject_high_bits_roundtrip() {
+        let handler = handler_with_framework().await;
+        let mut data = [0u128; 80];
+        data[0] = 1u128 << 80;
+        data[5] = u128::MAX;
+        let original = HVec10240 { data };
+        let b64 = hvec_to_b64(&original);
+
+        let inject = json!({
+            "concept_id": "high-bits",
+            "vector": b64,
+        });
+        handler.execute_tool("memory_inject", inject).await.unwrap();
+
+        // Probe with the same vector should find the concept (results are (id, score) tuples).
+        let probe = json!({
+            "vector": hvec_to_b64(&original),
+            "top_k": 1,
+        });
+        let result = handler.execute_tool("memory_probe", probe).await.unwrap();
+        assert_eq!(result["status"], "ok");
+        let results = result["results"].as_array().unwrap();
+        assert!(!results.is_empty());
+        assert_eq!(results[0][0], "high-bits");
+
+        // Concept serialization uses the same base64 wire format.
+        let get = handler
+            .execute_tool("memory_get", json!({"concept_id": "high-bits"}))
+            .await
+            .unwrap();
+        let wire = get["concept"]["vector"]
+            .as_str()
+            .expect("concept.vector must be base64 string");
+        let restored = parse_hvec(&json!(wire)).unwrap();
+        assert_eq!(restored.data[0], 1u128 << 80);
+        assert_eq!(restored.data[5], u128::MAX);
+        assert_eq!(restored.to_bytes(), original.to_bytes());
     }
 
     #[tokio::test]
@@ -307,10 +438,9 @@ mod tests {
     async fn test_execute_tool_delete() {
         let handler = handler_with_framework().await;
         // Inject first
-        let vector: Vec<Value> = (0..80).map(|i| json!(i as u64)).collect();
         let inject_args = json!({
             "concept_id": "to-delete",
-            "vector": vector,
+            "vector": zero_vector_b64(),
         });
         handler
             .execute_tool("memory_inject", inject_args)

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -8,7 +8,7 @@ use csm_core::error::{MemoryError, Result};
 use libsql::{Builder, Connection, Database, params};
 use std::sync::Arc;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
-pub(crate) const LATEST_SCHEMA_VERSION: i64 = 10;
+pub(crate) const LATEST_SCHEMA_VERSION: i64 = 11;
 
 #[derive(Debug)]
 pub struct Persistence {

--- a/src/persistence_concepts.rs
+++ b/src/persistence_concepts.rs
@@ -15,8 +15,14 @@ impl Persistence {
         let expires_at: Option<i64> = concept.expires_at.map(|t| t as i64);
         let canonical_concept_ids_json = serde_json::to_string(&concept.canonical_concept_ids)?;
 
-        conn.execute(
-            "INSERT INTO csm_concepts
+        // ADR-0093: single transaction so row + version + revision stay consistent.
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to begin transaction: {e}")))?;
+
+        if let Err(e) = conn
+            .execute(
+                "INSERT INTO csm_concepts
              (namespace, id, vector, metadata, created_at, modified_at, expires_at, canonical_concept_ids_json)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
              ON CONFLICT(namespace, id) DO UPDATE SET
@@ -25,28 +31,45 @@ impl Persistence {
              modified_at = excluded.modified_at,
              expires_at = excluded.expires_at,
              canonical_concept_ids_json = excluded.canonical_concept_ids_json",
-            params![
-                ns,
-                concept.id.as_str(),
-                vector_bytes.as_slice(),
-                metadata_json.as_str(),
-                concept.created_at as i64,
-                concept.modified_at as i64,
-                expires_at,
-                canonical_concept_ids_json.as_str()
-            ],
-        )
-        .await
-        .map_err(|e| MemoryError::database(format!("Failed to save concept: {e}")))?;
+                params![
+                    ns,
+                    concept.id.as_str(),
+                    vector_bytes.as_slice(),
+                    metadata_json.as_str(),
+                    concept.created_at as i64,
+                    concept.modified_at as i64,
+                    expires_at,
+                    canonical_concept_ids_json.as_str()
+                ],
+            )
+            .await
+        {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(MemoryError::database(format!("Failed to save concept: {e}")));
+        }
 
-        self.record_concept_version_scoped(
-            &conn,
-            ns,
-            concept,
-            Some(&vector_bytes),
-            Some(&metadata_json),
-        )
-        .await?;
+        if let Err(e) = self
+            .record_concept_version_scoped(
+                &conn,
+                ns,
+                concept,
+                Some(&vector_bytes),
+                Some(&metadata_json),
+            )
+            .await
+        {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(e);
+        }
+
+        if let Err(e) = self.bump_namespace_revision_with_conn(&conn, ns).await {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(e);
+        }
+
+        conn.execute("COMMIT", ())
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to commit concept save: {e}")))?;
         Ok(())
     }
 
@@ -117,6 +140,12 @@ impl Persistence {
         if let Some(error) = first_error {
             let _ = conn.execute("ROLLBACK", ()).await;
             return Err(error);
+        }
+
+        // One revision bump for the batch (authoritative mutation set).
+        if let Err(e) = self.bump_namespace_revision_with_conn(&conn, ns).await {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(e);
         }
 
         conn.execute("COMMIT", ())
@@ -290,6 +319,12 @@ impl Persistence {
             return Err(MemoryError::database(format!(
                 "Failed to delete concept: {e}"
             )));
+        }
+
+        // ADR-0093: durable delete advances revision (stales ANN snapshot).
+        if let Err(e) = self.bump_namespace_revision_with_conn(&conn, ns).await {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(e);
         }
 
         conn.execute("COMMIT", ())

--- a/src/persistence_index.rs
+++ b/src/persistence_index.rs
@@ -1,13 +1,14 @@
-//! ANN index persistence operations.
+//! ANN index persistence and namespace revision (ADR-0093).
 //!
 //! Extracted from persistence.rs to satisfy the 500 LOC gate.
 
+use crate::index_envelope::IndexSnapshotEnvelope;
 use crate::persistence::Persistence;
 use csm_core::error::{MemoryError, Result};
 use libsql::params;
 
 impl Persistence {
-    /// Save the serialized index state to the database.
+    /// Save the serialized index state to the database (raw or pre-wrapped bytes).
     pub async fn save_index(&self, ns: &str, id: &str, data: &[u8]) -> Result<()> {
         let _permit = self.acquire_remote_slot().await?;
         let conn = self.connect().await?;
@@ -24,6 +25,18 @@ impl Persistence {
         .await
         .map_err(|e| MemoryError::database(format!("Failed to save index: {e}")))?;
         Ok(())
+    }
+
+    /// Save a revisioned index envelope.
+    pub async fn save_index_envelope(
+        &self,
+        ns: &str,
+        id: &str,
+        envelope: &IndexSnapshotEnvelope,
+    ) -> Result<()> {
+        envelope.validate_integrity()?;
+        let encoded = envelope.encode()?;
+        self.save_index(ns, id, &encoded).await
     }
 
     /// Load the serialized index state from the database.
@@ -51,16 +64,138 @@ impl Persistence {
             Ok(None)
         }
     }
+
+    /// Load and parse a revisioned index envelope. Legacy raw blobs yield `Ok(None)`.
+    pub async fn load_index_envelope(
+        &self,
+        ns: &str,
+        id: &str,
+    ) -> Result<Option<IndexSnapshotEnvelope>> {
+        match self.load_index(ns, id).await? {
+            Some(bytes) => IndexSnapshotEnvelope::try_decode(&bytes),
+            None => Ok(None),
+        }
+    }
+
+    /// Current namespace revision (0 if no row).
+    pub async fn get_namespace_revision(&self, ns: &str) -> Result<u64> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                "SELECT revision FROM csm_namespace_meta WHERE namespace = ?1",
+                params![ns],
+            )
+            .await
+            .map_err(|e| {
+                MemoryError::database(format!("Failed to load namespace revision: {e}"))
+            })?;
+
+        if let Some(row) = rows.next().await.map_err(|e| {
+            MemoryError::database(format!("Failed to fetch namespace revision row: {e}"))
+        })? {
+            let revision: i64 = row.get(0).map_err(|e| {
+                MemoryError::database(format!("Failed to parse namespace revision: {e}"))
+            })?;
+            Ok(revision as u64)
+        } else {
+            Ok(0)
+        }
+    }
+
+    /// Atomically increment namespace revision; returns the new value.
+    pub async fn bump_namespace_revision(&self, ns: &str) -> Result<u64> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+        self.bump_namespace_revision_with_conn(&conn, ns).await
+    }
+
+    /// Increment revision using an existing connection (for transactional callers).
+    pub(crate) async fn bump_namespace_revision_with_conn(
+        &self,
+        conn: &libsql::Connection,
+        ns: &str,
+    ) -> Result<u64> {
+        conn.execute(
+            "INSERT INTO csm_namespace_meta (namespace, revision)
+             VALUES (?1, 1)
+             ON CONFLICT(namespace) DO UPDATE SET revision = revision + 1",
+            params![ns],
+        )
+        .await
+        .map_err(|e| MemoryError::database(format!("Failed to bump namespace revision: {e}")))?;
+
+        let mut rows = conn
+            .query(
+                "SELECT revision FROM csm_namespace_meta WHERE namespace = ?1",
+                params![ns],
+            )
+            .await
+            .map_err(|e| {
+                MemoryError::database(format!("Failed to read namespace revision: {e}"))
+            })?;
+
+        let row = rows
+            .next()
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to fetch revision row: {e}")))?
+            .ok_or_else(|| MemoryError::database("namespace revision missing after bump"))?;
+
+        let revision: i64 = row
+            .get(0)
+            .map_err(|e| MemoryError::database(format!("Failed to parse revision: {e}")))?;
+        Ok(revision as u64)
+    }
+
+    /// Load all associations for a namespace in one query (ADR-0093 P1).
+    pub async fn load_all_associations(&self, ns: &str) -> Result<Vec<(String, String, f32, u64)>> {
+        let _permit = self.acquire_remote_slot().await?;
+        let conn = self.connect().await?;
+
+        let mut rows = conn
+            .query(
+                "SELECT from_id, to_id, strength, created_at
+                 FROM csm_associations WHERE namespace = ?1",
+                params![ns],
+            )
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to bulk-load associations: {e}")))?;
+
+        let mut associations = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| MemoryError::database(format!("Failed to fetch association row: {e}")))?
+        {
+            let from_id: String = row
+                .get(0)
+                .map_err(|e| MemoryError::database(format!("Failed to get from_id: {e}")))?;
+            let to_id: String = row
+                .get(1)
+                .map_err(|e| MemoryError::database(format!("Failed to get to_id: {e}")))?;
+            let strength: f64 = row
+                .get(2)
+                .map_err(|e| MemoryError::database(format!("Failed to get strength: {e}")))?;
+            let created_at: i64 = row
+                .get(3)
+                .map_err(|e| MemoryError::database(format!("Failed to get created_at: {e}")))?;
+            associations.push((from_id, to_id, strength as f32, created_at as u64));
+        }
+
+        Ok(associations)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
     use super::*;
+    use crate::index_envelope::IndexSnapshotEnvelope;
 
     #[tokio::test]
     async fn test_save_and_load_index_roundtrip() {
         let path = "/tmp/test_index_persist_rt.db";
+        let _ = std::fs::remove_file(path);
         let persistence = Persistence::new_local(path).await.unwrap();
 
         let test_data = vec![1u8, 2, 3, 4, 5, 42, 99];
@@ -72,13 +207,70 @@ mod tests {
         let loaded = persistence.load_index("default", "test-idx").await.unwrap();
         assert_eq!(loaded, Some(test_data));
 
-        // Non-existent index returns None
         let missing = persistence
             .load_index("default", "no-such-idx")
             .await
             .unwrap();
         assert_eq!(missing, None);
 
+        std::fs::remove_file(path).ok();
+    }
+
+    #[tokio::test]
+    async fn namespace_revision_bumps() {
+        let path = "/tmp/test_ns_revision.db";
+        let _ = std::fs::remove_file(path);
+        let persistence = Persistence::new_local(path).await.unwrap();
+        assert_eq!(persistence.get_namespace_revision("ns").await.unwrap(), 0);
+        assert_eq!(persistence.bump_namespace_revision("ns").await.unwrap(), 1);
+        assert_eq!(persistence.bump_namespace_revision("ns").await.unwrap(), 2);
+        assert_eq!(persistence.get_namespace_revision("ns").await.unwrap(), 2);
+        std::fs::remove_file(path).ok();
+    }
+
+    #[tokio::test]
+    async fn envelope_save_load() {
+        let path = "/tmp/test_env_index.db";
+        let _ = std::fs::remove_file(path);
+        let persistence = Persistence::new_local(path).await.unwrap();
+        let env = IndexSnapshotEnvelope::new(3, "bruteforce", vec![7, 8, 9]);
+        persistence
+            .save_index_envelope("ns", "main", &env)
+            .await
+            .unwrap();
+        let loaded = persistence
+            .load_index_envelope("ns", "main")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded.namespace_revision, 3);
+        assert_eq!(loaded.index_data, vec![7, 8, 9]);
+        std::fs::remove_file(path).ok();
+    }
+
+    #[tokio::test]
+    async fn bulk_associations_load() {
+        let path = "/tmp/test_bulk_assoc.db";
+        let _ = std::fs::remove_file(path);
+        let persistence = Persistence::new_local(path).await.unwrap();
+        let c1 = crate::singularity::ConceptBuilder::new("a")
+            .with_vector(csm_core::hyperdim::HVec10240::zero())
+            .build()
+            .unwrap();
+        let c2 = crate::singularity::ConceptBuilder::new("b")
+            .with_vector(csm_core::hyperdim::HVec10240::zero())
+            .build()
+            .unwrap();
+        persistence.save_concept("ns", &c1).await.unwrap();
+        persistence.save_concept("ns", &c2).await.unwrap();
+        persistence
+            .save_association("ns", "a", "b", 0.9)
+            .await
+            .unwrap();
+        let all = persistence.load_all_associations("ns").await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].0, "a");
+        assert_eq!(all[0].1, "b");
         std::fs::remove_file(path).ok();
     }
 }

--- a/src/persistence_migrations.rs
+++ b/src/persistence_migrations.rs
@@ -380,6 +380,18 @@ impl Persistence {
                 .map_err(|e| MemoryError::database(format!("Failed migration v10: {e}")))?;
             }
 
+            // ADR-0093: namespace revision for derived ANN snapshot validation
+            if version == 11 {
+                conn.execute_batch(
+                    "CREATE TABLE IF NOT EXISTS csm_namespace_meta (
+                        namespace TEXT PRIMARY KEY,
+                        revision INTEGER NOT NULL DEFAULT 0
+                    );",
+                )
+                .await
+                .map_err(|e| MemoryError::database(format!("Failed migration v11: {e}")))?;
+            }
+
             conn.execute(
                 "INSERT INTO csm_schema_version(version) VALUES (?1)",
                 libsql::params![version],

--- a/src/persistence_wasm.rs
+++ b/src/persistence_wasm.rs
@@ -86,6 +86,31 @@ impl Persistence {
         Err(wasm_persistence_unavailable())
     }
 
+    pub async fn get_namespace_revision(&self, _ns: &str) -> Result<u64> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn bump_namespace_revision(&self, _ns: &str) -> Result<u64> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn save_index_envelope(
+        &self,
+        _ns: &str,
+        _id: &str,
+        _envelope: &crate::index_envelope::IndexSnapshotEnvelope,
+    ) -> Result<()> {
+        Err(wasm_persistence_unavailable())
+    }
+
+    pub async fn load_index_envelope(
+        &self,
+        _ns: &str,
+        _id: &str,
+    ) -> Result<Option<crate::index_envelope::IndexSnapshotEnvelope>> {
+        Err(wasm_persistence_unavailable())
+    }
+
     pub async fn clear_namespace(&self, _ns: &str) -> Result<()> {
         Err(wasm_persistence_unavailable())
     }

--- a/src/retrieval/bm25.rs
+++ b/src/retrieval/bm25.rs
@@ -317,10 +317,11 @@ impl Bm25Index {
 
             DOC_SCORES_BUFFER.with(|buffer| {
                 let mut doc_scores = buffer.borrow_mut();
-                // Ensure buffer is large enough; we use sparse zeroing to maintain it.
-                // Buffer retains high-water-mark size; shrinking is O(N) and not worth it.
+                // Active prefix zeroed each search (residuals break sparse touch tracking).
                 if doc_scores.len() < num_docs {
                     doc_scores.resize(num_docs, 0.0);
+                } else {
+                    doc_scores[..num_docs].fill(0.0);
                 }
 
                 self.ensure_norm_cache();
@@ -330,6 +331,7 @@ impl Bm25Index {
                         .read()
                         .expect("Bm25Index norm_cache lock poisoned");
                     let factors = &cache.factors;
+                    debug_assert_eq!(factors.len(), num_docs);
 
                     for (weighted_idf, entries) in query_weights {
                         if weighted_idf <= 0.0 {
@@ -337,26 +339,18 @@ impl Bm25Index {
                         }
 
                         for &(doc_idx, tf) in entries {
-                            // SAFETY: doc_idx is guaranteed to be within bounds because:
-                            // 1. It is derived from the postings index which is strictly synchronized with
-                            //    the documents vector in add_document/remove_document_at.
-                            // 2. doc_scores is ensured to be >= num_docs at search start.
-                            // 3. Normalization buffers are synchronized in ensure_norm_cache() before access.
-                            // Mathematical Impact: O(Q * D_q) search complexity.
+                            // SAFETY: doc_idx from postings; buffers sized to num_docs.
                             unsafe {
                                 let score_ptr = doc_scores.get_unchecked_mut(doc_idx);
                                 if *score_ptr == 0.0 {
                                     touched_indices.push(doc_idx);
                                 }
-
                                 let (doc_term_b, tf1_recip) = *factors.get_unchecked(doc_idx);
                                 if tf == 1 {
-                                    // Fast path for the most common case: single term frequency.
                                     *score_ptr += weighted_idf * tf1_recip;
                                 } else {
                                     let tf = tf as f32;
-                                    let denominator = tf + doc_term_b;
-                                    *score_ptr += (tf * weighted_idf) / denominator;
+                                    *score_ptr += (tf * weighted_idf) / (tf + doc_term_b);
                                 }
                             }
                         }
@@ -442,8 +436,16 @@ impl Bm25Index {
     #[allow(clippy::significant_drop_tightening)]
     #[allow(clippy::expect_used)]
     fn ensure_norm_cache(&self) {
+        let n_docs = self.documents.len();
         if !self.norm_cache_dirty.load(AtomicOrdering::Acquire) {
-            return;
+            let cache = self
+                .norm_cache
+                .read()
+                .expect("Bm25Index norm_cache lock poisoned");
+            // Rebuild if length drifted even when dirty flag is clear.
+            if cache.factors.len() == n_docs {
+                return;
+            }
         }
 
         if self.is_empty() {
@@ -451,13 +453,12 @@ impl Bm25Index {
             return;
         }
 
-        // Double-checked locking to prevent redundant work
         let mut cache = self
             .norm_cache
             .write()
             .expect("Bm25Index norm_cache lock poisoned");
 
-        if !self.norm_cache_dirty.load(AtomicOrdering::Acquire) {
+        if !self.norm_cache_dirty.load(AtomicOrdering::Acquire) && cache.factors.len() == n_docs {
             return;
         }
 

--- a/src/retrieval/bm25.rs
+++ b/src/retrieval/bm25.rs
@@ -317,12 +317,11 @@ impl Bm25Index {
 
             DOC_SCORES_BUFFER.with(|buffer| {
                 let mut doc_scores = buffer.borrow_mut();
-                // Active prefix zeroed each search (residuals break sparse touch tracking).
+                // Always clear the active prefix (resize alone does not zero old slots).
                 if doc_scores.len() < num_docs {
                     doc_scores.resize(num_docs, 0.0);
-                } else {
-                    doc_scores[..num_docs].fill(0.0);
                 }
+                doc_scores[..num_docs].fill(0.0);
 
                 self.ensure_norm_cache();
                 {
@@ -492,7 +491,8 @@ impl Bm25Index {
 }
 
 fn score_cmp_desc(a: &(usize, f32), b: &(usize, f32)) -> Ordering {
-    b.1.total_cmp(&a.1)
+    // Score desc, then doc index asc — stable under equal scores / sort_unstable.
+    b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0))
 }
 
 #[cfg(test)]

--- a/src/retrieval/bm25/tests.rs
+++ b/src/retrieval/bm25/tests.rs
@@ -265,9 +265,13 @@ fn test_cache_consistency() {
     // Scores should change because avgdl changed
     assert!((score1_initial - score1_after).abs() > 1e-6);
 
-    // Warm-cache search must match cold-after-mutation scores bit-for-bit.
+    // Warm-cache parity (use miri -Zmiri-deterministic-floats in CI).
     let results3 = index.search(&["hello"], 10);
-    assert_eq!(results2, results3);
+    assert_eq!(results2.len(), results3.len());
+    for ((id_a, s_a), (id_b, s_b)) in results2.iter().zip(results3.iter()) {
+        assert_eq!(id_a, id_b);
+        assert!((s_a - s_b).abs() < 1e-6, "{id_a}: {s_a} vs {s_b}");
+    }
 }
 
 #[test]

--- a/src/retrieval/bm25/tests.rs
+++ b/src/retrieval/bm25/tests.rs
@@ -265,10 +265,9 @@ fn test_cache_consistency() {
     // Scores should change because avgdl changed
     assert!((score1_initial - score1_after).abs() > 1e-6);
 
-    // Identity check for cached search
+    // Warm-cache search must match cold-after-mutation scores bit-for-bit.
     let results3 = index.search(&["hello"], 10);
-    let score1_cached = results3.iter().find(|(id, _)| id == "doc1").unwrap().1;
-    assert!((score1_after - score1_cached).abs() < 1e-6);
+    assert_eq!(results2, results3);
 }
 
 #[test]

--- a/tests/ann_revision_envelope.rs
+++ b/tests/ann_revision_envelope.rs
@@ -1,0 +1,153 @@
+//! ADR-0093: revisioned ANN snapshot validation and durable mutation semantics.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use chaotic_semantic_memory::index_envelope::IndexSnapshotEnvelope;
+use chaotic_semantic_memory::persistence::Persistence;
+use chaotic_semantic_memory::prelude::*;
+use tempfile::NamedTempFile;
+
+#[tokio::test]
+async fn stale_snapshot_after_inject_is_rejected_on_reload() {
+    let temp = NamedTempFile::new().unwrap();
+    let db_path = temp.path().to_str().unwrap();
+
+    // Session 1: inject + persist index envelope at revision R.
+    {
+        let fw = FrameworkBuilder::new()
+            .with_local_db(db_path)
+            .build()
+            .await
+            .unwrap();
+        let mut v = HVec10240::zero();
+        v.set_bit(1);
+        fw.inject_concept("c1", v).await.unwrap();
+        fw.persist().await.unwrap();
+    }
+
+    // Session 2: inject without re-persisting index → revision advances, envelope stale.
+    {
+        let fw = FrameworkBuilder::new()
+            .with_local_db(db_path)
+            .build()
+            .await
+            .unwrap();
+        let mut v = HVec10240::zero();
+        v.set_bit(2);
+        fw.inject_concept("c2", v).await.unwrap();
+        // Intentionally do not call persist() — ANN snapshot still has old revision.
+    }
+
+    // Session 3: load_replace must rebuild and surface both concepts.
+    {
+        let fw = FrameworkBuilder::new()
+            .with_local_db(db_path)
+            .build()
+            .await
+            .unwrap();
+        let mut q = HVec10240::zero();
+        q.set_bit(1);
+        let r1 = fw.probe(q, 5).await.unwrap();
+        assert!(
+            r1.iter().any(|(id, _)| id == "c1"),
+            "c1 must remain findable after rebuild"
+        );
+        let mut q2 = HVec10240::zero();
+        q2.set_bit(2);
+        let r2 = fw.probe(q2, 5).await.unwrap();
+        assert!(
+            r2.iter().any(|(id, _)| id == "c2"),
+            "c2 must be present after stale snapshot rejection"
+        );
+    }
+}
+
+#[tokio::test]
+async fn backend_mismatch_rejects_snapshot() {
+    let temp = NamedTempFile::new().unwrap();
+    let db_path = temp.path().to_str().unwrap();
+    let p = Persistence::new_local(db_path).await.unwrap();
+
+    // Store envelope claiming wrong backend fingerprint.
+    let env = IndexSnapshotEnvelope::new(0, "hnsw:m=16:efc=200:efs=50", vec![1, 2, 3]);
+    p.save_index_envelope("_default", "main", &env)
+        .await
+        .unwrap();
+
+    let fw = FrameworkBuilder::new()
+        .with_local_db(db_path)
+        .build()
+        .await
+        .unwrap();
+    // build() calls load_replace — must not panic; brute-force rebuild.
+    let _ = fw.probe(HVec10240::zero(), 1).await.unwrap();
+}
+
+#[tokio::test]
+async fn corrupt_envelope_does_not_brick_load() {
+    let temp = NamedTempFile::new().unwrap();
+    let db_path = temp.path().to_str().unwrap();
+    {
+        let fw = FrameworkBuilder::new()
+            .with_local_db(db_path)
+            .build()
+            .await
+            .unwrap();
+        let mut v = HVec10240::zero();
+        v.set_bit(5);
+        fw.inject_concept("keep-me", v).await.unwrap();
+    }
+    // Write a magic-prefixed but corrupt envelope blob.
+    let p = Persistence::new_local(db_path).await.unwrap();
+    let mut bad = b"CSMIDX01".to_vec();
+    bad.extend_from_slice(&[0xff; 32]);
+    p.save_index("_default", "main", &bad).await.unwrap();
+
+    let fw = FrameworkBuilder::new()
+        .with_local_db(db_path)
+        .build()
+        .await
+        .unwrap();
+    let mut q = HVec10240::zero();
+    q.set_bit(5);
+    let results = fw.probe(q, 1).await.unwrap();
+    assert_eq!(results[0].0, "keep-me");
+}
+
+#[tokio::test]
+async fn load_merge_rebuilds_union_not_snapshot() {
+    let temp = NamedTempFile::new().unwrap();
+    let db_path = temp.path().to_str().unwrap();
+
+    {
+        let fw = FrameworkBuilder::new()
+            .with_local_db(db_path)
+            .build()
+            .await
+            .unwrap();
+        let mut v = HVec10240::zero();
+        v.set_bit(10);
+        fw.inject_concept("persisted", v).await.unwrap();
+        fw.persist().await.unwrap();
+    }
+
+    // Start from empty memory + DB rows; inject a second concept in-process,
+    // then load_merge again (idempotent) and confirm both remain probeable.
+    let fw2 = FrameworkBuilder::new()
+        .with_local_db(db_path)
+        .build()
+        .await
+        .unwrap();
+    let mut v2 = HVec10240::zero();
+    v2.set_bit(12);
+    fw2.inject_concept("extra", v2).await.unwrap();
+    fw2.load_merge().await.unwrap();
+
+    let mut q = HVec10240::zero();
+    q.set_bit(10);
+    let results = fw2.probe(q, 5).await.unwrap();
+    assert!(results.iter().any(|(id, _)| id == "persisted"));
+    let mut q2 = HVec10240::zero();
+    q2.set_bit(12);
+    let results2 = fw2.probe(q2, 5).await.unwrap();
+    assert!(results2.iter().any(|(id, _)| id == "extra"));
+}

--- a/tests/mcp_integration.rs
+++ b/tests/mcp_integration.rs
@@ -123,3 +123,45 @@ fn transport_clone() {
     let t2 = t;
     assert!(matches!(t2, Transport::Stdio));
 }
+
+// --- Hypervector wire format (ADR-0094) ---
+
+#[test]
+fn mcp_hypervector_base64_preserves_high_bits() {
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD;
+    use chaotic_semantic_memory::HVec10240;
+
+    // Full 10240-bit vectors must survive the MCP wire format (base64 of
+    // HVec10240::to_bytes()). JSON integers cannot carry bits above 64.
+    let mut data = [0u128; 80];
+    data[0] = 1u128 << 80;
+    data[1] = u128::MAX;
+    data[2] = (u64::MAX as u128) << 64 | 0xCAFE_F00D;
+    let original = HVec10240 { data };
+
+    let wire = STANDARD.encode(original.to_bytes());
+    assert!(
+        !wire.is_empty(),
+        "MCP vector wire is a non-empty base64 string"
+    );
+
+    let restored = HVec10240::from_bytes(
+        &STANDARD
+            .decode(&wire)
+            .expect("MCP wire must be valid standard base64"),
+    )
+    .expect("decoded bytes must be a valid 1280-byte HVec10240");
+
+    assert_eq!(restored.data[0], 1u128 << 80);
+    assert_eq!(restored.data[1], u128::MAX);
+    assert_eq!(restored.data[2], (u64::MAX as u128) << 64 | 0xCAFE_F00D);
+    assert_eq!(restored.to_bytes(), original.to_bytes());
+
+    // Serde human-readable form must match the same base64 wire (used when
+    // concepts are returned from memory_get).
+    let json = serde_json::to_value(original).expect("HVec serializes");
+    assert_eq!(json.as_str(), Some(wire.as_str()));
+    let via_serde: HVec10240 = serde_json::from_value(json).expect("HVec deserializes");
+    assert_eq!(via_serde.data[0], 1u128 << 80);
+}


### PR DESCRIPTION
## Summary

GOAP-orchestrated Wave 32 Phase 1 continuation (swarm of agents) implementing five queued actions:

1. **`enforce_authoritative_persistence_and_ann_revision` (ADR-0093)** — Schema v11 `csm_namespace_meta` revisions; `IndexSnapshotEnvelope` (magic, revision, backend fingerprint, FNV checksum); durable inject/delete before in-memory mutation; load rejects stale/legacy/mismatched ANN snapshots; `load_merge` rebuilds union.
2. **`bulk_load_associations_and_release_state_locks` (ADR-0093)** — `load_all_associations` single-query bulk load; I/O outside singularity locks.
3. **`fix_mcp_hypervector_wire_format` (ADR-0094)** — MCP `vector` is base64 of 1280-byte HVec; legacy 160 u64-half path retained; high-bit round-trips.
4. **`correct_benchmark_metric_definitions` (ADR-0095)** — Separate hit rate vs multi-label recall; log₂ NDCG; abstention uses `should_abstain`.
5. **`complete_workspace_ci_and_supply_chain_matrix` (ADR-0095)** — `csm-chaos` matrix entry; `cargo deny` job; benchmark workspace unit tests in CI.

## Test plan

- [x] `cargo clippy -- -D warnings` (+ `--features mcp`)
- [x] `cargo test --lib`
- [x] `cargo test --test ann_revision_envelope`
- [x] `cargo test --test framework_lifecycle --test persistence_crud --test migration_errors`
- [x] `cargo test --test mcp_integration --features mcp`
- [x] `cargo test --manifest-path benchmarks/Cargo.toml`
- [x] ADR parity + skill-format validation
- [ ] Full GitHub Actions CI green on this PR

## Plans

Updated `plans/GOAP_STATE.md` and `plans/ACTIONS.md` (five actions → complete). Remaining Wave 32: skill behavioral evals, fuzz short/scheduled runs, feature contracts, ownership consolidation, evidence tiers.