### PR TITLE
fix(ci): update fuzz/Cargo.lock for cc/clap_complete/either upgrades

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -436,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
 dependencies = [
  "clap",
 ]
@@ -657,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "equivalent"

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -658,6 +658,7 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub use csm_retrieval::{HybridResult, RetrievalAbstention}
 - pub fn compute_weights
 - pub fn normalize_scores
+- pub fn normalize_scores_in_place
 - pub fn merge_results
 - pub enum HybridMode
 - pub struct HybridConfig
@@ -671,7 +672,7 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub mod rerank
 - pub use bm25::{Bm25Config, Bm25Index}
 - pub use graph_rag::{GraphRagConfig, GraphRagResult, graph_rag_retrieve}
-- pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores}
+- pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores, normalize_scores_in_place}
 - pub use rerank::{MmrReranker, RerankCandidate, Reranker}
 
 ### src/retrieval/rerank.rs
@@ -4329,6 +4330,22 @@ Normalize scores to [0, 1] range using min-max normalization.
 
 If all scores are equal, returns 1.0 for all.
 
+#### Note
+For performance-critical pipelines (like search/retrieval hot paths), prefer
+using [`normalize_scores_in_place`] to completely bypass vector allocations
+and redundant string cloning.
+
+### normalize_scores_in_place
+
+```rust
+pub fn normalize_scores_in_place(scores: &mut [(String, f32)])
+```
+
+Normalize scores in place to [0, 1] range using min-max normalization.
+
+This is the preferred method in high-frequency/hot query pathways because
+it mutates existing score vectors, avoiding heap allocations and string cloning.
+
 ## src/retrieval/mod.rs
 
 ### bm25::{Bm25Config, Bm25Index}
@@ -4343,10 +4360,10 @@ pub use bm25::{Bm25Config, Bm25Index};
 pub use graph_rag::{GraphRagConfig, GraphRagResult, graph_rag_retrieve};
 ```
 
-### hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores}
+### hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores, normalize_scores_in_place}
 
 ```rust
-pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores};
+pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores, normalize_scores_in_place};
 ```
 
 ### rerank::{MmrReranker, RerankCandidate, Reranker}

--- a/llms.txt
+++ b/llms.txt
@@ -658,6 +658,7 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub use csm_retrieval::{HybridResult, RetrievalAbstention}
 - pub fn compute_weights
 - pub fn normalize_scores
+- pub fn normalize_scores_in_place
 - pub fn merge_results
 - pub enum HybridMode
 - pub struct HybridConfig
@@ -671,7 +672,7 @@ Created by: [cargo-llms-txt](https://github.com/masinc/cargo-llms-txt)
 - pub mod rerank
 - pub use bm25::{Bm25Config, Bm25Index}
 - pub use graph_rag::{GraphRagConfig, GraphRagResult, graph_rag_retrieve}
-- pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores}
+- pub use hybrid::{HybridConfig, HybridMode, compute_weights, merge_results, normalize_scores, normalize_scores_in_place}
 - pub use rerank::{MmrReranker, RerankCandidate, Reranker}
 
 ### src/retrieval/rerank.rs


### PR DESCRIPTION
## Summary

- Updates `fuzz/Cargo.lock` after recent upstream dep upgrades: `cc` 1.3→1.4, `clap_complete` 4.6.7→4.6.8, `either` 1.16→1.17
- Fixes the CI `fuzz-build` job which uses `--locked` and was failing with: `the lock file needs to be updated but --locked was passed`

## Test plan
- [x] `cargo check --manifest-path fuzz/Cargo.toml --all-targets --locked` passes locally
- [x] All other validation gates pass (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)