### PR TITLE
fix(release): correct WASM build path and add recovery dispatch mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      recover:
+        description: Retry missing artifacts for the current version even when its tag exists
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: release-${{ github.ref }}
@@ -88,6 +94,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       release-needed: ${{ steps.tag.outputs.release-needed }}
+      release-ref: ${{ steps.tag.outputs.release-ref }}
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
@@ -167,8 +174,14 @@ jobs:
       run: |
         VERSION="${{ steps.version.outputs.version }}"
         TAG="v${VERSION}"
+        echo "release-ref=${TAG}" >> $GITHUB_OUTPUT
         git fetch --tags --force
         if git rev-parse "$TAG" >/dev/null 2>&1; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.recover }}" = "true" ]; then
+            echo "Tag ${TAG} already exists; recovering missing release artifacts."
+            echo "release-needed=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
           echo "Tag ${TAG} already exists; skipping release."
           echo "release-needed=false" >> $GITHUB_OUTPUT
           exit 0
@@ -275,6 +288,8 @@ jobs:
     if: needs.validate.outputs.release-needed == 'true'
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        ref: ${{ needs.validate.outputs.release-ref }}
 
     - name: Install Rust
       uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
@@ -329,6 +344,8 @@ jobs:
     if: needs.validate.outputs.release-needed == 'true'
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        ref: ${{ needs.validate.outputs.release-ref }}
 
     - name: Install Rust
       uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
@@ -340,12 +357,12 @@ jobs:
       run: rustup target add wasm32-unknown-unknown
 
     - name: Build WASM release
-      run: cargo build --target wasm32-unknown-unknown --release --features wasm
+      run: cargo build --target wasm32-unknown-unknown --release -p csm-wasm
 
     - name: Prepare WASM artifact
       run: |
         mkdir -p release
-        cp target/wasm32-unknown-unknown/release/chaotic_semantic_memory.wasm release/
+        cp target/wasm32-unknown-unknown/release/csm_wasm.wasm release/chaotic_semantic_memory.wasm
         cd release
         tar -czvf chaotic_semantic_memory-${{ needs.validate.outputs.version }}-wasm.tar.gz chaotic_semantic_memory.wasm
 
@@ -363,6 +380,8 @@ jobs:
     environment: crates.io
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        ref: ${{ needs.validate.outputs.release-ref }}
 
     - name: Install Rust
       uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
@@ -424,6 +443,7 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
+        ref: ${{ needs.validate.outputs.release-ref }}
         fetch-depth: 0
 
     - name: Check if GitHub release already exists
@@ -503,6 +523,8 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        ref: ${{ needs.validate.outputs.release-ref }}
 
     - name: Setup Node.js
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -534,14 +556,26 @@ jobs:
 
     - name: Build WASM package
       if: steps.npm-check.outputs.already-published != 'true'
-      env:
-        WASM_OPT_FLAGS: "--enable-bulk-memory --enable-sign-ext"
       run: |
-        wasm-pack build --target web --out-dir wasm/pkg -- --features wasm
-        cp LICENSE wasm/pkg/
-        cp README.md wasm/pkg/
+        # ADR-0094: canonical npm artifact is crates/csm-wasm (matches CI wasm job).
+        # Absolute out-dir: wasm-pack resolves relative paths from the crate dir.
+        # Recovery tags may predate package-local wasm-opt metadata, so inject it
+        # only when absent; this changes build metadata, not release code.
+        if ! grep -q '^\[package.metadata.wasm-pack.profile.release\]' crates/csm-wasm/Cargo.toml; then
+          cat >> crates/csm-wasm/Cargo.toml <<'EOF'
+
+        [package.metadata.wasm-pack.profile.release]
+        wasm-opt = ["-O", "--enable-bulk-memory", "--enable-sign-ext", "--enable-nontrapping-float-to-int"]
+        EOF
+        fi
+        OUT="${{ github.workspace }}/wasm/pkg"
+        wasm-pack build crates/csm-wasm --release --target web \
+          --out-dir "${OUT}" \
+          --out-name chaotic_semantic_memory
+        cp LICENSE "${OUT}/"
+        cp README.md "${OUT}/"
         # Use prepared package.json with scoped name @d-o-hub/chaotic_semantic_memory
-        cp wasm/package.json wasm/pkg/package.json
+        cp wasm/package.json "${OUT}/package.json"
 
     - name: Publish to npm
       if: steps.npm-check.outputs.already-published != 'true'
@@ -590,6 +624,8 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        ref: ${{ needs.validate.outputs.release-ref }}
 
     - name: Setup Node.js
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -331,6 +331,3 @@ events-http = ["cloudevents", "cloudevents-sdk/http-binding", "dep:reqwest"]
 prometheus = ["dep:prometheus", "dep:hyper", "dep:hyper-util", "dep:http-body-util"]
 otlp-json = []
 otlp = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", "dep:tracing-opentelemetry"]
-
-[package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-O", "--enable-bulk-memory", "--enable-sign-ext"]

--- a/crates/csm-wasm/Cargo.toml
+++ b/crates/csm-wasm/Cargo.toml
@@ -30,5 +30,8 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = ["console_error_panic_hook"]
 
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O", "--enable-bulk-memory", "--enable-sign-ext", "--enable-nontrapping-float-to-int"]
+
 [lints]
 workspace = true

--- a/llms.txt
+++ b/llms.txt
@@ -1597,8 +1597,5 @@ events-http = ["cloudevents", "cloudevents-sdk/http-binding", "dep:reqwest"]
 prometheus = ["dep:prometheus", "dep:hyper", "dep:hyper-util", "dep:http-body-util"]
 otlp-json = []
 otlp = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", "dep:tracing-opentelemetry"]
-
-[package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-O", "--enable-bulk-memory", "--enable-sign-ext"]
 ```
 

--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -4995,3 +4995,20 @@ actions:
       Land PR #532 (framework ops #524–#526) after CI green; triage #534 hybrid
       min-max (merge if correct, close if duplicate/regressed). Close issues.
 
+  - name: recover_v037_failed_deployments
+    preconditions:
+      ci_all_checks_passed: true
+    effects:
+      release_recovery_dispatch_supported: true
+      wasm_opt_nontrapping_float_enabled: true
+      v037_registry_deployments_recovered: true
+    cost: 2
+    status: in_progress
+    priority: P0
+    wave: "wave-33"
+    file: .github/workflows/release.yml, crates/csm-wasm/Cargo.toml
+    description: |
+      Add an explicit, idempotent workflow-dispatch recovery mode for an
+      existing release tag and enable wasm-opt's non-trapping float-to-int
+      feature. Dispatch recovery for v0.3.7 after CI so the updated crates.io
+      credential and npm OIDC publisher fill only missing registry artifacts.


### PR DESCRIPTION
## Summary
- Fix WASM build to use `-p csm-wasm` package instead of `--features wasm` on root crate
- Fix npm WASM build to run `wasm-pack build crates/csm-wasm` instead of root-level build
- Move `wasm-opt` metadata from root `Cargo.toml` to `crates/csm-wasm/Cargo.toml` with `--enable-nontrapping-float-to-int`
- Add `workflow_dispatch` `recover` input for retrying missing release artifacts for existing tags
- Pin all checkout steps to `release-ref` output for tag-pinned recovery runs

## Context
v0.3.7 was released on 2026-06-28 but crates.io and npm WASM (`@d-o-hub/chaotic_semantic_memory`) still show 0.3.6. The WASM build was using wrong package path and binary name. After this merges, a recovery dispatch (`gh workflow run release.yml -f recover=true`) will fill the missing registry artifacts.

## Verification
After merge + recovery dispatch:
```bash
cargo search chaotic_semantic_memory | grep 0.3.7
npm view @d-o-hub/chaotic_semantic_memory version  # should be 0.3.7
```