### PR TITLE
perf(framework): framework ops issues #524–#526

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -729,7 +729,8 @@ criterion_group!(
     bench_bm25_search,
     bench_singularity_scalability,
     bench_graph_rag,
-    bench_probe_batch_comparison
+    bench_probe_batch_comparison,
+    bench_inject_concepts_batch
 );
 criterion_main!(benches);
 
@@ -785,6 +786,37 @@ fn bench_probe_batch_comparison(c: &mut Criterion) {
                         .map(|q| sing.find_similar(&ns, q, 10))
                         .collect();
                     black_box(results);
+                })
+            })
+        });
+    }
+    group.finish();
+}
+
+/// #525: inject_concepts construction+durable path at several batch sizes.
+fn bench_inject_concepts_batch(c: &mut Criterion) {
+    use chaotic_semantic_memory::prelude::*;
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let framework = rt.block_on(async {
+        ChaoticSemanticFramework::builder()
+            .without_persistence()
+            .build()
+            .await
+            .unwrap()
+    });
+
+    let mut group = c.benchmark_group("inject_concepts_batch");
+    group.sample_size(10);
+
+    for size in [1, 10, 100, 1000] {
+        let batch: Vec<(String, HVec10240)> = (0..size)
+            .map(|i| (format!("inj_{size}_{i}"), HVec10240::random()))
+            .collect();
+        group.bench_function(format!("batch_{size}"), |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    framework.inject_concepts(black_box(&batch)).await.unwrap();
                 })
             })
         });

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -399,6 +399,10 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 
 - impl ChaoticSemanticFramework
 
+### src/framework_ops_import.rs
+
+- impl ChaoticSemanticFramework
+
 ### src/framework_persistence.rs
 
 - impl ChaoticSemanticFramework
@@ -2922,6 +2926,21 @@ impl ChaoticSemanticFramework {
     pub fn associate_many(&self, associations: &[(String, String, f32)]) -> Result<()>;
     pub fn probe_batch(&self, queries: &[HVec10240], top_k: usize) -> Result<Vec<Vec<(String, f32)>>>;
     pub fn probe_batch_cached(&self, queries: &[HVec10240], top_k: usize) -> Result<Vec<Arc<[(String, f32)]>>>;
+    pub fn update_concept_vector(&self, id: &str, vector: HVec10240) -> Result<()>;
+    pub fn update_concept_metadata(&self, id: &str, metadata: std::collections::HashMap<String, serde_json::Value>) -> Result<()>;
+    pub fn disassociate(&self, from: &str, to: &str) -> Result<()>;
+    pub fn clear_associations(&self, id: &str) -> Result<()>;
+    pub fn clear_similarity_cache(&self);
+    pub fn bundle_concepts_strict(&self, ids: &[String]) -> Result<HVec10240>;
+}
+```
+
+## src/framework_ops_import.rs
+
+### impl ChaoticSemanticFramework
+
+```rust
+impl ChaoticSemanticFramework {
     pub fn export_json(&self, path: &str) -> Result<()>;
     pub fn import_json(&self, path: &str, merge: bool) -> Result<usize>;
     pub fn export_binary(&self, path: &str) -> Result<()>;
@@ -2929,12 +2948,6 @@ impl ChaoticSemanticFramework {
     pub fn backup(&self, path: &str) -> Result<()>;
     pub fn restore(&self, path: &str) -> Result<()>;
     pub fn concept_history(&self, id: &str, limit: usize) -> Result<Vec<crate::singularity::ConceptVersion>>;
-    pub fn update_concept_vector(&self, id: &str, vector: HVec10240) -> Result<()>;
-    pub fn update_concept_metadata(&self, id: &str, metadata: std::collections::HashMap<String, serde_json::Value>) -> Result<()>;
-    pub fn disassociate(&self, from: &str, to: &str) -> Result<()>;
-    pub fn clear_associations(&self, id: &str) -> Result<()>;
-    pub fn clear_similarity_cache(&self);
-    pub fn bundle_concepts_strict(&self, ids: &[String]) -> Result<HVec10240>;
 }
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -399,6 +399,10 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 
 - impl ChaoticSemanticFramework
 
+### src/framework_ops_import.rs
+
+- impl ChaoticSemanticFramework
+
 ### src/framework_persistence.rs
 
 - impl ChaoticSemanticFramework

--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -4883,3 +4883,18 @@ actions:
       empty #520, fixed CI on #527 and merged, rewrote #529 after Jules
       regression and merged when green. Updated GOAP_STATE, PROGRESS, LEARNINGS.
 
+  - name: framework_ops_perf_524_525_526
+    preconditions:
+      tests_passing: true
+    effects:
+      issue_524_done: true
+      issue_525_done: true
+      issue_526_done: true
+    cost: 9
+    status: complete
+    priority: P1
+    wave: "framework-ops-perf"
+    description: |
+      #524 single namespace clone, #525 parallel inject construction,
+      #526 import inject/associate split write locks. One PR.
+

--- a/plans/GOAP_ORCHESTRATOR.md
+++ b/plans/GOAP_ORCHESTRATOR.md
@@ -1,47 +1,48 @@
-# GOAP Orchestrator State — Open PR Triage 2026-07-18
+# GOAP Orchestrator — Open Issues Wave 2026-07-18
 
-## Target State — ACHIEVED
-- All open PRs either merged (green + useful) or closed (empty/obsolete)
-- GOAP_STATE / ACTIONS / PROGRESS / LEARNINGS updated
+## Target state
+- Issues #524, #525, #526 closed via single PR
+- All tests pass; framework_ops.rs ≤ 500 LOC
+- GOAP_STATE / PROGRESS updated
 
-## Final Outcomes
+## World scan
+| Issue | Title | Module | Cost |
+|-------|-------|--------|------|
+| #524 | redundant `namespace.read()` | `framework_ops` | 2 |
+| #525 | parallelize `inject_concepts` build | `framework_ops` | 3 |
+| #526 | shorten import association write lock | `framework_ops` | 4 |
 
-| PR | Title | Outcome |
-|----|-------|---------|
-| #528 | BM25 hot loop | **MERGED** `f8b2bbc` |
-| #527 | Rayon probe_batch | **MERGED** `1e94c11` |
-| #520 | LSH research simulate | **CLOSED** empty no-op |
-| #529 | hybrid merge_results top-k | **MERGED** `d2db671` (closes #523) |
+All three touch `src/framework_ops.rs` only → **single feature branch / one PR**.
 
-## Merge order executed
-```
-528 → close 520 → fix+CI 527 → merge 527 → rewrite+CI 529 → merge 529 → docs
-```
+## Action plan (dependency order)
 
-## GOAP actions
+### A1: `fix_redundant_namespace_reads` (#524)
+- **Effect**: one `namespace` clone (or single guard) per op; no dual `read().await`
+- **Why clone not guard**: tokio `RwLockReadGuard` is not held across `.await` (Send)
+- **Funcs**: `associate_many`, `update_concept_vector`, `update_concept_metadata`,
+  `disassociate`, `clear_associations`, import paths
 
-| Action | Status |
-|--------|--------|
-| merge_pr_528_bm25_hot_loop | complete |
-| close_pr_520_empty_research | complete |
-| fix_pr_527_ci_blockers | complete |
-| merge_pr_527_probe_batch_rayon | complete |
-| fix_merge_pr_529_hybrid_topk | complete |
-| update_progress_and_learnings | complete |
+### A2: `parallel_inject_concepts_build` (#525)
+- **Effect**: Rayon `par_iter` construction before `durable_inject_concepts`
+- **cfg**: `parallel` + non-wasm; serial fallback otherwise
+- **Note**: write lock remains inside `durable_inject_concepts` (post-build)
 
-## PR #529 repair notes
-Jules force-pushed a regression that reverted probe_batch Rayon from #527.
-Clean rewrite from `origin/main`: fold min/max + partial top-k + boundary
-test + `run_query` mutation exclude.
+### A3: `shorten_import_write_locks` (#526)
+- **Effect**: validate concepts outside lock; phase-1 inject write; phase-2 associate write
+- **TOCTOU**: documented; invalid assoc still skipped with `warn!` (existing semantics)
+- **DRY**: shared `apply_import_payload` helper for json/binary
 
-## Remaining after triage
-- Issues #524–#526 (framework perf) — not yet PRs
-- Wave 33 ownership / evidence / agent hygiene
+### A4: tests + bench + state
+- Unit tests in `framework_ops_tests.rs`
+- Optional criterion group for inject batch sizes
+- Update GOAP_STATE / PROGRESS / close issues via PR body `Fixes`
+
+## Branch
+`feat/framework-ops-perf-524-525-526`
 
 ## Swarm
-| Agent | Role | Result |
-|-------|------|--------|
-| orchestrator | GOAP lead | plan + merges + state |
-| agent-527 | fix CI | green, merged |
-| agent-529 | first fix | good then Jules overwrote |
-| orchestrator | 529 rewrite | `f6d54bb` → merge `d2db671` |
+| Agent | Task |
+|-------|------|
+| orchestrator | plan, integrate, PR |
+| implement | framework_ops + tests (same file → single agent) |
+| validate | cargo test/clippy/fmt |

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -1760,7 +1760,7 @@ world_state:
   # Open PR Triage (GOAP orchestrator + swarm) 2026-07-18
   # plans/GOAP_ORCHESTRATOR.md
   # ═══════════════════════════════════════════════════════
-  action_last_completed: open_pr_triage_2026_07_18
+  # action_last_completed: open_pr_triage_2026_07_18  # superseded
   open_pr_triage_2026_07_18:
     started_at: "2026-07-18"
     completed_at: "2026-07-18"
@@ -1791,3 +1791,19 @@ world_state:
     remaining_open_issues_perf: [524, 525, 526]
     learnings_recorded: true
     progress_recorded: true
+
+  # ═══════════════════════════════════════════════════════
+  # Framework ops perf issues #524-#526 (2026-07-18)
+  # ═══════════════════════════════════════════════════════
+  action_last_completed: framework_ops_perf_524_525_526_2026_07_18
+  framework_ops_perf_524_525_526:
+    branch: feat/framework-ops-perf-524-525-526
+    issues: [524, 525, 526]
+    changes:
+      - "namespace clone once via namespace() for dual-read ops (#524)"
+      - "inject_concepts Rayon construction before durable write lock (#525)"
+      - "import json/binary: split inject vs associate write holds (#526)"
+    files:
+      - src/framework_ops.rs
+      - src/framework_ops_tests.rs
+      - benches/benchmark.rs

--- a/progress/PROGRESS.md
+++ b/progress/PROGRESS.md
@@ -1,3 +1,21 @@
+## 2026-07-18: Framework ops perf (#524–#526)
+
+### Summary
+Single PR implementing all open GitHub issues under GOAP orchestration:
+namespace single-clone (#524), parallel `inject_concepts` build (#525),
+split import write locks (#526).
+
+### Changes
+- `self.namespace().await` once per op (tokio guard cannot cross await)
+- Rayon `par_iter` ConceptBuilder construction before `durable_inject_concepts`
+- Shared `apply_import_payload` / `clear_for_import_replace` / `persist_import`
+- Tests + `bench_inject_concepts_batch` (1/10/100/1000)
+
+### Issues
+Fixes #524, #525, #526
+
+---
+
 ## 2026-07-18: Open PR Triage (GOAP + Swarm)
 
 ### Summary

--- a/src/framework_ops.rs
+++ b/src/framework_ops.rs
@@ -1,23 +1,18 @@
 #![allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
-use crate::export_payload::{BinaryExportPayload, ExportPayload, unix_now_secs};
+use crate::export_payload::unix_now_secs;
 use crate::framework::ChaoticSemanticFramework;
 use crate::framework_events::MemoryEvent;
-use crate::framework_validation::{MAX_IMPORT_SIZE, validate_path};
 use crate::singularity::ConceptBuilder;
-use bincode::Options;
 use csm_core::error::Result;
 use csm_core::hyperdim::HVec10240;
 use std::sync::Arc;
-use tokio::fs;
-use tracing::{instrument, warn};
+use tracing::instrument;
 
 // Singularity is Send + Sync for Rayon probe/inject construction (#525 / probe_batch).
 const _: () = {
     const fn assert_sync_send<T: Sync + Send>() {}
     assert_sync_send::<crate::singularity::Singularity>();
 };
-
-const MAX_HISTORY_LIMIT: usize = 1000;
 
 impl ChaoticSemanticFramework {
     /// Batch inject: build concepts (optionally parallel) then durable commit.
@@ -162,231 +157,6 @@ impl ChaoticSemanticFramework {
             }
         };
         Ok(out)
-    }
-
-    /// Export memory state to JSON file.
-    #[instrument(err, skip(self), fields(path))]
-    pub async fn export_json(&self, path: &str) -> Result<()> {
-        let validated_path = validate_path(path)?;
-
-        let payload = {
-            let sing = self.singularity.read().await;
-            let ns = self.namespace.read().await;
-            ExportPayload {
-                version: env!("CARGO_PKG_VERSION").to_string(),
-                exported_at: unix_now_secs(),
-                concepts: sing.all_concepts(&ns),
-                associations: sing.all_associations(&ns),
-            }
-        };
-        let data = serde_json::to_vec_pretty(&payload)?;
-        fs::write(validated_path, data).await?;
-        Ok(())
-    }
-
-    /// Securely read a file into bytes with size limit (CWE-770).
-    pub(crate) async fn secure_read_file(
-        &self,
-        path: &std::path::Path,
-        limit: u64,
-    ) -> Result<Vec<u8>> {
-        let metadata = fs::metadata(path).await?;
-        if metadata.len() > limit {
-            return Err(csm_core::error::MemoryError::InvalidInput {
-                field: "file_size".to_string(),
-                reason: format!(
-                    "File size {} exceeds maximum allowed size {}",
-                    metadata.len(),
-                    limit
-                ),
-            });
-        }
-        Ok(fs::read(path).await?)
-    }
-
-    /// #526: apply import payload with short write holds.
-    ///
-    /// Phase 1 (write): inject concepts only.  
-    /// Phase 2 (write): associations only so readers can run between phases.
-    /// TOCTOU: a concurrent delete between phases may cause associate to fail;
-    /// invalid associations are skipped with `warn!` (pre-existing semantics).
-    async fn apply_import_payload(
-        &self,
-        payload: &ExportPayload,
-    ) -> Result<Vec<(String, String, f32)>> {
-        for concept in &payload.concepts {
-            self.validate_concept(concept)?;
-        }
-        let ns = self.namespace().await;
-
-        {
-            let mut sing = self.singularity.write().await;
-            for concept in &payload.concepts {
-                sing.inject(&ns, concept.clone())?;
-            }
-        }
-
-        let mut associations = Vec::with_capacity(payload.associations.len());
-        {
-            let mut sing = self.singularity.write().await;
-            for (from, to, strength) in &payload.associations {
-                match sing.associate(&ns, from, to, *strength) {
-                    Ok(()) => associations.push((from.clone(), to.clone(), *strength)),
-                    Err(error) => {
-                        warn!(
-                            from_id = %from,
-                            to_id = %to,
-                            strength = *strength,
-                            error = %error,
-                            "skipping invalid association during import"
-                        );
-                    }
-                }
-            }
-        }
-        Ok(associations)
-    }
-
-    async fn clear_for_import_replace(&self) -> Result<()> {
-        let ns = self.namespace().await;
-        {
-            let mut sing = self.singularity.write().await;
-            sing.clear(&ns);
-        }
-        if let Some(ref persistence) = self.persistence {
-            persistence.clear_namespace(&ns).await?;
-        }
-        Ok(())
-    }
-
-    async fn persist_import(
-        &self,
-        payload: &ExportPayload,
-        associations: &[(String, String, f32)],
-    ) -> Result<()> {
-        if let Some(ref persistence) = self.persistence {
-            let ns = self.namespace().await;
-            persistence.save_concepts(&ns, &payload.concepts).await?;
-            persistence.save_associations(&ns, associations).await?;
-        }
-        Ok(())
-    }
-
-    /// Import memory state from JSON file.
-    #[instrument(err, skip(self), fields(path, merge))]
-    pub async fn import_json(&self, path: &str, merge: bool) -> Result<usize> {
-        let validated_path = validate_path(path)?;
-        let bytes = self
-            .secure_read_file(&validated_path, MAX_IMPORT_SIZE)
-            .await?;
-        let payload: ExportPayload = serde_json::from_slice(&bytes)?;
-
-        if !merge {
-            self.clear_for_import_replace().await?;
-        }
-        let valid_associations = self.apply_import_payload(&payload).await?;
-        self.persist_import(&payload, &valid_associations).await?;
-        Ok(payload.concepts.len())
-    }
-
-    /// Export memory state to binary file.
-    #[allow(clippy::significant_drop_tightening)]
-    #[instrument(err, skip(self), fields(path))]
-    pub async fn export_binary(&self, path: &str) -> Result<()> {
-        let validated_path = validate_path(path)?;
-
-        let payload = {
-            let sing = self.singularity.read().await;
-            let ns = self.namespace.read().await;
-            let json_payload = ExportPayload {
-                version: env!("CARGO_PKG_VERSION").to_string(),
-                exported_at: unix_now_secs(),
-                concepts: sing.all_concepts(&ns),
-                associations: sing.all_associations(&ns),
-            };
-            let res = BinaryExportPayload::from(json_payload);
-            drop(sing);
-            res
-        };
-
-        let options = bincode::DefaultOptions::new().with_limit(MAX_IMPORT_SIZE);
-        let data = options.serialize(&payload).map_err(|e| {
-            csm_core::error::MemoryError::Serialization(serde_json::Error::io(
-                std::io::Error::other(e.to_string()),
-            ))
-        })?;
-        fs::write(validated_path, data).await?;
-        Ok(())
-    }
-
-    /// Import memory state from binary file.
-    #[instrument(err, skip(self), fields(path, merge))]
-    pub async fn import_binary(&self, path: &str, merge: bool) -> Result<usize> {
-        let validated_path = validate_path(path)?;
-        let bytes = self
-            .secure_read_file(&validated_path, MAX_IMPORT_SIZE)
-            .await?;
-        let options = bincode::DefaultOptions::new().with_limit(MAX_IMPORT_SIZE);
-        let binary_payload: BinaryExportPayload = options.deserialize(&bytes).map_err(|e| {
-            csm_core::error::MemoryError::InvalidInput {
-                field: "import_data".to_string(),
-                reason: format!("bincode deserialization failed: {e}"),
-            }
-        })?;
-        let payload = binary_payload.to_export_payload().map_err(|e| {
-            csm_core::error::MemoryError::InvalidInput {
-                field: "import_data".to_string(),
-                reason: format!("failed to convert binary payload: {e}"),
-            }
-        })?;
-        if !merge {
-            self.clear_for_import_replace().await?;
-        }
-        let valid_associations = self.apply_import_payload(&payload).await?;
-        self.persist_import(&payload, &valid_associations).await?;
-        Ok(payload.concepts.len())
-    }
-
-    /// Create database backup (SQLite only).
-    #[instrument(err, skip(self), fields(path))]
-    pub async fn backup(&self, path: &str) -> Result<()> {
-        let validated_path = validate_path(path)?;
-        if let Some(ref persistence) = self.persistence {
-            persistence
-                .backup(validated_path.to_str().unwrap_or(path))
-                .await?;
-        }
-        Ok(())
-    }
-
-    /// Restore from database backup (SQLite only).
-    #[instrument(err, skip(self), fields(path))]
-    pub async fn restore(&self, path: &str) -> Result<()> {
-        let validated_path = validate_path(path)?;
-        if let Some(ref persistence) = self.persistence {
-            persistence
-                .restore(validated_path.to_str().unwrap_or(path))
-                .await?;
-            self.load_replace().await?;
-        }
-        Ok(())
-    }
-
-    /// Get version history for a concept.
-    #[instrument(err, skip(self), fields(id, limit))]
-    pub async fn concept_history(
-        &self,
-        id: &str,
-        mut limit: usize,
-    ) -> Result<Vec<crate::singularity::ConceptVersion>> {
-        if limit > MAX_HISTORY_LIMIT {
-            limit = MAX_HISTORY_LIMIT;
-        }
-        if let Some(ref persistence) = self.persistence {
-            let ns = self.namespace().await;
-            return persistence.get_concept_history(&ns, id, limit).await;
-        }
-        Ok(Vec::new())
     }
 
     /// Update a concept's vector.

--- a/src/framework_ops.rs
+++ b/src/framework_ops.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use tokio::fs;
 use tracing::{instrument, warn};
 
-// Verify Singularity is Send + Sync for concurrent Rayon execution
+// Singularity is Send + Sync for Rayon probe/inject construction (#525 / probe_batch).
 const _: () = {
     const fn assert_sync_send<T: Sync + Send>() {}
     assert_sync_send::<crate::singularity::Singularity>();
@@ -20,22 +20,40 @@ const _: () = {
 const MAX_HISTORY_LIMIT: usize = 1000;
 
 impl ChaoticSemanticFramework {
-    /// Batch inject multiple concepts into memory.
-    // Singularity write lock needed for batch inject
+    /// Batch inject: build concepts (optionally parallel) then durable commit.
+    /// Construction runs **before** any write lock (`durable_inject_concepts`).
     #[instrument(err, skip(self, concepts))]
     pub async fn inject_concepts(&self, concepts: &[(String, HVec10240)]) -> Result<()> {
         self.validate_batch_size(concepts.len())?;
         if concepts.is_empty() {
             return Ok(());
         }
-        let mut to_save = Vec::with_capacity(concepts.len());
-        for (id, vector) in concepts {
-            Self::validate_concept_id(id)?;
-            let concept = ConceptBuilder::new(id.clone())
-                .with_vector(*vector)
-                .build()?;
-            to_save.push(concept);
-        }
+
+        // #525: parallel CPU-bound ConceptBuilder work outside the write lock.
+        #[cfg(all(not(target_arch = "wasm32"), feature = "parallel"))]
+        let to_save: Vec<_> = {
+            use rayon::prelude::*;
+            concepts
+                .par_iter()
+                .map(|(id, vector)| {
+                    Self::validate_concept_id(id)?;
+                    ConceptBuilder::new(id.clone()).with_vector(*vector).build()
+                })
+                .collect::<Result<Vec<_>>>()?
+        };
+        #[cfg(any(target_arch = "wasm32", not(feature = "parallel")))]
+        let to_save: Vec<_> = {
+            let mut out = Vec::with_capacity(concepts.len());
+            for (id, vector) in concepts {
+                Self::validate_concept_id(id)?;
+                out.push(
+                    ConceptBuilder::new(id.clone())
+                        .with_vector(*vector)
+                        .build()?,
+                );
+            }
+            out
+        };
 
         #[cfg(not(target_arch = "wasm32"))]
         let p_start = std::time::Instant::now();
@@ -58,9 +76,10 @@ impl ChaoticSemanticFramework {
         if associations.is_empty() {
             return Ok(());
         }
+        // #524: clone namespace once (tokio guard cannot cross await).
+        let ns = self.namespace().await;
         {
             let mut sing = self.singularity.write().await;
-            let ns = self.namespace.read().await;
             for (from, to, strength) in associations {
                 Self::validate_concept_id(from)?;
                 Self::validate_concept_id(to)?;
@@ -70,7 +89,6 @@ impl ChaoticSemanticFramework {
         }
 
         if let Some(ref persistence) = self.persistence {
-            let ns = self.namespace.read().await;
             persistence.save_associations(&ns, associations).await?;
         }
 
@@ -165,7 +183,8 @@ impl ChaoticSemanticFramework {
         fs::write(validated_path, data).await?;
         Ok(())
     }
-    /// Securely read a file into bytes with size limit to prevent OOM/TOCTOU (CWE-770).
+
+    /// Securely read a file into bytes with size limit (CWE-770).
     pub(crate) async fn secure_read_file(
         &self,
         path: &std::path::Path,
@@ -182,8 +201,75 @@ impl ChaoticSemanticFramework {
                 ),
             });
         }
-        let buffer = fs::read(path).await?;
-        Ok(buffer)
+        Ok(fs::read(path).await?)
+    }
+
+    /// #526: apply import payload with short write holds.
+    ///
+    /// Phase 1 (write): inject concepts only.  
+    /// Phase 2 (write): associations only so readers can run between phases.
+    /// TOCTOU: a concurrent delete between phases may cause associate to fail;
+    /// invalid associations are skipped with `warn!` (pre-existing semantics).
+    async fn apply_import_payload(
+        &self,
+        payload: &ExportPayload,
+    ) -> Result<Vec<(String, String, f32)>> {
+        for concept in &payload.concepts {
+            self.validate_concept(concept)?;
+        }
+        let ns = self.namespace().await;
+
+        {
+            let mut sing = self.singularity.write().await;
+            for concept in &payload.concepts {
+                sing.inject(&ns, concept.clone())?;
+            }
+        }
+
+        let mut associations = Vec::with_capacity(payload.associations.len());
+        {
+            let mut sing = self.singularity.write().await;
+            for (from, to, strength) in &payload.associations {
+                match sing.associate(&ns, from, to, *strength) {
+                    Ok(()) => associations.push((from.clone(), to.clone(), *strength)),
+                    Err(error) => {
+                        warn!(
+                            from_id = %from,
+                            to_id = %to,
+                            strength = *strength,
+                            error = %error,
+                            "skipping invalid association during import"
+                        );
+                    }
+                }
+            }
+        }
+        Ok(associations)
+    }
+
+    async fn clear_for_import_replace(&self) -> Result<()> {
+        let ns = self.namespace().await;
+        {
+            let mut sing = self.singularity.write().await;
+            sing.clear(&ns);
+        }
+        if let Some(ref persistence) = self.persistence {
+            persistence.clear_namespace(&ns).await?;
+        }
+        Ok(())
+    }
+
+    async fn persist_import(
+        &self,
+        payload: &ExportPayload,
+        associations: &[(String, String, f32)],
+    ) -> Result<()> {
+        if let Some(ref persistence) = self.persistence {
+            let ns = self.namespace().await;
+            persistence.save_concepts(&ns, &payload.concepts).await?;
+            persistence.save_associations(&ns, associations).await?;
+        }
+        Ok(())
     }
 
     /// Import memory state from JSON file.
@@ -196,54 +282,14 @@ impl ChaoticSemanticFramework {
         let payload: ExportPayload = serde_json::from_slice(&bytes)?;
 
         if !merge {
-            {
-                let mut sing = self.singularity.write().await;
-                let ns = self.namespace.read().await;
-                sing.clear(&ns);
-            }
-            if let Some(ref persistence) = self.persistence {
-                let ns = self.namespace.read().await;
-                persistence.clear_namespace(&ns).await?;
-            }
+            self.clear_for_import_replace().await?;
         }
-
-        // Acquire write lock, inject concepts + build associations list, then release
-        let valid_associations = {
-            let mut sing = self.singularity.write().await;
-            let ns = self.namespace.read().await;
-            let mut associations = Vec::with_capacity(payload.associations.len());
-            for concept in &payload.concepts {
-                self.validate_concept(concept)?;
-                sing.inject(&ns, concept.clone())?;
-            }
-            for (from, to, strength) in &payload.associations {
-                match sing.associate(&ns, from, to, *strength) {
-                    Ok(()) => associations.push((from.clone(), to.clone(), *strength)),
-                    Err(error) => {
-                        warn!(
-                            from_id = %from,
-                            to_id = %to,
-                            strength = *strength,
-                            error = %error,
-                            "skipping invalid association during import_json"
-                        );
-                    }
-                }
-            }
-            associations
-        }; // Lock released here
-        // Persist concepts and associations (no lock needed)
-        if let Some(ref persistence) = self.persistence {
-            let ns = self.namespace.read().await;
-            persistence.save_concepts(&ns, &payload.concepts).await?;
-            persistence
-                .save_associations(&ns, &valid_associations)
-                .await?;
-        }
+        let valid_associations = self.apply_import_payload(&payload).await?;
+        self.persist_import(&payload, &valid_associations).await?;
         Ok(payload.concepts.len())
     }
+
     /// Export memory state to binary file.
-    // Singularity read lock needed for binary export
     #[allow(clippy::significant_drop_tightening)]
     #[instrument(err, skip(self), fields(path))]
     pub async fn export_binary(&self, path: &str) -> Result<()> {
@@ -287,7 +333,6 @@ impl ChaoticSemanticFramework {
                 reason: format!("bincode deserialization failed: {e}"),
             }
         })?;
-        // Convert to regular payload
         let payload = binary_payload.to_export_payload().map_err(|e| {
             csm_core::error::MemoryError::InvalidInput {
                 field: "import_data".to_string(),
@@ -295,51 +340,10 @@ impl ChaoticSemanticFramework {
             }
         })?;
         if !merge {
-            {
-                let mut sing = self.singularity.write().await;
-                let ns = self.namespace.read().await;
-                sing.clear(&ns);
-            }
-            if let Some(ref persistence) = self.persistence {
-                let ns = self.namespace.read().await;
-                persistence.clear_namespace(&ns).await?;
-            }
+            self.clear_for_import_replace().await?;
         }
-        // Acquire write lock, inject concepts + build associations list, then release
-        let valid_associations = {
-            let mut sing = self.singularity.write().await;
-            let ns = self.namespace.read().await;
-            let mut associations = Vec::with_capacity(payload.associations.len());
-            for concept in &payload.concepts {
-                self.validate_concept(concept)?;
-                sing.inject(&ns, concept.clone())?;
-            }
-            for (from, to, strength) in &payload.associations {
-                match sing.associate(&ns, from, to, *strength) {
-                    Ok(()) => associations.push((from.clone(), to.clone(), *strength)),
-                    Err(error) => {
-                        warn!(
-                            from_id = %from,
-                            to_id = %to,
-                            strength = *strength,
-                            error = %error,
-                            "skipping invalid association during import_binary"
-                        );
-                    }
-                }
-            }
-            associations
-        }; // Lock released here
-
-        // Persist concepts and associations (no lock needed)
-        if let Some(ref persistence) = self.persistence {
-            let ns = self.namespace.read().await;
-            persistence.save_concepts(&ns, &payload.concepts).await?;
-            persistence
-                .save_associations(&ns, &valid_associations)
-                .await?;
-        }
-
+        let valid_associations = self.apply_import_payload(&payload).await?;
+        self.persist_import(&payload, &valid_associations).await?;
         Ok(payload.concepts.len())
     }
 
@@ -379,7 +383,7 @@ impl ChaoticSemanticFramework {
             limit = MAX_HISTORY_LIMIT;
         }
         if let Some(ref persistence) = self.persistence {
-            let ns = self.namespace.read().await;
+            let ns = self.namespace().await;
             return persistence.get_concept_history(&ns, id, limit).await;
         }
         Ok(Vec::new())
@@ -389,15 +393,14 @@ impl ChaoticSemanticFramework {
     #[instrument(err, skip(self), fields(id))]
     pub async fn update_concept_vector(&self, id: &str, vector: HVec10240) -> Result<()> {
         Self::validate_concept_id(id)?;
+        let ns = self.namespace().await;
         let concept = {
             let mut sing = self.singularity.write().await;
-            let ns = self.namespace.read().await;
             sing.update(&ns, id, vector)?;
             sing.get(&ns, id).cloned()
         };
 
         if let (Some(concept), Some(persistence)) = (concept, &self.persistence) {
-            let ns = self.namespace.read().await;
             persistence.save_concept(&ns, &concept).await?;
         }
         self.emit_event(MemoryEvent::ConceptUpdated {
@@ -417,15 +420,14 @@ impl ChaoticSemanticFramework {
     ) -> Result<()> {
         Self::validate_concept_id(id)?;
         Self::validate_metadata_bytes(&metadata, self.config.max_metadata_bytes)?;
+        let ns = self.namespace().await;
         let concept = {
             let mut sing = self.singularity.write().await;
-            let ns = self.namespace.read().await;
             sing.update_metadata(&ns, id, metadata)?;
             sing.get(&ns, id).cloned()
         };
 
         if let (Some(concept), Some(persistence)) = (concept, &self.persistence) {
-            let ns = self.namespace.read().await;
             persistence.save_concept(&ns, &concept).await?;
         }
         self.emit_event(MemoryEvent::ConceptUpdated {
@@ -441,14 +443,13 @@ impl ChaoticSemanticFramework {
     pub async fn disassociate(&self, from: &str, to: &str) -> Result<()> {
         Self::validate_concept_id(from)?;
         Self::validate_concept_id(to)?;
+        let ns = self.namespace().await;
         {
             let mut sing = self.singularity.write().await;
-            let ns = self.namespace.read().await;
             sing.disassociate(&ns, from, to)?;
         }
 
         if let Some(persistence) = &self.persistence {
-            let ns = self.namespace.read().await;
             persistence.delete_association(&ns, from, to).await?;
         }
         self.emit_event(MemoryEvent::Disassociated {
@@ -463,14 +464,13 @@ impl ChaoticSemanticFramework {
     #[instrument(err, skip(self), fields(id))]
     pub async fn clear_associations(&self, id: &str) -> Result<()> {
         Self::validate_concept_id(id)?;
+        let ns = self.namespace().await;
         {
             let mut sing = self.singularity.write().await;
-            let ns = self.namespace.read().await;
             sing.clear_associations(&ns, id)?;
         }
 
         if let Some(persistence) = &self.persistence {
-            let ns = self.namespace.read().await;
             persistence.clear_concept_associations(&ns, id).await?;
         }
         Ok(())

--- a/src/framework_ops_import.rs
+++ b/src/framework_ops_import.rs
@@ -1,0 +1,240 @@
+//! Export, import, backup/restore, and concept history operations.
+//!
+//! Split from `framework_ops.rs` to respect the 500-LOC module ceiling.
+
+use crate::export_payload::{BinaryExportPayload, ExportPayload, unix_now_secs};
+use crate::framework::ChaoticSemanticFramework;
+use crate::framework_validation::{MAX_IMPORT_SIZE, validate_path};
+use bincode::Options;
+use csm_core::error::Result;
+use tokio::fs;
+use tracing::{instrument, warn};
+
+const MAX_HISTORY_LIMIT: usize = 1000;
+
+impl ChaoticSemanticFramework {
+    /// Export memory state to JSON file.
+    #[instrument(err, skip(self), fields(path))]
+    pub async fn export_json(&self, path: &str) -> Result<()> {
+        let validated_path = validate_path(path)?;
+
+        let payload = {
+            let sing = self.singularity.read().await;
+            let ns = self.namespace.read().await;
+            ExportPayload {
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                exported_at: unix_now_secs(),
+                concepts: sing.all_concepts(&ns),
+                associations: sing.all_associations(&ns),
+            }
+        };
+        let data = serde_json::to_vec_pretty(&payload)?;
+        fs::write(validated_path, data).await?;
+        Ok(())
+    }
+
+    /// Securely read a file into bytes with size limit (CWE-770).
+    pub(crate) async fn secure_read_file(
+        &self,
+        path: &std::path::Path,
+        limit: u64,
+    ) -> Result<Vec<u8>> {
+        let metadata = fs::metadata(path).await?;
+        if metadata.len() > limit {
+            return Err(csm_core::error::MemoryError::InvalidInput {
+                field: "file_size".to_string(),
+                reason: format!(
+                    "File size {} exceeds maximum allowed size {}",
+                    metadata.len(),
+                    limit
+                ),
+            });
+        }
+        Ok(fs::read(path).await?)
+    }
+
+    /// #526: apply import payload with short write holds.
+    ///
+    /// Phase 1 (write): inject concepts only.  
+    /// Phase 2 (write): associations only so readers can run between phases.
+    /// TOCTOU: a concurrent delete between phases may cause associate to fail;
+    /// invalid associations are skipped with `warn!` (pre-existing semantics).
+    async fn apply_import_payload(
+        &self,
+        payload: &ExportPayload,
+    ) -> Result<Vec<(String, String, f32)>> {
+        for concept in &payload.concepts {
+            self.validate_concept(concept)?;
+        }
+        let ns = self.namespace().await;
+
+        {
+            let mut sing = self.singularity.write().await;
+            for concept in &payload.concepts {
+                sing.inject(&ns, concept.clone())?;
+            }
+        }
+
+        let mut associations = Vec::with_capacity(payload.associations.len());
+        {
+            let mut sing = self.singularity.write().await;
+            for (from, to, strength) in &payload.associations {
+                match sing.associate(&ns, from, to, *strength) {
+                    Ok(()) => associations.push((from.clone(), to.clone(), *strength)),
+                    Err(error) => {
+                        warn!(
+                            from_id = %from,
+                            to_id = %to,
+                            strength = *strength,
+                            error = %error,
+                            "skipping invalid association during import"
+                        );
+                    }
+                }
+            }
+        }
+        Ok(associations)
+    }
+
+    async fn clear_for_import_replace(&self) -> Result<()> {
+        let ns = self.namespace().await;
+        {
+            let mut sing = self.singularity.write().await;
+            sing.clear(&ns);
+        }
+        if let Some(ref persistence) = self.persistence {
+            persistence.clear_namespace(&ns).await?;
+        }
+        Ok(())
+    }
+
+    async fn persist_import(
+        &self,
+        payload: &ExportPayload,
+        associations: &[(String, String, f32)],
+    ) -> Result<()> {
+        if let Some(ref persistence) = self.persistence {
+            let ns = self.namespace().await;
+            persistence.save_concepts(&ns, &payload.concepts).await?;
+            persistence.save_associations(&ns, associations).await?;
+        }
+        Ok(())
+    }
+
+    /// Import memory state from JSON file.
+    #[instrument(err, skip(self), fields(path, merge))]
+    pub async fn import_json(&self, path: &str, merge: bool) -> Result<usize> {
+        let validated_path = validate_path(path)?;
+        let bytes = self
+            .secure_read_file(&validated_path, MAX_IMPORT_SIZE)
+            .await?;
+        let payload: ExportPayload = serde_json::from_slice(&bytes)?;
+
+        if !merge {
+            self.clear_for_import_replace().await?;
+        }
+        let valid_associations = self.apply_import_payload(&payload).await?;
+        self.persist_import(&payload, &valid_associations).await?;
+        Ok(payload.concepts.len())
+    }
+
+    /// Export memory state to binary file.
+    #[allow(clippy::significant_drop_tightening)]
+    #[instrument(err, skip(self), fields(path))]
+    pub async fn export_binary(&self, path: &str) -> Result<()> {
+        let validated_path = validate_path(path)?;
+
+        let payload = {
+            let sing = self.singularity.read().await;
+            let ns = self.namespace.read().await;
+            let json_payload = ExportPayload {
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                exported_at: unix_now_secs(),
+                concepts: sing.all_concepts(&ns),
+                associations: sing.all_associations(&ns),
+            };
+            let res = BinaryExportPayload::from(json_payload);
+            drop(sing);
+            res
+        };
+
+        let options = bincode::DefaultOptions::new().with_limit(MAX_IMPORT_SIZE);
+        let data = options.serialize(&payload).map_err(|e| {
+            csm_core::error::MemoryError::Serialization(serde_json::Error::io(
+                std::io::Error::other(e.to_string()),
+            ))
+        })?;
+        fs::write(validated_path, data).await?;
+        Ok(())
+    }
+
+    /// Import memory state from binary file.
+    #[instrument(err, skip(self), fields(path, merge))]
+    pub async fn import_binary(&self, path: &str, merge: bool) -> Result<usize> {
+        let validated_path = validate_path(path)?;
+        let bytes = self
+            .secure_read_file(&validated_path, MAX_IMPORT_SIZE)
+            .await?;
+        let options = bincode::DefaultOptions::new().with_limit(MAX_IMPORT_SIZE);
+        let binary_payload: BinaryExportPayload = options.deserialize(&bytes).map_err(|e| {
+            csm_core::error::MemoryError::InvalidInput {
+                field: "import_data".to_string(),
+                reason: format!("bincode deserialization failed: {e}"),
+            }
+        })?;
+        let payload = binary_payload.to_export_payload().map_err(|e| {
+            csm_core::error::MemoryError::InvalidInput {
+                field: "import_data".to_string(),
+                reason: format!("failed to convert binary payload: {e}"),
+            }
+        })?;
+        if !merge {
+            self.clear_for_import_replace().await?;
+        }
+        let valid_associations = self.apply_import_payload(&payload).await?;
+        self.persist_import(&payload, &valid_associations).await?;
+        Ok(payload.concepts.len())
+    }
+
+    /// Create database backup (SQLite only).
+    #[instrument(err, skip(self), fields(path))]
+    pub async fn backup(&self, path: &str) -> Result<()> {
+        let validated_path = validate_path(path)?;
+        if let Some(ref persistence) = self.persistence {
+            persistence
+                .backup(validated_path.to_str().unwrap_or(path))
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Restore from database backup (SQLite only).
+    #[instrument(err, skip(self), fields(path))]
+    pub async fn restore(&self, path: &str) -> Result<()> {
+        let validated_path = validate_path(path)?;
+        if let Some(ref persistence) = self.persistence {
+            persistence
+                .restore(validated_path.to_str().unwrap_or(path))
+                .await?;
+            self.load_replace().await?;
+        }
+        Ok(())
+    }
+
+    /// Get version history for a concept.
+    #[instrument(err, skip(self), fields(id, limit))]
+    pub async fn concept_history(
+        &self,
+        id: &str,
+        mut limit: usize,
+    ) -> Result<Vec<crate::singularity::ConceptVersion>> {
+        if limit > MAX_HISTORY_LIMIT {
+            limit = MAX_HISTORY_LIMIT;
+        }
+        if let Some(ref persistence) = self.persistence {
+            let ns = self.namespace().await;
+            return persistence.get_concept_history(&ns, id, limit).await;
+        }
+        Ok(Vec::new())
+    }
+}

--- a/src/framework_ops_tests.rs
+++ b/src/framework_ops_tests.rs
@@ -113,3 +113,310 @@ async fn secure_read_file_over_limit_is_rejected() {
     std::fs::write(&path, b"hello!").unwrap();
     assert!(fw.secure_read_file(path.as_path(), 5).await.is_err());
 }
+
+// --- Mutation-killing side-effect assertions (PR #532) ---
+// These tests verify *observable* side effects so that mutants replacing a
+// function body with `Ok(())` / `Ok(0)` / `Ok(vec![])` are caught by `--lib`.
+
+#[tokio::test]
+async fn associate_many_creates_visible_associations() {
+    let fw = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .build()
+        .await
+        .unwrap();
+    fw.inject_concepts(&[
+        ("src".to_string(), HVec10240::random()),
+        ("dst1".to_string(), HVec10240::random()),
+        ("dst2".to_string(), HVec10240::random()),
+    ])
+    .await
+    .unwrap();
+    fw.associate_many(&[
+        ("src".to_string(), "dst1".to_string(), 0.7),
+        ("src".to_string(), "dst2".to_string(), 0.3),
+    ])
+    .await
+    .unwrap();
+    let links = fw.get_associations("src").await.unwrap();
+    let mut by_id: std::collections::HashMap<String, f32> = links.into_iter().collect();
+    assert_eq!(by_id.remove("dst1"), Some(0.7));
+    assert_eq!(by_id.remove("dst2"), Some(0.3));
+    assert!(by_id.is_empty(), "no extra associations: {by_id:?}");
+}
+
+#[tokio::test]
+async fn update_concept_vector_replaces_stored_vector() {
+    let fw = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .build()
+        .await
+        .unwrap();
+    let original = HVec10240::random();
+    fw.inject_concepts(&[("vc".to_string(), original)])
+        .await
+        .unwrap();
+    let next = HVec10240::random();
+    fw.update_concept_vector("vc", next).await.unwrap();
+    let stored = fw.get_concept("vc").await.unwrap().unwrap();
+    assert_eq!(stored.vector, next, "vector must be replaced after update");
+}
+
+#[tokio::test]
+async fn update_concept_metadata_replaces_stored_metadata() {
+    let fw = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .build()
+        .await
+        .unwrap();
+    let mut m0 = std::collections::HashMap::new();
+    m0.insert("k".to_string(), serde_json::json!("v0"));
+    fw.inject_concept_with_metadata("mc", HVec10240::random(), m0)
+        .await
+        .unwrap();
+    let mut m1 = std::collections::HashMap::new();
+    m1.insert("k".to_string(), serde_json::json!("v1"));
+    m1.insert("added".to_string(), serde_json::json!(true));
+    fw.update_concept_metadata("mc", m1).await.unwrap();
+    let stored = fw.get_concept("mc").await.unwrap().unwrap();
+    assert_eq!(stored.metadata.get("k"), Some(&serde_json::json!("v1")));
+    assert_eq!(stored.metadata.get("added"), Some(&serde_json::json!(true)));
+    assert_eq!(stored.metadata.len(), 2);
+}
+
+#[tokio::test]
+async fn disassociate_removes_visible_link() {
+    let fw = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .build()
+        .await
+        .unwrap();
+    fw.inject_concepts(&[
+        ("d_from".to_string(), HVec10240::random()),
+        ("d_to".to_string(), HVec10240::random()),
+    ])
+    .await
+    .unwrap();
+    fw.associate_many(&[("d_from".to_string(), "d_to".to_string(), 0.6)])
+        .await
+        .unwrap();
+    assert_eq!(fw.get_associations("d_from").await.unwrap().len(), 1);
+    fw.disassociate("d_from", "d_to").await.unwrap();
+    let after = fw.get_associations("d_from").await.unwrap();
+    assert!(after.is_empty(), "association must be removed: {after:?}");
+}
+
+#[tokio::test]
+async fn clear_associations_empties_all_outbound() {
+    let fw = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .build()
+        .await
+        .unwrap();
+    fw.inject_concepts(&[
+        ("hub".to_string(), HVec10240::random()),
+        ("spoke1".to_string(), HVec10240::random()),
+        ("spoke2".to_string(), HVec10240::random()),
+    ])
+    .await
+    .unwrap();
+    fw.associate_many(&[
+        ("hub".to_string(), "spoke1".to_string(), 0.5),
+        ("hub".to_string(), "spoke2".to_string(), 0.4),
+    ])
+    .await
+    .unwrap();
+    assert_eq!(fw.get_associations("hub").await.unwrap().len(), 2);
+    fw.clear_associations("hub").await.unwrap();
+    let after = fw.get_associations("hub").await.unwrap();
+    assert!(after.is_empty(), "all outbound must be cleared: {after:?}");
+}
+
+#[tokio::test]
+async fn import_binary_roundtrip_returns_correct_count() {
+    let fw = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .build()
+        .await
+        .unwrap();
+    fw.inject_concepts(&[
+        ("bin-a".to_string(), HVec10240::random()),
+        ("bin-b".to_string(), HVec10240::random()),
+        ("bin-c".to_string(), HVec10240::random()),
+    ])
+    .await
+    .unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("mem.bin");
+    fw.export_binary(path.to_str().unwrap()).await.unwrap();
+
+    let fw2 = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .build()
+        .await
+        .unwrap();
+    let n = fw2
+        .import_binary(path.to_str().unwrap(), false)
+        .await
+        .unwrap();
+    assert_eq!(n, 3, "import_binary must return the concept count");
+    let stats = fw2.stats().await.unwrap();
+    assert_eq!(stats.concept_count, 3);
+}
+
+#[tokio::test]
+async fn import_json_replace_mode_clears_preexisting_concepts() {
+    let fw = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .build()
+        .await
+        .unwrap();
+    fw.inject_concepts(&[
+        ("keep-a".to_string(), HVec10240::random()),
+        ("keep-b".to_string(), HVec10240::random()),
+    ])
+    .await
+    .unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("replace.json");
+    fw.export_json(path.to_str().unwrap()).await.unwrap();
+
+    // Target starts with an unrelated pre-existing concept.
+    let target = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .build()
+        .await
+        .unwrap();
+    target
+        .inject_concepts(&[("preexisting".to_string(), HVec10240::random())])
+        .await
+        .unwrap();
+    assert_eq!(target.stats().await.unwrap().concept_count, 1);
+
+    let n = target
+        .import_json(path.to_str().unwrap(), false)
+        .await
+        .unwrap();
+    assert_eq!(n, 2);
+    // merge=false must have cleared the pre-existing concept.
+    assert!(target.get_concept("preexisting").await.unwrap().is_none());
+    assert!(target.get_concept("keep-a").await.unwrap().is_some());
+    assert!(target.get_concept("keep-b").await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn import_binary_replace_mode_clears_preexisting_concepts() {
+    let fw = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .build()
+        .await
+        .unwrap();
+    fw.inject_concepts(&[("rb-a".to_string(), HVec10240::random())])
+        .await
+        .unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("replace.bin");
+    fw.export_binary(path.to_str().unwrap()).await.unwrap();
+
+    let target = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .build()
+        .await
+        .unwrap();
+    target
+        .inject_concepts(&[("rb-old".to_string(), HVec10240::random())])
+        .await
+        .unwrap();
+    target
+        .import_binary(path.to_str().unwrap(), false)
+        .await
+        .unwrap();
+    assert!(
+        target.get_concept("rb-old").await.unwrap().is_none(),
+        "merge=false must clear pre-existing concepts"
+    );
+    assert!(target.get_concept("rb-a").await.unwrap().is_some());
+}
+
+#[cfg(not(miri))]
+#[tokio::test]
+async fn import_with_persistence_is_loadable_from_fresh_framework() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("imported.db");
+    let db_path = db.to_str().unwrap();
+
+    // Source framework (no persistence) produces a JSON export.
+    let src = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .build()
+        .await
+        .unwrap();
+    src.inject_concepts(&[
+        ("imp-1".to_string(), HVec10240::random()),
+        ("imp-2".to_string(), HVec10240::random()),
+    ])
+    .await
+    .unwrap();
+    let export_path = dir.path().join("exp.json");
+    src.export_json(export_path.to_str().unwrap())
+        .await
+        .unwrap();
+
+    // Target framework WITH persistence imports the payload.
+    let target = ChaoticSemanticFramework::builder()
+        .with_local_db(db_path)
+        .build()
+        .await
+        .unwrap();
+    let n = target
+        .import_json(export_path.to_str().unwrap(), false)
+        .await
+        .unwrap();
+    assert_eq!(n, 2);
+    target.persist().await.unwrap();
+
+    // A fresh framework on the same DB must see the imported concepts.
+    let reloaded = ChaoticSemanticFramework::builder()
+        .with_local_db(db_path)
+        .build()
+        .await
+        .unwrap();
+    reloaded.load().await.unwrap();
+    assert!(reloaded.get_concept("imp-1").await.unwrap().is_some());
+    assert!(reloaded.get_concept("imp-2").await.unwrap().is_some());
+}
+
+#[cfg(not(miri))]
+#[tokio::test]
+async fn concept_history_with_persistence_returns_versions_after_update() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("history.db");
+    let db_path = db.to_str().unwrap();
+
+    let fw = ChaoticSemanticFramework::builder()
+        .with_local_db(db_path)
+        .with_version_retention(10)
+        .build()
+        .await
+        .unwrap();
+    fw.inject_concept_with_metadata(
+        "hist-c",
+        HVec10240::random(),
+        std::collections::HashMap::new(),
+    )
+    .await
+    .unwrap();
+    fw.persist().await.unwrap();
+
+    // Vector update must create a new version record.
+    fw.update_concept_vector("hist-c", HVec10240::random())
+        .await
+        .unwrap();
+    fw.persist().await.unwrap();
+
+    let history = fw.concept_history("hist-c", 100).await.unwrap();
+    assert!(
+        !history.is_empty(),
+        "concept_history must return recorded versions, got empty"
+    );
+}

--- a/src/framework_ops_tests.rs
+++ b/src/framework_ops_tests.rs
@@ -21,6 +21,74 @@ async fn probe_batch_and_cached_return_injected_concept() {
 }
 
 #[tokio::test]
+async fn inject_concepts_batch_is_queryable() {
+    let fw = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .build()
+        .await
+        .unwrap();
+    let batch: Vec<(String, HVec10240)> = (0..32)
+        .map(|i| (format!("c{i}"), HVec10240::random()))
+        .collect();
+    fw.inject_concepts(&batch).await.unwrap();
+    let hits = fw.probe_batch(&[batch[0].1], 1).await.unwrap();
+    assert_eq!(hits[0][0].0, "c0");
+}
+
+#[tokio::test]
+async fn disassociate_and_clear_use_single_namespace_clone() {
+    let fw = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .build()
+        .await
+        .unwrap();
+    let a = HVec10240::random();
+    let b = HVec10240::random();
+    fw.inject_concepts(&[("a".into(), a), ("b".into(), b)])
+        .await
+        .unwrap();
+    fw.associate_many(&[("a".into(), "b".into(), 0.9)])
+        .await
+        .unwrap();
+    fw.disassociate("a", "b").await.unwrap();
+    fw.clear_associations("a").await.unwrap();
+}
+
+#[tokio::test]
+async fn import_json_roundtrip_with_associations() {
+    let fw = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .build()
+        .await
+        .unwrap();
+    let a = HVec10240::random();
+    let b = HVec10240::random();
+    fw.inject_concepts(&[("a".into(), a), ("b".into(), b)])
+        .await
+        .unwrap();
+    fw.associate_many(&[("a".into(), "b".into(), 0.5)])
+        .await
+        .unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("mem.json");
+    fw.export_json(path.to_str().unwrap()).await.unwrap();
+
+    let fw2 = ChaoticSemanticFramework::builder()
+        .without_persistence()
+        .build()
+        .await
+        .unwrap();
+    let n = fw2
+        .import_json(path.to_str().unwrap(), false)
+        .await
+        .unwrap();
+    assert_eq!(n, 2);
+    let hits = fw2.probe_batch(&[a], 1).await.unwrap();
+    assert_eq!(hits[0][0].0, "a");
+}
+
+#[tokio::test]
 async fn secure_read_file_exact_limit_is_allowed() {
     let fw = ChaoticSemanticFramework::builder()
         .without_persistence()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@ mod framework_metrics;
 mod framework_namespaces;
 #[cfg(not(target_arch = "wasm32"))]
 mod framework_ops;
+#[cfg(not(target_arch = "wasm32"))]
+mod framework_ops_import;
 mod framework_persistence;
 mod framework_ttl;
 pub mod framework_ttl_advanced;


### PR DESCRIPTION
## Summary
GOAP-orchestrated implementation of **all open GitHub issues** in one PR:

| Issue | Change |
|-------|--------|
| **#524** | Eliminate redundant `namespace.read()` — single `namespace()` clone per op (tokio guards cannot cross `.await`) |
| **#525** | Parallelize `inject_concepts` `ConceptBuilder` construction with Rayon *before* `durable_inject_concepts` (write lock) |
| **#526** | Split import write locks: validate → inject (write) → associate (write) so readers can proceed between phases; TOCTOU documented; invalid associations still skipped |

## Implementation notes
- Shared helpers: `apply_import_payload`, `clear_for_import_replace`, `persist_import`
- `framework_ops.rs` stays ≤500 LOC (493)
- Serial fallback when `wasm` or no `parallel` feature
- Bench: `inject_concepts_batch` at sizes 1 / 10 / 100 / 1000

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib framework_ops`
- [x] `path_validation`, `import_export_coverage`, `framework_lifecycle`, `import_error_paths`
- [x] LOC gate

## GOAP
Plan: `plans/GOAP_ORCHESTRATOR.md`  
State: `action_last_completed: framework_ops_perf_524_525_526_2026_07_18`