### PR TITLE
feat(workspace): enforce explicit feature contracts across crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,7 @@ rayon = { version = "1.10.0", optional = true }
 
 # Database - Use libsql NOT turso-client (opt-in via "persistence" feature)
 libsql = { version = "0.9.30", default-features = false, features = ["sync", "hrana", "remote"], optional = true }
-csm-persistence = { path = "crates/csm-persistence", version = "0.3.7" }
+csm-persistence = { path = "crates/csm-persistence", version = "0.3.7", default-features = false }
 # `net` is required by the Prometheus /metrics server (ADR-0072).
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "fs", "net"] }
 
@@ -305,7 +305,7 @@ required-features = ["prometheus", "otlp-json"]
 experimental-neural-circuit = ["csm-chaos/experimental-neural-circuit"]
 default = ["cli", "persistence", "parallel"]
 cli = ["dep:clap", "dep:clap_complete", "dep:anyhow", "dep:colored", "dep:glob"]
-persistence = ["dep:libsql"]
+persistence = ["dep:libsql", "csm-persistence/persistence"]
 parallel = ["dep:rayon"]
 wasm = []
 mcp = ["dep:rmcp", "cli", "dep:axum", "dep:tower", "dep:tower-http"]  # ADR-0067: MCP server requires CLI infrastructure

--- a/crates/csm-cli/Cargo.toml
+++ b/crates/csm-cli/Cargo.toml
@@ -13,7 +13,7 @@ csm-core-lib = { path = "../csm-core-lib", version = "0.3.7" }
 csm-memory = { path = "../csm-memory", version = "0.3.7" }
 csm-embedding = { path = "../csm-embedding", version = "0.3.7" }
 csm-retrieval = { path = "../csm-retrieval", version = "0.3.7" }
-csm-persistence = { path = "../csm-persistence", version = "0.3.7" }
+csm-persistence = { path = "../csm-persistence", version = "0.3.7", default-features = false }
 clap = { version = "4.5", features = ["derive", "env", "string"] }
 clap_complete = { version = "4.5.42" }
 anyhow = "1.0.102"

--- a/crates/csm-memory/Cargo.toml
+++ b/crates/csm-memory/Cargo.toml
@@ -23,7 +23,7 @@ rand = { workspace = true, optional = true }
 rand_chacha = { version = "0.10.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-rayon = "1.10"
+rayon = { version = "1.10", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.77"
@@ -33,7 +33,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [features]
 default = []
-parallel = ["csm-core-lib/parallel"]
+parallel = ["csm-core-lib/parallel", "dep:rayon"]
 ann-hnsw = ["dep:hnsw_rs", "dep:tempfile", "dep:bincode"]
 ann-lsh = ["dep:bincode", "dep:rand", "dep:rand_chacha"]
 

--- a/crates/csm-persistence/Cargo.toml
+++ b/crates/csm-persistence/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tempfile = { workspace = true }
 
 [features]
-default = ["persistence"]
+default = []
 persistence = ["dep:libsql"]
 libsql = ["persistence"]
 wasm = ["uuid"]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -436,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
 dependencies = [
  "clap",
 ]
@@ -607,7 +607,6 @@ version = "0.3.7"
 dependencies = [
  "csm-core-lib",
  "js-sys",
- "rayon",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -657,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "equivalent"

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -57,7 +57,7 @@
 - otlp-json: []
 - otlp: [dep:opentelemetry, dep:opentelemetry_sdk, dep:opentelemetry-otlp, dep:tracing-opentelemetry]
 - parallel: [dep:rayon]
-- persistence: [dep:libsql]
+- persistence: [dep:libsql, csm-persistence/persistence]
 - prometheus: [dep:prometheus, dep:hyper, dep:hyper-util, dep:http-body-util]
 - wasm: []
 
@@ -658,6 +658,7 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub use csm_retrieval::{HybridResult, RetrievalAbstention}
 - pub fn compute_weights
 - pub fn normalize_scores
+- pub fn normalize_scores_in_place
 - pub fn merge_results
 - pub enum HybridMode
 - pub struct HybridConfig
@@ -671,7 +672,7 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub mod rerank
 - pub use bm25::{Bm25Config, Bm25Index}
 - pub use graph_rag::{GraphRagConfig, GraphRagResult, graph_rag_retrieve}
-- pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores}
+- pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores, normalize_scores_in_place}
 - pub use rerank::{MmrReranker, RerankCandidate, Reranker}
 
 ### src/retrieval/rerank.rs
@@ -4329,6 +4330,22 @@ Normalize scores to [0, 1] range using min-max normalization.
 
 If all scores are equal, returns 1.0 for all.
 
+#### Note
+For performance-critical pipelines (like search/retrieval hot paths), prefer
+using [`normalize_scores_in_place`] to completely bypass vector allocations
+and redundant string cloning.
+
+### normalize_scores_in_place
+
+```rust
+pub fn normalize_scores_in_place(scores: &mut [(String, f32)])
+```
+
+Normalize scores in place to [0, 1] range using min-max normalization.
+
+This is the preferred method in high-frequency/hot query pathways because
+it mutates existing score vectors, avoiding heap allocations and string cloning.
+
 ## src/retrieval/mod.rs
 
 ### bm25::{Bm25Config, Bm25Index}
@@ -4343,10 +4360,10 @@ pub use bm25::{Bm25Config, Bm25Index};
 pub use graph_rag::{GraphRagConfig, GraphRagResult, graph_rag_retrieve};
 ```
 
-### hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores}
+### hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores, normalize_scores_in_place}
 
 ```rust
-pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores};
+pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores, normalize_scores_in_place};
 ```
 
 ### rerank::{MmrReranker, RerankCandidate, Reranker}

--- a/llms.txt
+++ b/llms.txt
@@ -57,7 +57,7 @@
 - otlp-json: []
 - otlp: [dep:opentelemetry, dep:opentelemetry_sdk, dep:opentelemetry-otlp, dep:tracing-opentelemetry]
 - parallel: [dep:rayon]
-- persistence: [dep:libsql]
+- persistence: [dep:libsql, csm-persistence/persistence]
 - prometheus: [dep:prometheus, dep:hyper, dep:hyper-util, dep:http-body-util]
 - wasm: []
 
@@ -658,6 +658,7 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub use csm_retrieval::{HybridResult, RetrievalAbstention}
 - pub fn compute_weights
 - pub fn normalize_scores
+- pub fn normalize_scores_in_place
 - pub fn merge_results
 - pub enum HybridMode
 - pub struct HybridConfig
@@ -671,7 +672,7 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub mod rerank
 - pub use bm25::{Bm25Config, Bm25Index}
 - pub use graph_rag::{GraphRagConfig, GraphRagResult, graph_rag_retrieve}
-- pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores}
+- pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores, normalize_scores_in_place}
 - pub use rerank::{MmrReranker, RerankCandidate, Reranker}
 
 ### src/retrieval/rerank.rs
@@ -1454,7 +1455,7 @@ rayon = { version = "1.10.0", optional = true }
 
 # Database - Use libsql NOT turso-client (opt-in via "persistence" feature)
 libsql = { version = "0.9.30", default-features = false, features = ["sync", "hrana", "remote"], optional = true }
-csm-persistence = { path = "crates/csm-persistence", version = "0.3.7" }
+csm-persistence = { path = "crates/csm-persistence", version = "0.3.7", default-features = false }
 # `net` is required by the Prometheus /metrics server (ADR-0072).
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "fs", "net"] }
 
@@ -1572,7 +1573,7 @@ required-features = ["prometheus", "otlp-json"]
 experimental-neural-circuit = ["csm-chaos/experimental-neural-circuit"]
 default = ["cli", "persistence", "parallel"]
 cli = ["dep:clap", "dep:clap_complete", "dep:anyhow", "dep:colored", "dep:glob"]
-persistence = ["dep:libsql"]
+persistence = ["dep:libsql", "csm-persistence/persistence"]
 parallel = ["dep:rayon"]
 wasm = []
 mcp = ["dep:rmcp", "cli", "dep:axum", "dep:tower", "dep:tower-http"]  # ADR-0067: MCP server requires CLI infrastructure

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -50,8 +50,8 @@ for file in $(find src crates -name '*.rs' -not -path '*/target/*'); do
 done
 
 if rustup target list --installed | grep -q "^${WASM_TARGET}\$"; then
-  echo "==> cargo check --target ${WASM_TARGET} --features wasm"
-  cargo check --target "${WASM_TARGET}" --features wasm
+  echo "==> cargo check --target ${WASM_TARGET} --no-default-features --features wasm"
+  cargo check --target "${WASM_TARGET}" --no-default-features --features wasm
 else
   echo "skip: ${WASM_TARGET} target not installed"
 fi


### PR DESCRIPTION
## Summary

Implements `enforce_workspace_feature_contracts` from Wave 33 planning.

- **csm-persistence**: Changed `default = ["persistence"]` to `default = []` — libSQL is no longer silently pulled in for any crate that depends on csm-persistence without explicitly enabling the `persistence` feature
- **csm-memory**: Made `rayon` optional in `[target.non-wasm.dependencies]` and wired it to the `parallel` feature via `dep:rayon` — `cargo tree --no-default-features` no longer includes Rayon
- **root Cargo.toml**: Added `default-features = false` to the non-WASM `csm-persistence` dep and forwarded `csm-persistence/persistence` from the root `persistence` feature so the existing feature graph is fully preserved
- **csm-cli**: Added `default-features = false` to its `csm-persistence` dep; the existing `persistence = ["csm-persistence/libsql", ...]` feature already explicitly enables persistence

The three `use rayon::prelude::*` lines in `singularity_retrieval.rs`, `index/lsh.rs`, and `index/brute_force.rs` already had the correct `#[cfg(all(not(target_arch = "wasm32"), feature = "parallel"))]` guards and required no changes.

## Test plan

- [x] `cargo check` (default features) passes
- [x] `cargo check --all-features` passes
- [x] `cargo test --lib` — 222 tests passed, 0 failed
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] Pre-commit hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)