### PR TITLE
docs(release): add crates.io name verification and environment troubleshooting

### DIFF
--- a/.agents/skills/release-management/SKILL.md
+++ b/.agents/skills/release-management/SKILL.md
@@ -104,6 +104,37 @@ grep -q "^\[${VERSION}\]:" CHANGELOG.md
 | GitHub Release | `softprops/action-gh-release` | Same |
 | GitHub Pages | mdBook deploy | Docs path on main / release jobs |
 
+## crates.io name verification (FIRST PUBLISH)
+
+Before first publish, verify workspace crate names are available on crates.io:
+
+```bash
+for crate in csm-chaos csm-core csm-traits csm-embedding csm-memory csm-retrieval csm-persistence; do
+  echo -n "$crate: "
+  cargo search "$crate" 2>/dev/null | head -1
+done
+```
+
+If a name is taken by an unrelated project (e.g., `csm-core` is "Candle-based inference for Sesame CSM-1B"), rename the crate before publishing. Use prefixes like `chaotic-semantic-memory-*` or suffixes like `csm-core-lib` to avoid conflicts.
+
+**Known conflicts (as of 2026-07-22):**
+- `csm-core`: Taken by Sesame CSM-1B TTS project
+- `csm-chaos`: Available (published at 0.3.7)
+- `csm-traits`, `csm-embedding`, `csm-memory`, `csm-retrieval`, `csm-persistence`, `csm-wasm`: Not yet published, availability unknown
+
+## GitHub environment configuration
+
+The `crates.io` environment may have protection rules that block automatic publishing:
+
+- **Wait timer**: Default 15 minutes. Remove in GitHub Settings → Environments → crates.io if not needed.
+- **Required reviewers**: Must be configured if manual approval is needed.
+- **Deployment branches**: Restrict to `main` only.
+
+Check pending deployments before re-running failed releases:
+```bash
+gh api repos/{owner}/{repo}/actions/runs/{run_id}/pending_deployments
+```
+
 ## Tag ownership (single owner)
 
 | Who | Action |

--- a/.agents/skills/release-management/references/release-workflow.md
+++ b/.agents/skills/release-management/references/release-workflow.md
@@ -70,6 +70,58 @@ cargo yank --version X.Y.Z chaotic_semantic_memory
 
 Prefer **fix-forward** (patch release) over deleting published artifacts.
 
+## Recovery dispatch (workflow_dispatch)
+
+For partially published releases (e.g., npm succeeded but crates.io failed), use recovery dispatch:
+
+```bash
+# Retry missing artifacts for existing tag
+gh workflow run release.yml --ref main -f recover=true
+```
+
+The recovery workflow:
+1. Sees tag exists, but `recover=true` → proceeds with `release-needed=true`
+2. Each job checks if its artifact already exists → skips if so
+3. Publishes only missing artifacts (idempotent)
+
+**Prerequisites for recovery:**
+- `CARGO_REGISTRY_TOKEN` must belong to an owner of ALL workspace crates on crates.io
+- crates.io environment must not have a wait timer blocking the `publish-crates` job
+- Workspace crate names must not be taken by unrelated projects (see below)
+
+## crates.io name conflicts
+
+Workspace crate names (`csm-core`, `csm-traits`, etc.) may be taken by unrelated projects on crates.io. If so, `cargo publish` will fail with:
+
+```
+403 Forbidden: this crate exists but you don't seem to be an owner.
+```
+
+**Solution:** Rename crates before first publish. Use prefixes like `chaotic-semantic-memory-*` or suffixes like `csm-core-lib`.
+
+```bash
+# Check if names are available
+for crate in csm-chaos csm-core csm-traits csm-embedding csm-memory csm-retrieval csm-persistence; do
+  echo -n "$crate: "
+  cargo search "$crate" 2>/dev/null | head -1
+done
+```
+
+**Known conflicts (as of 2026-07-22):**
+- `csm-core`: Taken by Sesame CSM-1B TTS project (v0.1.0)
+
+## Environment wait timer
+
+The `crates.io` GitHub environment may have a wait timer (default 15 minutes). This blocks the `publish-crates` job until the timer expires.
+
+```bash
+# Check pending deployments
+gh api repos/{owner}/{repo}/actions/runs/{run_id}/pending_deployments
+# Look for wait_timer > 0
+```
+
+**Solution:** Remove the timer in GitHub Settings → Environments → crates.io, or wait for it to expire before the job starts.
+
 ## Local helpers
 
 | Path | Role |
@@ -91,3 +143,4 @@ This repository does **not** use a separate `semantic-release.yml` or npm `seman
 - [ ] GitHub Release notes non-empty
 - [ ] Pages/docs still building
 - [ ] No accidental second tag for same version
+- [ ] Workspace crate names verified available before next release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -403,12 +403,35 @@ jobs:
     - name: Publish workspace crates in dependency order
       if: steps.crates-check.outputs.already-published != 'true'
       run: |
+        # Pre-check: Verify workspace crate names are not taken by unrelated projects
+        echo "Checking crates.io name availability..."
+        CRATES="csm-chaos csm-core csm-traits csm-embedding csm-memory csm-retrieval csm-persistence"
+        NAME_CONFLICT=false
+        for crate in $CRATES; do
+          CRATE_VERSION=$(grep -m1 '^version' "crates/$crate/Cargo.toml" | cut -d'"' -f2)
+          SEARCH_RESULT=$(cargo search "$crate" 2>/dev/null | head -1)
+          if echo "$SEARCH_RESULT" | grep -q "^$crate = "; then
+            # Name exists - check if it's our version or an unrelated crate
+            EXISTING_VERSION=$(echo "$SEARCH_RESULT" | grep -oP '"\K[^"]+')
+            if [ "$EXISTING_VERSION" != "$CRATE_VERSION" ]; then
+              echo "❌ CONFLICT: $crate@$EXISTING_VERSION exists on crates.io (need $CRATE_VERSION)"
+              echo "   This name is taken by an unrelated project. Rename the crate before publishing."
+              NAME_CONFLICT=true
+            fi
+          fi
+        done
+        if [ "$NAME_CONFLICT" = true ]; then
+          echo ""
+          echo "::error::Workspace crate name conflicts detected. Rename crates and update Cargo.toml dependencies."
+          exit 1
+        fi
+        echo "✅ All workspace crate names available"
+
         # Publish order based on dependency graph:
         # 1. csm-chaos (no internal deps)
         # 2. csm-core (depends on csm-chaos optionally)
         # 3. csm-traits, csm-embedding, csm-memory (depend on csm-core)
         # 4. csm-retrieval, csm-persistence (depend on csm-core + csm-memory)
-        CRATES="csm-chaos csm-core csm-traits csm-embedding csm-memory csm-retrieval csm-persistence"
         for crate in $CRATES; do
           echo "Publishing $crate..."
           # Skip if already published (idempotent)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,6 +365,24 @@ Refer to the `dist-channel-selection` skill for canonical commands.
    grep -q "^## \[${VERSION}\]" CHANGELOG.md
    ```
 
+5. **Verify crates.io name availability** (FIRST PUBLISH ONLY):
+   ```bash
+   # Check if workspace crate names are already taken by unrelated projects
+   for crate in csm-chaos csm-core csm-traits csm-embedding csm-memory csm-retrieval csm-persistence; do
+     echo -n "$crate: "
+     cargo search "$crate" 2>/dev/null | head -1
+   done
+   # If names are taken, rename crates before first publish (e.g., csm-core → csm-core-lib)
+   ```
+
+6. **Check crates.io environment wait timer**:
+   ```bash
+   # The crates.io environment may have a wait timer (default 15min)
+   # Check pending deployments before re-running failed releases
+   gh api repos/{owner}/{repo}/actions/runs/{run_id}/pending_deployments
+   # If wait_timer > 0, either wait or remove timer in GitHub Settings → Environments → crates.io
+   ```
+
 ### Version Bump Workflow
 
 1. Update `Cargo.toml` version
@@ -386,6 +404,16 @@ Refer to the `dist-channel-selection` skill for canonical commands.
 - `.github/workflows/release.yml` — Has `wait-for-ci` guardrail job
 - `.agents/skills/release-management/` — Full release skill
 - `scripts/validate.sh` — Pre-commit validation gates
+
+### Common Deployment Failures
+
+1. **crates.io name conflicts**: Workspace crate names (`csm-core`, `csm-traits`, etc.) may be taken by unrelated projects. Check `cargo search` before first publish. Rename crates if needed (e.g., `csm-core` → `csm-core-lib`).
+
+2. **Environment wait timer**: The `crates.io` GitHub environment may have a wait timer (typically 15 minutes). This blocks `publish-crates` job until the timer expires. Remove the timer in GitHub Settings → Environments → crates.io if not needed.
+
+3. **Token ownership**: The `CARGO_REGISTRY_TOKEN` must belong to a user who owns all crates on crates.io. If a crate name is taken by another project, the token won't have permission to publish. Use `cargo owner --list <crate>` to verify ownership.
+
+4. **Recovery dispatch**: Use `gh workflow run release.yml -f recover=true` to retry failed releases for existing tags. The workflow is idempotent — it skips already-published artifacts.
 
 ---
 ## Key Files


### PR DESCRIPTION
## Summary
- Add crates.io name availability check to pre-release checklist
- Document workspace crate name conflicts (csm-core taken by unrelated project)
- Add environment wait timer documentation and troubleshooting
- Add recovery dispatch documentation for partially published releases
- Add pre-publish name conflict detection in release workflow
- Update post-release checklist with name verification step

## Context
v0.3.7 release failed to publish workspace crates to crates.io because:
1. `csm-core` name is taken by an unrelated project (Sesame CSM-1B TTS)
2. The `crates.io` environment had a 15-minute wait timer blocking the publish job
3. The `CARGO_REGISTRY_TOKEN` didn't have ownership of the conflicting crate

These changes document the lessons learned and add automated checks to prevent similar failures.

## Verification
After merge, the release workflow will:
- Check crates.io name availability before attempting to publish
- Fail early with a clear error message if names are conflicts
- Document recovery steps for partially published releases