### PR TITLE
docs: harden instructions from open PR triage learnings

### DIFF
--- a/.agents/skills/git-workflow/SKILL.md
+++ b/.agents/skills/git-workflow/SKILL.md
@@ -77,12 +77,26 @@ gh pr list --state open --json number,reviewDecision \
 
 **Merge order rules:**
 1. Check `mergeable` status FIRST — resolve conflicts before CI fixes
-2. Independent PRs (docs, CI-only) merge first
+2. Independent green PRs (docs, pure perf with all checks green) merge first
 3. Foundation PRs (lints, commitlint config) merge before dependent PRs
 4. Feature PRs that touch the same files go last
 5. After each merge, rebase remaining PRs on updated main
+6. Never `gh pr merge --auto` when clearing multiple PRs (rebase loop)
 
 **Never skip:** A PR showing `MERGEABLE` in the API can still have conflicts after other PRs merge. Re-check after each merge.
+
+## Jules / bot PR hygiene
+
+- **Empty research PRs**: if `gh pr diff --name-only` is empty (0 files), close as
+  no-op — do not spend mutation/CI budget.
+- **Re-diff vs `origin/main` before merge**: Jules can force-push after a human/agent
+  fix and silently drop sibling merges (e.g. remove Rayon from `probe_batch`).
+  Always: `git diff --stat origin/main...HEAD` and skim for unexpected reverts.
+- **Commitlint full range**: CI runs `commitlint --from base --to head`. One early
+  bad scope (`perf(ops):`) fails even if later commits are valid. Squash/reword;
+  validate with `npx commitlint --from origin/main --to HEAD --verbose`.
+- **Invalid scopes are not inventable**: use only `commitlint.config.cjs` `scope-enum`
+  (e.g. `framework`, not `ops`; `docs` without a fake `plans` scope).
 
 ## Merging Multiple PRs (Sequential Merge Protocol)
 

--- a/.agents/skills/github-ci-guardrails/SKILL.md
+++ b/.agents/skills/github-ci-guardrails/SKILL.md
@@ -7,5 +7,31 @@ description: Validate merge readiness with atomic commits and GitHub Actions che
 
 1. Ensure change set is one logical unit (atomic commit).
 2. Run local gates from `references/local-gates.md`.
-3. Validate GitHub checks with `references/gh-ci-truth.md`.
-4. If checks fail, report failing job and log URL.
+3. **Commitlint full PR range** before push:
+   `npx commitlint --from origin/main --to HEAD --verbose`
+4. Validate GitHub checks with `references/gh-ci-truth.md`.
+5. If checks fail, report failing job and log URL; map failure class via
+   `references/ci-pitfalls-pr-triage.md` (commitlint scope, mutation surface,
+   clippy `duplicated_attributes`, Jules force-push regression).
+6. Do not claim green until `gh pr checks` shows no failures.
+
+## Mutation gate (fast in-diff)
+
+- Score = killed / (killed + missed); threshold typically 85% (`MUTATION_THRESHOLD`).
+- **Minimize unrelated churn** in the PR diff — cosmetic rewrites of adjacent
+  functions put them in the mutant set (e.g. `import_json -> Ok(1)` survives a
+  test that only imports one concept).
+- **Kill comparison boundary mutants** when using `select_nth_unstable_by(k)`:
+  test the `len == k` path so `>` → `>=` panics and is caught.
+- **CLI async entry points** (`run_query -> Ok(())`) are usually unkillable under
+  `--lib`-only mutation CI; prefer exclude in `scripts/mutation_test.sh` with a
+  one-line rationale, not path-excluding whole production modules.
+
+## Pre-merge re-check (multi-PR or bot PRs)
+
+```bash
+git fetch origin main
+git diff --stat origin/main...HEAD   # unexpected reverts?
+npx commitlint --from origin/main --to HEAD --verbose
+gh pr checks <n>
+```

--- a/.agents/skills/github-ci-guardrails/references/ci-pitfalls-pr-triage.md
+++ b/.agents/skills/github-ci-guardrails/references/ci-pitfalls-pr-triage.md
@@ -1,0 +1,23 @@
+# CI pitfalls — PR triage & mutation (2026-07)
+
+Compact map from failing job → likely cause → fix. Use after open-PR sweeps
+or Jules bot PRs. Broader Wave 32 wasm/fuzz notes may live in agent docs if present.
+
+| Failure | Likely cause | Fix |
+|---------|--------------|-----|
+| **commitlint** | Scope not in `scope-enum` (`ops`, `plans`, …); bad early commit in range | Squash/reword to allowed scope; `npx commitlint --from origin/main --to HEAD` |
+| **lint / clippy** | `duplicated_attributes`: `#![cfg(test)]` in file also loaded via `#[cfg(test)] mod` | Drop inner `#![cfg(test)]`; keep mod-level gate in `lib.rs` |
+| **mutation-test** score &lt; threshold | Unrelated functions in git diff; `Ok(1)` survives N=1 import test; `>` vs `>=` on top-k | Restore unrelated lines to main; assert multi/empty counts; boundary test `len == top_k`; exclude unkillable CLI entry (`run_query`) |
+| **mutation-test** timeouts | Pathological mutants or heavy modules in surface | Tighten excludes with rationale; do not blank-path-exclude production code |
+| **Empty Jules PR** | Research-sim task pushed 0 files | Close as no-op; optional issue for research notes |
+| **Regressed after “green” fix** | Jules force-push rewrote branch | Re-diff `origin/main...HEAD`; restore sibling merges; force-with-lease clean tip |
+
+## Allowed commitlint scopes (canonical)
+
+See `commitlint.config.cjs` `scope-enum`. Common valid: `framework`, `retrieval`,
+`ci`, `docs`, `workspace`. Prefer bare `docs:` over inventing `docs(plans)`.
+
+## Merge order
+
+Green independent first → CI fixes → dependent features. One squash-merge at a
+time; never multi-PR `--auto` when base must be current.

--- a/.agents/skills/github-ci-guardrails/references/local-gates.md
+++ b/.agents/skills/github-ci-guardrails/references/local-gates.md
@@ -24,3 +24,11 @@ When adding new workspace crates or package scopes, update `commitlint.config.cj
 - Valid scopes: singularity, reservoir, framework, persistence, cli, cli-npm, wasm,
   retrieval, embedding, mcp, observability, bridge, duckdb, chaos, memory, core,
   traits, deps, ci, codacy, docs, release, clippy, lints, build, loc-gate, workspace
+
+**Always validate the full PR range** (CI does this; last-commit-only is insufficient):
+
+```bash
+npx commitlint --from origin/main --to HEAD --verbose
+```
+
+Do not invent scopes (`ops`, `plans`, `goap` unless added to the enum first).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,12 @@ Build and maintain `chaotic_semantic_memory` as a production Rust crate for AI m
     creates a rebase loop (merge A → B is stale → auto-merge cancelled).
     Instead: merge one PR → rebase next → wait for CI → merge → repeat.
 
+    **Jules / multi-PR extras** (see `.agents/skills/git-workflow/SKILL.md`):
+    - Close empty research PRs (0 files) without CI thrash.
+    - Before merge, `git diff --stat origin/main...HEAD` to catch bot force-push
+      reverts of already-merged work.
+    - Commitlint: full range `npx commitlint --from origin/main --to HEAD`.
+
 19. **Fix ALL issues (including pre-existing)** — CI must pass completely:
     - New failures: Fix immediately
     - Pre-existing warnings: Fix before claiming completion
@@ -219,8 +225,11 @@ Before starting any task, verify:
 
 Before completing any task, verify:
 - [ ] **Branch created (NOT main)** — never push directly to protected branch
+- [ ] **Commitlint full range** — `npx commitlint --from origin/main --to HEAD --verbose`
 - [ ] **PR created and CI passing** — merge only after green checks
 - [ ] All validation gates pass (check, test, fmt, clippy)
+- [ ] **CI pitfall scan** when touching mutation/TTL/CLI/Jules PRs — see
+      `.agents/skills/github-ci-guardrails/references/ci-pitfalls-pr-triage.md`
 - [ ] **Coverage gate** — test:source ratio >= 90% (or improving)
 - [ ] **Real usage validated** — CLI workflow, skill-memory db, file persistence
 - [ ] CI workflow passes

--- a/agents-docs/hard-constraints.md
+++ b/agents-docs/hard-constraints.md
@@ -25,6 +25,11 @@
   and address failures (upgrade deps or document ignores in `deny.toml`).
 - **Commitlint scopes must be kept current.** When adding a new workspace crate
   or package scope, also add the scope to `commitlint.config.cjs` `scope-enum` list.
+  Validate the **full PR range** before push (`npx commitlint --from origin/main --to HEAD`).
+- **Mutation in-diff discipline:** do not expand PR surface with unrelated
+  rewrites (score is scored on the git diff). Prefer kill tests or justified
+  `scripts/mutation_test.sh` excludes over path-excluding production modules.
+  Pitfalls: `.agents/skills/github-ci-guardrails/references/ci-pitfalls-pr-triage.md`.
 - **Version numbers must be synchronized across all files before release.**
   Run `scripts/verify-version-sync.sh` to verify. Files checked:
   - `Cargo.toml` - `version = "X.Y.Z"`

--- a/progress/LEARNINGS.md
+++ b/progress/LEARNINGS.md
@@ -125,6 +125,12 @@
 - **Jules bot commits may not follow conventional format**: Added an ignore rule
   for PR merge commits that have no conventional prefix. This prevents CI failures
   on main after bot-authored PRs are merged.
+- **Validate the full branch range**, not just the last commit: CI runs
+  `commitlint --from base --to head`. Prefer bare `docs:` over inventing scopes
+  (`docs(plans)` fails until `plans` is enum-listed).
+- Instruction home for multi-PR / Jules / mutation pitfalls:
+  `.agents/skills/git-workflow/SKILL.md` and
+  `.agents/skills/github-ci-guardrails/references/ci-pitfalls-pr-triage.md`.
 
 ### Supply Chain Advisory Discipline
 - **Run `cargo deny check` before releases and after dependency upgrades**:

--- a/scripts/mutation_test.sh
+++ b/scripts/mutation_test.sh
@@ -154,6 +154,8 @@ EXCLUDE_ARGS=(
   --exclude "src/mcp/*"
   --exclude "src/persistence_wasm.rs"
   --exclude-re "replace > with >= in <impl Reranker for MmrReranker>::rerank"
+  # CLI entry points: async I/O + side effects; --lib mutation cannot kill
+  # "replace run_query -> Result<()> with Ok(())" without integration fixtures.
   --exclude-re "run_query"
   --exclude-re "replace run_query"
 )


### PR DESCRIPTION
## Summary
Encodes durable patterns from the 2026-07-18 open-PR triage so agents do not re-learn them from `LEARNINGS.md` alone.

## What changed
| Surface | Addition |
|---------|----------|
| `git-workflow` skill | Jules empty PRs, force-push re-diff, commitlint full range, no invent scopes |
| `github-ci-guardrails` skill | Mutation surface rules + pre-merge re-check |
| **New** `ci-pitfalls-pr-triage.md` | Failure class → fix table |
| `local-gates.md` | Full-range commitlint command |
| `AGENTS.md` | Merge extras + checklist commitlint/pitfalls |
| `hard-constraints.md` | Mutation in-diff + commitlint range |
| `mutation_test.sh` | Rationale comment for `run_query` exclude |
| `LEARNINGS.md` | Pointers to instruction homes |

## Why
LEARNINGS already captured session detail; instructions now **enforce** multi-PR/Jules/mutation discipline on every session.

## Test plan
- [x] Docs/skills/scripts comments only
- [x] `npx commitlint --from origin/main --to HEAD`