### PR TITLE
fix(ci): exclude benchmarks from validate.sh to prevent lint timeout

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -30,8 +30,8 @@ if echo "$OUTPUT" | grep -qi "warning:"; then
   exit 1
 fi
 
-echo "==> cargo test --all-targets --all-features"
-cargo test --all-targets --all-features
+echo "==> cargo test --lib --tests --all-features (exclude benchmarks)"
+cargo test --lib --tests --all-features
 
 echo "==> Source file LOC gate (< ${MAX_SRC_LOC})"
 for file in $(find src crates -name '*.rs' -not -path '*/target/*'); do


### PR DESCRIPTION
## Summary
- `validate.sh` ran `cargo test --all-targets --all-features` which includes criterion benchmarks
- The `ann_hnsw` benchmark (from PR #582) runs 7+ minutes, causing the 15-minute lint job to timeout
- Changed to `cargo test --lib --tests --all-features` to match the CI test job behavior

## Root Cause
The lint job in CI runs `validate.sh` as its last step. `validate.sh` used `--all-targets` which compiles and runs criterion benchmarks in test mode. The `ann_hnsw/search_1000` benchmark alone takes 7+ minutes, pushing the job past the 15-minute timeout.

## Fix
Use `--lib --tests` instead of `--all-targets`. This runs library tests and integration tests but excludes benchmarks. Benchmarks are covered by the dedicated `benchmark-ci` job.

## Measured Impact

| Metric | Before (PR #582) | After (main post-merge) |
|--------|-----------------|------------------------|
| **lint duration** | 15m 17s (cancelled) | 11m 7s (success) |
| **CI overall** | failure | success |

The lint job improved by ~4 minutes and now completes within the 15-minute timeout.

## Test Plan
- [x] CI lint job passes within timeout
- [x] All existing tests still run (lib + integration)
- [x] Benchmark tests still covered by benchmark-ci job